### PR TITLE
Improves completion api with new input parameters for LLMs

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -6,7 +6,7 @@ import { transformAsyncIterator } from "@llumiverse/core/async";
 import { ClaudeMessagesPrompt, formatClaudePrompt } from "@llumiverse/core/formatters";
 import { AwsCredentialIdentity, Provider } from "@smithy/types";
 import mnemonist from "mnemonist";
-import { AI21RequestPayload, AmazonRequestPayload, ClaudeRequestPayload, CohereCommandRPayload, CohereRequestPayload, LLama2RequestPayload, MistralPayload } from "./payloads.js";
+import { AI21JurassicRequestPayload, AmazonRequestPayload, ClaudeRequestPayload, CohereCommandRPayload, CohereRequestPayload, LLama3RequestPayload, MistralPayload } from "./payloads.js";
 import { forceUploadFile } from "./s3.js";
 
 const { LRUCache } = mnemonist;
@@ -248,7 +248,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 prompt,
                 temperature: options.temperature,
                 max_gen_len: options.max_tokens,
-            } as LLama2RequestPayload
+                top_p: options.top_p
+            } as LLama3RequestPayload
         } else if (contains(options.model, "claude")) {
 
             const maxToken = () => {
@@ -266,35 +267,55 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 ...(prompt as ClaudeMessagesPrompt),
                 temperature: options.temperature,
                 max_tokens: maxToken(),
+                top_p: options.top_p,
+                top_k: options.top_k,
+                stop_sequences: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
             } as ClaudeRequestPayload;
         } else if (contains(options.model, "ai21")) {
             return {
                 prompt: prompt,
                 temperature: options.temperature,
                 maxTokens: options.max_tokens,
-            } as AI21RequestPayload;
+                topP: options.top_p,
+                stopSequences: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
+                presencePenalty: {scale: options.presence_penalty},
+                frequencyPenalty: {scale: options.frequency_penalty},
+            } as AI21JurassicRequestPayload;
         } else if (contains(options.model, "command-r-plus")) {
             return {
                 message: prompt as string,
                 max_tokens: options.max_tokens,
                 temperature: options.temperature,
+                p: options.top_p,
+                k: options.top_k,
+                frequency_penalty: options.frequency_penalty,
+                presence_penalty: options.presence_penalty,
+                stop_sequences: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
             } as CohereCommandRPayload;
-
         }
         else if (contains(options.model, "cohere")) {
             return {
                 prompt: prompt,
                 temperature: options.temperature,
                 max_tokens: options.max_tokens,
+                p: options.top_p,
+                k: options.top_k,
+                stop_sequences: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
             } as CohereRequestPayload;
         } else if (contains(options.model, "amazon")) {
+            const stop_seq: string[] = (typeof options.stop_sequence === 'string' ?
+            [options.stop_sequence] : options.stop_sequence) ?? [];
             return {
                 inputText: "User: " + (prompt as string) + "\nBot:", // see https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html#model-parameters-titan-request-response
                 textGenerationConfig: {
                     temperature: options.temperature,
                     topP: options.top_p,
                     maxTokenCount: options.max_tokens,
-                    //stopSequences: ["\n"],
+                    stopSequences: ["\n", ...stop_seq],
                 },
             } as AmazonRequestPayload;
         } else if (contains(options.model, "mistral")) {
@@ -302,6 +323,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 prompt: prompt,
                 temperature: options.temperature,
                 max_tokens: options.max_tokens,
+                top_k: options.top_k,
+                top_p: options.top_p,
+                stop: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
             } as MistralPayload;
         } else {
             throw new Error("Cannot prepare payload for unknown provider: " + options.model);

--- a/drivers/src/bedrock/payloads.ts
+++ b/drivers/src/bedrock/payloads.ts
@@ -1,48 +1,73 @@
 import { ClaudeMessagesPrompt } from "@llumiverse/core/formatters";
 
-export interface LLama2RequestPayload {
+//Overall documentation:
+//https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters.html
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-meta.html
+export interface LLama3RequestPayload {
     prompt: string;
-    temperature: number;
+    temperature?: number;
     top_p?: number;
-    max_gen_len: number;
+    max_gen_len?: number;
 }
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-anthropic-claude-messages.html
 export interface ClaudeRequestPayload extends ClaudeMessagesPrompt {
     anthropic_version: "bedrock-2023-05-31";
     max_tokens: number;
-    prompt: string;
     temperature?: number;
     top_p?: number;
     top_k?: number;
     stop_sequences?: [string];
 }
-export interface AI21RequestPayload {
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-jurassic2.html
+export interface AI21JurassicRequestPayload {
     prompt: string;
     temperature: number;
     maxTokens: number;
+    topP?: number;
+    stopSequences?: [string]
+    presencePenalty?: {
+        scale : number
+    }
+    frequencyPenalty?: {
+        scale : number
+    }
 }
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command.html
 export interface CohereRequestPayload {
     prompt: string;
     temperature: number;
     max_tokens?: number;
     p?: number;
+    k?: number;
+    stop_sequences: [string],
 }
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-titan-text.html
 export interface AmazonRequestPayload {
     inputText: string;
-    textGenerationConfig: {
-        temperature: number;
-        topP: number;
-        maxTokenCount: number;
-        stopSequences: [string];
+    textGenerationConfig?: {
+        temperature?: number;
+        topP?: number;
+        maxTokenCount?: number;
+        stopSequences?: [string];
     };
 }
+
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-mistral-text-completion.html
 export interface MistralPayload {
     prompt: string;
     temperature: number;
     max_tokens: number;
     top_p?: number;
     top_k?: number;
+    stop?: [string]
 }
 
+//Docs at: https://docs.aws.amazon.com/bedrock/latest/userguide/model-parameters-cohere-command-r-plus.html
 export interface CohereCommandRPayload {
 
     message: string,

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -66,6 +66,11 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, OpenAITextMess
             messages: messages,
             max_tokens: options.max_tokens,
             temperature: options.temperature,
+            top_p: options.top_p,
+            //top_logprobs: options.top_logprobs,       //Logprobs output currently not supported
+            //logprobs: options.top_logprobs ? true : false,
+            presence_penalty: options.presence_penalty,
+            frequency_penalty: options.frequency_penalty,
             response_format: this.getResponseFormat(options),
         });
 
@@ -92,8 +97,13 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, OpenAITextMess
             messages: messages,
             max_tokens: options.max_tokens,
             temperature: options.temperature,
+            top_p: options.top_p,
+            //top_logprobs: options.top_logprobs,       //Logprobs output currently not supported
+            //logprobs: options.top_logprobs ? true : false,
+            presence_penalty: options.presence_penalty,
+            frequency_penalty: options.frequency_penalty,
             response_format: this.getResponseFormat(options),
-            stream: true
+            stream: true,
         });
 
         return transformAsyncIterator(res, (res) => res.choices[0].delta.content || '');

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -94,8 +94,11 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
                 messages: messages,
                 maxTokens: options.max_tokens,
                 temperature: options.temperature,
+                topP: options.top_p,
                 responseFormat: this.getResponseFormat(options),
-                stream: true
+                stream: true,
+                stopSequences: typeof options.stop_sequence === 'string' ?
+                [options.stop_sequence] : options.stop_sequence,
             }),
             reader: 'sse'
         });
