### PR TITLE
Adds finish_reason and token_usage support, streaming included.

### DIFF
--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -32,11 +32,10 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
         let resultTokens: number | undefined = undefined;
         for await (const chunk of stream) {
             if (chunk) {
-                if (typeof chunk === 'string'){
+                if (typeof chunk === 'string') {
                     chunks.push(chunk);
                     yield chunk;
                 }else{
-                    chunks.push(chunk.result);
                     if (chunk.finish_reason) {                           //Do not replace non-null values with null values
                         finish_reason = chunk.finish_reason;             //Used to skip empty finish_reason chunks coming after "stop" or "length"
                     }
@@ -47,7 +46,10 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                         promptTokens = Math.max(promptTokens,chunk.token_usage.prompt ?? 0);       
                         resultTokens = Math.max(resultTokens ?? 0,chunk.token_usage.result ?? 0);      
                     }
-                    yield chunk;
+                    if (chunk.result) {
+                        chunks.push(chunk.result);
+                        yield chunk.result;
+                    }
                 }                
             }
         }
@@ -90,7 +92,7 @@ export class FallbackCompletionStream<PromptT = any> implements CompletionStream
         );
         const completion = await this.driver._execute(this.prompt, this.options);
         const content = typeof completion.result === 'string' ? completion.result : JSON.stringify(completion.result);
-        yield {result:content};
+        yield content;
 
         this.completion = completion;
     }

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -22,7 +22,8 @@ import {
     PromptSegment,
     TrainingJob,
     TrainingOptions,
-    TrainingPromptOptions
+    TrainingPromptOptions,
+    CompletionChunk
 } from "./types.js";
 import { validateResult } from "./validation.js";
 
@@ -223,7 +224,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     abstract requestCompletion(prompt: PromptT, options: ExecutionOptions): Promise<Completion>;
 
-    abstract requestCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<string>>;
+    abstract requestCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>>;
 
     //list models available for this environement
     abstract listModels(params?: ModelSearchPayload): Promise<AIModel[]>;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -77,6 +77,10 @@ export interface ExecutionResponse<PromptT = any> extends Completion {
      * The time it took to execute the request in seconds
      */
     execution_time?: number;
+    /**
+     * The number of chunks for streamed executions
+     */
+    chunks?: number;
 }
 
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -40,6 +40,14 @@ export interface ResultValidationError {
     data?: string;
 }
 
