### PR TITLE
fix: correct versions length check for Page object in ReplicateDriver

### DIFF
--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -236,7 +236,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
             this.service.models.versions.list(owner, model),
         ]);
 
-        if (!rModel || !versions || versions.length === 0) {
+        if (!rModel || !versions || (versions as any).results?.length === 0) {
             throw new Error("Model not found or no versions available");
         }
 


### PR DESCRIPTION
## Summary
- Fixed TypeScript error in ReplicateDriver's listModelVersions method
- The versions object is a Page type, not an array, so we need to check `versions.results.length` instead of `versions.length`

## Changes
- Updated the condition to check `(versions as any).results?.length === 0` instead of `versions.length === 0`

🤖 Generated with Claude Code