### PR TITLE
fix: correct node-version matrix syntax in GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: 22.x
+        node-version: [22.x]
     steps:
       - uses: actions/checkout@main
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Fixed GitHub Actions workflow syntax error in build-and-test.yml
- Changed node-version matrix from scalar value to array format

## Changes
- Updated `node-version: 22.x` to `node-version: [22.x]` to fix the "Unexpected value '22.x'" error

🤖 Generated with Claude Code