@@ -173,6 +176,7 @@ function _makeChatCompletionRequest({
     safePrompt,
     toolChoice,
     responseFormat,
+    stopSequences,
 }: CompletionRequestParams) {
     return {
         model: model,
@@ -186,5 +190,6 @@ function _makeChatCompletionRequest({
         safe_prompt: (safeMode || safePrompt) ?? undefined,
         tool_choice: toolChoice ?? undefined,
         response_format: responseFormat ?? undefined,
+        stop: stopSequences ?? undefined,
     };
 };

--- a/drivers/src/mistral/types.ts
+++ b/drivers/src/mistral/types.ts
@@ -138,7 +138,8 @@ export interface CompletionRequestParams {
     safeMode?: boolean,
     safePrompt?: boolean,
     toolChoice?: ToolChoice,
-    responseFormat?: ResponseFormat
+    responseFormat?: ResponseFormat,
+    stopSequences?: string[],
 }
 
 // class MistralClient {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -90,11 +90,17 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
                 return chunk.choices[0]?.delta?.content ?? "";
             };
 
+        //TODO: OpenAI o1 support requires max_completions_tokens
         const stream = (await this.service.chat.completions.create({
             stream: true,
             model: options.model,
             messages: prompt,
             temperature: options.temperature,
+            top_p: options.top_p,
+            //top_logprobs: options.top_logprobs,       //Logprobs output currently not supported
+            //logprobs: options.top_logprobs ? true : false,
+            presence_penalty: options.presence_penalty,
+            frequency_penalty: options.frequency_penalty,
             n: 1,
             max_tokens: options.max_tokens,
             tools: options.result_schema
@@ -131,11 +137,17 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             ]
             : undefined;
 
+        //TODO: OpenAI o1 support requires max_completions_tokens
         const res = await this.service.chat.completions.create({
             stream: false,
             model: options.model,
             messages: prompt,
             temperature: options.temperature,
+            top_p: options.top_p,
+            //top_logprobs: options.top_logprobs,       //Logprobs output currently not supported
+            //logprobs: options.top_logprobs ? true : false,
+            presence_penalty: options.presence_penalty,
+            frequency_penalty: options.frequency_penalty,
             n: 1,
             max_tokens: options.max_tokens,
             tools: functions,

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -30,6 +30,10 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
     }
 
     async requestCompletion(prompt: string, options: ExecutionOptions): Promise<Completion<any>> {
+
+        const stop_seq = typeof options.stop_sequence == 'string' ? 
+            [options.stop_sequence] : options.stop_sequence ?? [];
+
         const res = await this.fetchClient.post('/v1/completions', {
             payload: {
                 model: options.model,
@@ -37,9 +41,15 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
                 response_format: this.getResponseFormat(options),
                 max_tokens: options.max_tokens,
                 temperature: options.temperature,
+                top_p: options.top_p,
+                top_k: options.top_k,
+                //logprobs: options.top_logprobs,       //Logprobs output currently not supported
+                frequency_penalty: options.frequency_penalty,
+                presence_penalty: options.presence_penalty,
                 stop: [
                     "</s>",
-                    "[/INST]"
+                    "[/INST]",
+                    ...stop_seq,
                 ],
             }
         }) as TextCompletion;
@@ -59,6 +69,8 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
     }
 
     async requestCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<string>> {
+        const stop_seq = typeof options.stop_sequence == 'string' ? 
+            [options.stop_sequence] : options.stop_sequence ?? [];
 
         const stream = await this.fetchClient.post('/v1/completions', {
             payload: {
@@ -67,10 +79,16 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
                 max_tokens: options.max_tokens,
                 temperature: options.temperature,
                 response_format: this.getResponseFormat(options),
+                top_p: options.top_p,
+                top_k: options.top_k,
+                //logprobs: options.top_logprobs,       //Logprobs output currently not supported
+                frequency_penalty: options.frequency_penalty,
+                presence_penalty: options.presence_penalty,
                 stream: true,
                 stop: [
                     "</s>",
-                    "[/INST]"
+                    "[/INST]",
+                    ...stop_seq,
                 ],
             },
             reader: 'sse'

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -39,6 +39,11 @@ function getGenerativeModel(driver: VertexAIDriver, options: ExecutionOptions, m
             candidateCount: modelParams?.generationConfig?.candidateCount ?? 1,
             temperature: options.temperature,
             maxOutputTokens: options.max_tokens,
+            topP: options.top_p,
+            topK: options.top_k,
+            frequencyPenalty: options.frequency_penalty,
+            stopSequences: typeof options.stop_sequence === 'string' ?
+            [options.stop_sequence] : options.stop_sequence
         },
     });
 

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver } from '@llumiverse/core';
+import { AIModel, AbstractDriver, ExecutionOptions } from '@llumiverse/core';
 import 'dotenv/config';
 import { GoogleAuth } from 'google-auth-library';
 import { describe, expect, test } from "vitest";
@@ -60,8 +60,8 @@ if (process.env.TOGETHER_API_KEY) {
             apiKey: process.env.TOGETHER_API_KEY as string
         }),
         models: [
-            //"meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-            //"mistralai/Mixtral-8x7B-Instruct-v0.1" too slow in tests for now
+            "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+            //"mistralai/Mixtral-8x7B-Instruct-v0.1" //too slow in tests for now
         ]
     }
     )
@@ -165,11 +165,23 @@ if (process.env.WATSONX_API_KEY) {
 
 describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => {
 
-    let fetchedModels: AIModel[]
+    let fetchedModels: AIModel[];
+
+    let test_options: ExecutionOptions = {
+        model: "",
+        max_tokens: 64,
+        temperature: 0.5,
+        top_k: 40,
+        top_p: 1.0,
+        top_logprobs: 5,        //Currently not supported, option will be ignored
+        presence_penalty: 0.0,
+        frequency_penalty: 0.0,
+    };
 
     test(`${name}: list models`, { timeout: TIMEOUT, retry: 1 }, async () => {
         const r = await driver.listModels();
         fetchedModels = r;
+        console.log(r)
         expect(r.length).toBeGreaterThan(0);
     });
 
@@ -191,27 +203,27 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
     });
 
     test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.execute(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024 });
