### PR TITLE
fix: use standard aiplatform auth pattern for Imagen

### DIFF
--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -20,7 +20,7 @@ import { TextEmbeddingsOptions, getEmbeddingsForText } from "./embeddings/embedd
 import { getModelDefinition } from "./models.js";
 import { EmbeddingsOptions } from "@llumiverse/core";
 import { getEmbeddingsForImages } from "./embeddings/embeddings-image.js";
-import { v1beta1 } from "@google-cloud/aiplatform";
+import { PredictionServiceClient, v1beta1 } from "@google-cloud/aiplatform";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { ImagenModelDefinition, ImagenPrompt } from "./models/imagen.js";
 import { GoogleGenAI, Content } from "@google/genai";
@@ -54,6 +54,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     googleGenAI: GoogleGenAI | undefined;
     llamaClient: FetchClient & { region?: string } | undefined;
     modelGarden: v1beta1.ModelGardenServiceClient | undefined;
+    imagenClient: PredictionServiceClient| undefined;
 
     authClient: JSONClient | GoogleAuth<JSONClient>;
 
@@ -66,6 +67,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         this.googleGenAI = undefined;
         this.modelGarden = undefined;
         this.llamaClient = undefined;
+        this.imagenClient = undefined;
 
         this.authClient = options.googleAuthOptions?.authClient ?? new GoogleAuth(options.googleAuthOptions);
     }
@@ -152,6 +154,19 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             });
         }
         return this.modelGarden;
+    }
+
+    public getImagenClient(): PredictionServiceClient {
+        //Lazy initialisation
+        if (!this.imagenClient) {
+            // TODO: make location configurable, fixed to us-central1 for now
+            this.imagenClient = new PredictionServiceClient({
+                projectId: this.options.project,
+                apiEndpoint: `us-central1-${API_BASE_PATH}`,
+                authClient: this.authClient as JSONClient,
+            });
+        }
+        return this.imagenClient;
     }
 
     validateResult(result: Completion, options: ExecutionOptions) {

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -4,15 +4,9 @@ import {
 } from "@llumiverse/core";
 import { VertexAIDriver } from "../index.js";
 
-const location = 'us-central1';
-
-import aiplatform, { protos } from '@google-cloud/aiplatform';
-
-// Imports the Google Cloud Prediction Service Client library
-const { PredictionServiceClient } = aiplatform.v1;
-
 // Import the helper module for converting arbitrary protobuf.Value objects
-import { helpers } from '@google-cloud/aiplatform';
+import { protos, helpers } from '@google-cloud/aiplatform';
+
 interface ImagenBaseReference {
     referenceType: "REFERENCE_TYPE_RAW" | "REFERENCE_TYPE_MASK" | "REFERENCE_TYPE_SUBJECT" |
     "REFERENCE_TYPE_CONTROL" | "REFERENCE_TYPE_STYLE";
@@ -88,14 +82,6 @@ export interface ImagenPrompt {
     subjectDescription?: string; //Used for image customization to describe in the reference image
     negativePrompt?: string; //Used for negative prompts
 }
-
-// Specifies the location of the api endpoint
-const clientOptions = {
-    apiEndpoint: `${location}-aiplatform.googleapis.com`,
-};
-
-// Instantiates a client
-const predictionServiceClient = new PredictionServiceClient(clientOptions);
 
 function getImagenParameters(taskType: string, options: ImagenOptions) {
     const commonParameters = {
@@ -353,7 +339,8 @@ export class ImagenModelDefinition {
         const modelName = options.model.split("/").pop() ?? '';
 
         // Configure the parent resource
-        const endpoint = `projects/${driver.options.project}/locations/${location}/publishers/google/models/${modelName}`;
+        // TODO: make location configurable, fixed to us-central1 for now
+        const endpoint = `projects/${driver.options.project}/locations/us-central1/publishers/google/models/${modelName}`;
 
         const instanceValue = helpers.toValue(prompt);
         if (!instanceValue) {
@@ -379,8 +366,10 @@ export class ImagenModelDefinition {
             parameters,
         };
 
+        const client = driver.getImagenClient();
+
         // Predict request
-        const [response] = await predictionServiceClient.predict(request, { timeout: 120000 * numberOfImages }); //Extended timeout for image generation
+        const [response] = await client.predict(request, { timeout: 120000 * numberOfImages }); //Extended timeout for image generation
         const predictions = response.predictions;
 
         if (!predictions) {


### PR DESCRIPTION
Use the standard client initialisation pattern we use for aiplatform clients.

This uses the authClient for the client construction rather than local variables.