+export interface CompletionChunkObject<ResultT = any> {
+    result: ResultT;
+    token_usage?: ExecutionTokenUsage;
+    finish_reason?: "stop" | "length" | string;
+}
+
+export type CompletionChunk = CompletionChunkObject | string;
+
 export interface Completion<ResultT = any> {
     // the driver impl must return the result and optionally the token_usage. the execution time is computed by the extended abstract driver
     result: ResultT;
@@ -72,7 +80,7 @@ export interface ExecutionResponse<PromptT = any> extends Completion {
 }
 
 
-export interface CompletionStream<PromptT = any> extends AsyncIterable<string> {
+export interface CompletionStream<PromptT = any> extends AsyncIterable<CompletionChunk> {
     completion: ExecutionResponse<PromptT> | undefined;
 }
 
@@ -118,6 +126,8 @@ export interface ExecutionOptions extends PromptOptions {
     top_p?: number;
 
     /**
+     * Currently not supported, will be ignored.
+     * Should be an integer.
      * Only supported for OpenAI. Look at OpenAI documentation for more detailsx
      */
     top_logprobs?: number;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -40,15 +40,17 @@ export interface ResultValidationError {
     data?: string;
 }
 
-export interface CompletionChunkObject<ResultT = any> {
+//Internal structure used in driver implementation.
+export interface CompletionChunkObject<ResultT = JSONObject | string> {
     result: ResultT;
     token_usage?: ExecutionTokenUsage;
     finish_reason?: "stop" | "length" | string;
 }
 
+//Internal structure used in driver implementation.
 export type CompletionChunk = CompletionChunkObject | string;
 
-export interface Completion<ResultT = any> {
+export interface Completion<ResultT = JSONObject | string> {
     // the driver impl must return the result and optionally the token_usage. the execution time is computed by the extended abstract driver
     result: ResultT;
     token_usage?: ExecutionTokenUsage;
@@ -84,7 +86,7 @@ export interface ExecutionResponse<PromptT = any> extends Completion {
 }
 
 
-export interface CompletionStream<PromptT = any> extends AsyncIterable<CompletionChunk> {
+export interface CompletionStream<PromptT = any> extends AsyncIterable<string> {
     completion: ExecutionResponse<PromptT> | undefined;
 }
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -40,8 +40,9 @@ export interface ResultValidationError {
     data?: string;
 }
 
+//ResultT should be either JSONObject or string
 //Internal structure used in driver implementation.
-export interface CompletionChunkObject<ResultT = JSONObject | string> {
+export interface CompletionChunkObject<ResultT = any> {
     result: ResultT;
     token_usage?: ExecutionTokenUsage;
     finish_reason?: "stop" | "length" | string;
@@ -50,7 +51,8 @@ export interface CompletionChunkObject<ResultT = JSONObject | string> {
 //Internal structure used in driver implementation.
 export type CompletionChunk = CompletionChunkObject | string;
 
-export interface Completion<ResultT = JSONObject | string> {
+//ResultT should be either JSONObject or string
+export interface Completion<ResultT = any> {
     // the driver impl must return the result and optionally the token_usage. the execution time is computed by the extended abstract driver
     result: ResultT;
     token_usage?: ExecutionTokenUsage;

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -101,8 +101,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     }
 
     //Update this when supporting new models
-    static getTextAnsStopReason(result: any, prompt?: BedrockPrompt): CompletionChunkObject {
-        console.log(result);
+    static getExtractedCompletionChunk(result: any, prompt?: BedrockPrompt): CompletionChunkObject {
         //AWS universal token_usage
         let token_usage = this.getAmazonInvocationMetrics(result);
         if (result.generation || result.generation == '') {
@@ -277,7 +276,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         const body = decoder.decode(response.body);
         const result = JSON.parse(body);
         
-        return BedrockDriver.getTextAnsStopReason(result, prompt);
+        return BedrockDriver.getExtractedCompletionChunk(result, prompt);
     }
 
     async requestCompletion(prompt: BedrockPrompt, options: ExecutionOptions): Promise<Completion> {
@@ -325,7 +324,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             return transformAsyncIterator(res.body, (stream: ResponseStream) => {
                 const segment = JSON.parse(decoder.decode(stream.chunk?.bytes));
                 //console.log("Debug Segment for model " + options.model, JSON.stringify(segment));
-                return BedrockDriver.getTextAnsStopReason(segment, prompt);
+                return BedrockDriver.getExtractedCompletionChunk(segment, prompt);
             });
 
         }).catch((err) => {

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -99,7 +99,11 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, OpenAITextMess
         return transformAsyncIterator(res, (res) => ({
             result: res.choices[0].delta.content ?? '',
             finish_reason: res.choices[0].finish_reason,
-            //Token usage not supported
+            token_usage: {
+                prompt: res.x_groq?.usage?.prompt_tokens,
+                result: res.x_groq?.usage?.completion_tokens,
+                total: res.x_groq?.usage?.total_tokens,
+            },
             } as CompletionChunkObject));
     }
 

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, CompletionChunk } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { OpenAITextMessage, formatOpenAILikeTextPrompt, getJSONSafetyNotice } from "@llumiverse/core/formatters";
 import { FetchClient } from "api-fetch-client";
@@ -82,12 +82,12 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
                 result: res.usage.completion_tokens,
                 total: res.usage.total_tokens,
             },
-            finish_reason: choice.finish_reason,
+            finish_reason: choice.finish_reason,        //Uses expected "stop" , "length" format
             original_response: options.include_original_response ? res : undefined,
         };
     }
 
-    async requestCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<string>> {
+    async requestCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
         const stream = await this.client.post('/v1/chat/completions', {
             payload: _makeChatCompletionRequest({
                 model: options.model,
@@ -102,7 +102,15 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);
-            return json.choices[0]?.delta.content ?? '';
+            return {
+                result: json.choices[0]?.delta.content ?? '',
+                finish_reason: json.choices[0]?.finish_reason,      //Uses expected "stop" , "length" format
+                token_usage: {
+                    prompt: json.usage?.prompt_tokens,
+                    result: json.usage?.completion_tokens,
+                    total: json.usage?.total_tokens,
+                },
+            };
         });
 
     }

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -107,6 +107,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         //TODO: OpenAI o1 support requires max_completions_tokens
         const stream = (await this.service.chat.completions.create({
             stream: true,
+            stream_options: {include_usage: true},
             model: options.model,
             messages: prompt,
             temperature: options.temperature,

--- a/drivers/src/test/TestErrorCompletionStream.ts
+++ b/drivers/src/test/TestErrorCompletionStream.ts
@@ -9,7 +9,7 @@ export class TestErrorCompletionStream implements CompletionStream<PromptSegment
         public options: ExecutionOptions) {
     }
     async *[Symbol.asyncIterator]() {
-        yield {result:"Started TestError. Next we will thrown an error.\n"};
+        yield "Started TestError. Next we will thrown an error.\n";
         sleep(1000);
         throwError("Testing stream completion error.", this.segments);
     }

--- a/drivers/src/test/TestErrorCompletionStream.ts
+++ b/drivers/src/test/TestErrorCompletionStream.ts
@@ -9,7 +9,7 @@ export class TestErrorCompletionStream implements CompletionStream<PromptSegment
         public options: ExecutionOptions) {
     }
     async *[Symbol.asyncIterator]() {
-        yield "Started TestError. Next we will thrown an error.\n";
+        yield {result:"Started TestError. Next we will thrown an error.\n"};
         sleep(1000);
         throwError("Testing stream completion error.", this.segments);
     }

--- a/drivers/src/test/TestValidationErrorCompletionStream.ts
+++ b/drivers/src/test/TestValidationErrorCompletionStream.ts
@@ -10,11 +10,11 @@ export class TestValidationErrorCompletionStream implements CompletionStream<Pro
         public options: ExecutionOptions) {
     }
     async *[Symbol.asyncIterator]() {
-        yield {result:"Started TestValidationError.\n"};
+        yield "Started TestValidationError.\n";
         await sleep(1000);
-        yield {result:"chunk1\n"}
+        yield "chunk1\n";
         await sleep(1000);
-        yield {result:"chunk2\n"}
+        yield "chunk2\n";
         await sleep(1000);
         this.completion = createValidationErrorCompletion(this.segments);
     }

--- a/drivers/src/test/TestValidationErrorCompletionStream.ts
+++ b/drivers/src/test/TestValidationErrorCompletionStream.ts
@@ -10,11 +10,11 @@ export class TestValidationErrorCompletionStream implements CompletionStream<Pro
         public options: ExecutionOptions) {
     }
     async *[Symbol.asyncIterator]() {
-        yield "Started TestValidationError.\n";
+        yield {result:"Started TestValidationError.\n"};
         await sleep(1000);
-        yield "chunk1\n"
+        yield {result:"chunk1\n"}
         await sleep(1000);
-        yield "chunk2\n"
+        yield {result:"chunk2\n"}
         await sleep(1000);
         this.completion = createValidationErrorCompletion(this.segments);
     }

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, DriverOptions, EmbeddingsResult, ExecutionOptions } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, DriverOptions, EmbeddingsResult, ExecutionOptions, CompletionChunk } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { FetchClient } from "api-fetch-client";
 import { TextCompletion, TogetherModelInfo } from "./interfaces.js";
@@ -53,12 +53,14 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
                 result: usage.completion_tokens,
                 total: usage.total_tokens,
             },
-            finish_reason: choice.finish_reason,
+            finish_reason: choice.finish_reason,                //Uses expected "stop" , "length" format
             original_response: options.include_original_response ? res : undefined,
         }
     }
 
-    async requestCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<string>> {
+    async requestCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
+        const stop_seq = typeof options.stop_sequence == 'string' ? 
+            [options.stop_sequence] : options.stop_sequence ?? [];
 
         const stream = await this.fetchClient.post('/v1/completions', {
             payload: {
@@ -78,7 +80,15 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);
-            return json.choices[0]?.text ?? '';
+            return {
+                result: json.choices[0]?.text ?? '',
+                finish_reason: json.choices[0]?.finish_reason,          //Uses expected "stop" , "length" format
+                token_usage: {
+                    prompt: json.usage?.prompt_tokens,
+                    result: json.usage?.completion_tokens,
+                    total: json.usage?.prompt_tokens + json.usage?.completion_tokens,
+                }
+            };
         });
 
     }

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -59,9 +59,6 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
     }
 
     async requestCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunk>> {
-        const stop_seq = typeof options.stop_sequence == 'string' ? 
-            [options.stop_sequence] : options.stop_sequence ?? [];
-
         const stream = await this.fetchClient.post('/v1/completions', {
             payload: {
                 model: options.model,

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -1,5 +1,5 @@
 import { GenerateContentRequest, VertexAI } from "@google-cloud/vertexai";
-import { AIModel, AbstractDriver, Completion, DriverOptions, EmbeddingsResult, ExecutionOptions, ModelSearchPayload, PromptOptions, PromptSegment } from "@llumiverse/core";
+import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, ModelSearchPayload, PromptOptions, PromptSegment } from "@llumiverse/core";
 import { FetchClient } from "api-fetch-client";
 import { GoogleAuth, GoogleAuthOptions } from "google-auth-library";
 import { JSONClient } from "google-auth-library/build/src/auth/googleauth.js";
@@ -58,7 +58,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Genera
     async requestCompletion(prompt: GenerateContentRequest, options: ExecutionOptions): Promise<Completion<any>> {
         return getModelDefinition(options.model).requestCompletion(this, prompt, options);
     }
-    async requestCompletionStream(prompt: GenerateContentRequest, options: ExecutionOptions): Promise<AsyncIterable<string>> {
+    async requestCompletionStream(prompt: GenerateContentRequest, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         return getModelDefinition(options.model).requestCompletionStream(this, prompt, options);
     }
 

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -1,4 +1,4 @@
-import { AIModel, Completion, ExecutionOptions, ModelType, PromptOptions, PromptSegment } from "@llumiverse/core";
+import { AIModel, Completion, CompletionChunkObject, ExecutionOptions, ModelType, PromptOptions, PromptSegment } from "@llumiverse/core";
 import { VertexAIDriver } from "./index.js";
 import { GeminiModelDefinition } from "./models/gemini.js";
 
@@ -10,7 +10,7 @@ export interface ModelDefinition<PromptT = any> {
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
     createPrompt: (driver: VertexAIDriver, segments: PromptSegment[], options: PromptOptions) => Promise<PromptT>;
     requestCompletion: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<Completion>;
-    requestCompletionStream: (driver: VertexAIDriver, promp: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<string>>;
+    requestCompletionStream: (driver: VertexAIDriver, promp: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunkObject>>;
 }
 
 export function getModelName(model: string) {

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -1,5 +1,5 @@
 import { Content, FinishReason, GenerateContentRequest, HarmBlockThreshold, HarmCategory, InlineDataPart, ModelParams, ResponseSchema, TextPart } from "@google-cloud/vertexai";
-import { AIModel, Completion, ExecutionOptions, ExecutionTokenUsage, PromptOptions, PromptRole, PromptSegment, readStreamAsBase64 } from "@llumiverse/core";
+import { AIModel, Completion, CompletionChunkObject, ExecutionOptions, ExecutionTokenUsage, PromptOptions, PromptRole, PromptSegment, readStreamAsBase64 } from "@llumiverse/core";
 import { asyncMap } from "@llumiverse/core/async";
 import { VertexAIDriver } from "../index.js";
 import { BuiltinModels, ModelDefinition } from "../models.js";
@@ -173,26 +173,46 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentReq
 
         return {
             result: result ?? '',
-            token_usage,
-            finish_reason,
+            token_usage: token_usage,
+            finish_reason: finish_reason,
             original_response: options.include_original_response ? response : undefined,
         } as Completion;
     }
 
-    async requestCompletionStream(driver: VertexAIDriver, prompt: GenerateContentRequest, options: ExecutionOptions): Promise<AsyncIterable<string>> {
+    async requestCompletionStream(driver: VertexAIDriver, prompt: GenerateContentRequest, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const model = getGenerativeModel(driver, options);
         const streamingResp = await model.generateContentStream(prompt);
 
         const stream = asyncMap(streamingResp.stream, async (item) => {
+            const usage = item.usageMetadata;
+            const token_usage: ExecutionTokenUsage = {
+                prompt: usage?.promptTokenCount,
+                result: usage?.candidatesTokenCount,
+                total: usage?.totalTokenCount,
+            }
             if (item.candidates && item.candidates.length > 0) {
                 for (const candidate of item.candidates) {
+                    let finish_reason: string | undefined;
+                    switch (candidate.finishReason) {
+                        case FinishReason.MAX_TOKENS: finish_reason = "length"; break;
+                        case FinishReason.STOP: finish_reason = "stop"; break;
+                        default: finish_reason = candidate.finishReason;
+                    }
                     if (candidate.content?.role === 'model') {
                         const text = collectTextParts(candidate.content);
-                        if (text) return text;
+                        return {
+                            result:text,
+                            token_usage: token_usage,
+                            finish_reason: finish_reason,
+                        };
                     }
                 }
             }
-            return '';
+            //No normal output, returning block reason if it exists.
+            return {
+                result: item.promptFeedback?.blockReasonMessage ?? "",
+                finish_reason: item.promptFeedback?.blockReason ?? "",
+            };
         });
 
         return stream;

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -193,7 +193,7 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
     test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
         const r = await driver.execute(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024 });
         console.debug("Result for " + model, JSON.stringify(r));
-        assertCompletionOk(r);
+        assertCompletionOk(r, model, driver);
     });
 
     test.each(models)(`${name}: execute prompt with streaming on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
@@ -205,7 +205,7 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
     test.each(models)(`${name}: execute prompt with schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {
         const r = await driver.execute(testPrompt_color, { model, temperature: 0.5, max_tokens: 1024, result_schema: testSchema_color });
         console.log("Result for " + model, JSON.stringify(r.result));
-        assertCompletionOk(r);
+        assertCompletionOk(r, model, driver);
     });
 
     test.each(models)(`${name}: execute prompt with streaming and schema on %s`, { timeout: TIMEOUT, retry: 3 }, async (model) => {

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -28,12 +28,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
 
     const out: string[] = []
     for await (const chunk of stream) {
-        //console.log("-----",chunk)
-        if (typeof chunk === 'string'){
-            out.push(chunk)
-        } else {
-            out.push(chunk.result)
-        }
+        out.push(chunk)
     }
 
     const r = stream.completion as ExecutionResponse;

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -1,14 +1,18 @@
 
+import { Bedrock } from '@aws-sdk/client-bedrock';
 import { CompletionStream, ExecutionResponse, extractAndParseJSON } from '@llumiverse/core';
 import { expect } from "vitest";
+import { BedrockDriver } from '../src';
 
-export function assertCompletionOk(r: ExecutionResponse) {
+export function assertCompletionOk(r: ExecutionResponse, model?: string, driver?) {
     expect(r.error).toBeFalsy();
     expect(r.prompt).toBeTruthy();
     //TODO: This just checks for existence of the object,
     //could do with more thorough test however not all models support token_usage.
     //Only create the object when there is meaningful information you want to interpret as a pass.
-    expect(r.token_usage).toBeTruthy();     
+    if (!(driver?.provider == 'bedrock' && model?.includes("mistral"))) { //Skip if bedrock:mistral, token_usage not supported.
+        expect(r.token_usage).toBeTruthy();
+    }
     expect(r.finish_reason).toBeTruthy();
     //if r.result is string, it should be longer than 2
     if (typeof r.result === 'string') {
@@ -27,7 +31,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
         //console.log("-----",chunk)
         if (typeof chunk === 'string'){
             out.push(chunk)
-        }else{
+        } else {
             out.push(chunk.result)
         }
     }

--- a/drivers/test/assertions.ts
+++ b/drivers/test/assertions.ts
@@ -5,7 +5,11 @@ import { expect } from "vitest";
 export function assertCompletionOk(r: ExecutionResponse) {
     expect(r.error).toBeFalsy();
     expect(r.prompt).toBeTruthy();
-    expect(r.token_usage).toBeTruthy();
+    //TODO: This just checks for existence of the object,
+    //could do with more thorough test however not all models support token_usage.
+    //Only create the object when there is meaningful information you want to interpret as a pass.
+    expect(r.token_usage).toBeTruthy();     
+    expect(r.finish_reason).toBeTruthy();
     //if r.result is string, it should be longer than 2
     if (typeof r.result === 'string') {
         expect(r.result.length).toBeGreaterThan(2);
@@ -20,7 +24,12 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
 
     const out: string[] = []
     for await (const chunk of stream) {
-        out.push(chunk)
+        //console.log("-----",chunk)
+        if (typeof chunk === 'string'){
+            out.push(chunk)
+        }else{
+            out.push(chunk.result)
+        }
     }
 
     const r = stream.completion as ExecutionResponse;
@@ -31,6 +40,7 @@ export async function assertStreamingCompletionOk(stream: CompletionStream, json
     expect(r.error).toBeFalsy();
     expect(r.prompt).toBeTruthy();
     expect(r.token_usage).toBeTruthy();
+    expect(r.finish_reason).toBeTruthy();
     if (typeof r.result === "string")  expect(r.result?.length).toBeGreaterThan(2);
 
     return out;


### PR DESCRIPTION
## Adds finish_reason and token_usage support, streaming included.
https://github.com/becomposable/studio/issues/17

This change effects a large number of files as the return type used to pass along stream chunks has changed from:
string (containing only the result chunk) ----> CompletionChunkObject 
Which supports: result, token_usage and finish_reason.

The below type has been introduced for utility functions so you can still use strings.
CompletionChunk = CompletionChunkObject | string

### New token_usage standard meaning:
Old: character count
New: Reported token count or when streaming and nothing is reported, stream chunks are counted (treating each chunk as 1 token).

### Instructions for review:
AWS models need to be checked, particularly Claude as the way the extra { is handled has changed.

### Instructions for validation:
In assertions.ts put a console.log(chunk) in the loop to output the whole object for each stream chunk. Similarly for non-streaming, before running the test file.
Note: you might need to extend how far back you can scroll on your terminal, to see all the raw output.
In VSCode this is "terminal.integrated.scrollback". I set mine to 10000.

The expected pattern can be seen at a glance.

finish_reason: there should be no chunks after a stop signal i.e.:
null,null,null,null,null,stop

token_usage: tokens reported should be cumulative, not independent, i.e:
result tokens:
1,3,6,7,10,12 - represents chunks of length 1,2,3,1,3,2
1,2,3,4,5,6,7,8,9 - is common when streaming and the default when no counts are reported.
prompt tokens:
should be identical for each stream chunk

Some models do not support prompt token reporting, giving only result tokens.