### PR TITLE
docs: clarify scope and add 'Why Llumiverse' + tooling updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ Use Llumiverse when you want a precise, typed, provider‑agnostic LLM connector
 - Fine‑tuning/training surfaces (currently OpenAI) with a path to extend per provider
 
 When not to use Llumiverse:
-- You want chains, memory, agents, retrieval, or a batteries‑included framework → consider LangChain.
-- You want a lightweight, UI‑first streaming toolkit and typed function calling for mostly OpenAI‑like providers → consider Vercel AI SDK (ai).
+- You want a larger platform with orchestration, evaluation, deployment, governance, and UI tooling → consider Vertesia.
+- You need a batteries‑included developer framework for chains, memory, agents, and retrieval → use a chains/agents framework.
+- You need a UI‑first streaming toolkit and typed function calling geared to single‑provider apps → use a lightweight streaming SDK.
 
 Llumiverse complements those tools by being a thin, reliable connector layer you can compose into your own architecture.
 


### PR DESCRIPTION
This PR improves the documentation to make it clear what Llumiverse is good for and when to use it.\n\nChanges\n- Add a new 'Why Llumiverse' section to README, outlining scope, strengths, and when not to use it (e.g., choose LangChain or Vercel AI SDK for other needs).\n- Add an Architecture section and clarify key concepts (prompts, streaming, structured output, capabilities/options).\n- Add Azure AI Foundry driver usage and model ID semantics (composite id: deploymentName::baseModel).\n- Add structured output (JSON Schema) example and behavior (Ajv validation with provider hints where supported).\n- Update embeddings section to note Azure Foundry support and clarify provider coverage.\n- Rewrite README-tools.md: reflect cross-provider tool support, correct types (ToolUse.tool_name/tool_input), conversation carry-over, and provider notes.\n\nRationale\n- Position Llumiverse as a thin, typed, provider-agnostic connector layer with strong multi-provider parity, rather than an all-in-one framework.\n\nPreview\n- README.md and README-tools.md updated accordingly.