-        console.debug("Result for " + model, JSON.stringify(r));
+        const r = await driver.execute(testPrompt_color, {...test_options, model: model} as ExecutionOptions);
+        console.log("Result for execute " + model, JSON.stringify(r));
         assertCompletionOk(r);
     });
 
     test.each(models)(`${name}: execute prompt with streaming on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.stream(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024 })
+        const r = await driver.stream(testPrompt_color, {...test_options, model: model} as ExecutionOptions);
         const out = await assertStreamingCompletionOk(r);
-        console.log("Result for " + model, JSON.stringify(out));
+        console.log("Result for streaming " + model, JSON.stringify(out));
     });
 
     test.each(models)(`${name}: execute prompt with schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.execute(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024, result_schema: testSchema_color });
-        console.log("Result for " + model, JSON.stringify(r.result));
+        const r = await driver.execute(testPrompt_color, {...test_options, model: model, result_schema: testSchema_color } as ExecutionOptions);
+        console.log("Result for execute with schema " + model, JSON.stringify(r.result));
         assertCompletionOk(r);
     });
 
     test.each(models)(`${name}: execute prompt with streaming and schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
-        const r = await driver.stream(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024, result_schema: testSchema_color })
+        const r = await driver.stream(testPrompt_color, {...test_options, model: model, result_schema: testSchema_color } as ExecutionOptions);
         const out = await assertStreamingCompletionOk(r, true);
-        console.log("Result for prompt with streaming and schema" + model, JSON.stringify(out));
+        console.log("Result for streaming with schema " + model, JSON.stringify(out));
     });
 
 
@@ -235,6 +247,4 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
         console.log("Result", r)
         assertCompletionOk(r);
     });
-
-
 });

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -115,7 +115,7 @@ if (process.env.BEDROCK_REGION) {
         models: [
             "anthropic.claude-3-sonnet-20240229-v1:0",
             "anthropic.claude-v2:1",
-            "cohere.command-text-v14",
+            //"cohere.command-text-v14", EOL
             "mistral.mixtral-8x7b-instruct-v0:1",
             "cohere.command-r-plus-v1:0",
             "meta.llama3-1-70b-instruct-v1:0"
@@ -169,12 +169,12 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
 
     let test_options: ExecutionOptions = {
         model: "",
-        max_tokens: 64,
-        temperature: 0.5,
+        max_tokens: 128,
+        temperature: 0.3,
         top_k: 40,
-        top_p: 1.0,
+        top_p: 0.7,             //Some models do not support top_p = 1.0, set to 0.99 or lower.
         top_logprobs: 5,        //Currently not supported, option will be ignored
-        presence_penalty: 0.0,
+        presence_penalty: 0.1,      //Cohere Command R does not support using presence & frequency penalty at the same time
         frequency_penalty: 0.0,
     };
 


### PR DESCRIPTION
## Improves completion api with new options for LLMs
https://github.com/becomposable/studio/issues/17

Supports:
- max_tokens
- stop_sequences
- top_k
- top_p
- presence_penalty
- frequency_penalty

as supported by the models/api/provider.

Also updates the test file to reflect this.

### Noteable TODOs:
- OpenAI o1 models use the max_completion_tokens rather than max_tokens
- top_logprobs option currently ignored (commented out on supporting models) as it's output is not supported.

### Instruction to validate:
Use change in test file to set new options, try extreme values that are expected to be invalid, this confirms that the model/provider is reading the option correctly. Or large values that produce identifiable behaviour, i.e. lots of repetitions with -2.0 frequency_penalty.

