### PR TITLE
feat: prompt caching support for all LLM drivers

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -656,6 +656,14 @@ export interface ExecutionTokenUsage {
     prompt?: number;
     result?: number;
     total?: number;
+    /**
+     * Number of input tokens read from prompt cache (discounted rate).
+     */
+    prompt_cached?: number;
+    /**
+     * Number of input tokens written to prompt cache.
+     */
+    prompt_cache_write?: number;
 }
 
 /**

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -664,6 +664,9 @@ export interface ExecutionTokenUsage {
      * Number of input tokens written to prompt cache.
      */
     prompt_cache_write?: number;
+
+    /* Number of new input tokens not from cache. This is useful for providers with prompt caching to understand how many tokens were actually newly processed in the prompt, separate from any cached tokens. Calculated as prompt - prompt_cached. */
+    prompt_new?: number; // Number of new input tokens not from cache (calculated as prompt - prompt_cached)
 }
 
 /**

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -53,7 +53,7 @@
         "vitest": "^4.0.18"
     },
     "dependencies": {
-        "@anthropic-ai/sdk": "^0.78.0",
+        "@anthropic-ai/sdk": "^0.85.0",
         "@anthropic-ai/vertex-sdk": "^0.14.4",
         "@aws-sdk/client-bedrock": "^3.985.0",
         "@aws-sdk/client-bedrock-runtime": "^3.985.0",
@@ -78,7 +78,7 @@
         "groq-sdk": "^0.37.0",
         "mnemonist": "^0.40.3",
         "node-web-stream-adapters": "^0.2.1",
-        "openai": "^6.22.0",
+        "openai": "^6.33.0",
         "replicate": "^1.4.0"
     },
     "ts_dual_module": {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -374,6 +374,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             result: reasoning + resultText ? [{ type: "text", value: reasoning + resultText }] : [],
             token_usage: {
                 prompt: result.usage?.inputTokens,
+                prompt_new: result.usage ? ((result.usage.inputTokens ?? 0) - (result.usage.cacheReadInputTokens ?? 0)) : undefined,
                 result: result.usage?.outputTokens,
                 total: result.usage?.totalTokens,
                 prompt_cached: result.usage?.cacheReadInputTokens ?? undefined,

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -145,6 +145,9 @@ function isClaudeVersionGTE(modelString: string, targetMajor: number, targetMino
 
 export type BedrockPrompt = NovaMessagesPrompt | ConverseRequest | TwelvelabsPegasusRequest;
 
+type BedrockSystemBlock = NonNullable<ConverseRequest['system']>[number];
+type BedrockToolEntry = NonNullable<NonNullable<ConverseRequest['toolConfig']>['tools']>[number];
+
 export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockPrompt> {
 
     static PROVIDER = "bedrock";
@@ -1035,14 +1038,36 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             request.messages = convertToolBlocksToText(request.messages);
         }
 
-        // Prompt caching: mark the conversation history prefix so subsequent calls
-        // reuse cached input tokens instead of reprocessing the entire conversation.
-        // Only for Claude models which support the cachePoint content block.
-        if (options.model.includes('claude') && request.messages && request.messages.length >= 4) {
-            request.messages = stripClaudeCachePoints(request.messages);
-            const pivotMsg = request.messages[request.messages.length - 2];
-            if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
-                pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default' } }];
+        // Prompt caching: use three breakpoints so stable system blocks, tool definitions,
+        // and the conversation history prefix can all be reused across Claude turns.
+        if (options.model.includes('claude')) {
+            if (request.messages) {
+                request.messages = stripClaudeCachePoints(request.messages);
+            }
+            request.system = stripClaudeCachePointsFromSystem(request.system);
+            if (request.toolConfig?.tools) {
+                request.toolConfig = {
+                    ...request.toolConfig,
+                    tools: stripClaudeCachePointsFromTools(request.toolConfig.tools),
+                };
+            }
+
+            if (request.system && request.system.length > 0) {
+                request.system = [...request.system, { cachePoint: { type: 'default' } } as BedrockSystemBlock];
+            }
+
+            if (request.toolConfig?.tools && request.toolConfig.tools.length > 0) {
+                request.toolConfig.tools = [
+                    ...request.toolConfig.tools,
+                    { cachePoint: { type: 'default' } } as BedrockToolEntry,
+                ];
+            }
+
+            if (request.messages && request.messages.length >= 4) {
+                const pivotMsg = request.messages[request.messages.length - 2];
+                if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+                    pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default' } }];
+                }
             }
         }
 
@@ -1598,6 +1623,16 @@ function stripClaudeCachePoints(messages: Message[]): Message[] {
         ...message,
         content: message.content?.filter(block => !('cachePoint' in block)),
     }));
+}
+
+function stripClaudeCachePointsFromSystem(system?: ConverseRequest['system']): ConverseRequest['system'] | undefined {
+    return (system?.filter(block => !('cachePoint' in (block as object))) ?? undefined) as ConverseRequest['system'] | undefined;
+}
+
+function stripClaudeCachePointsFromTools(
+    tools?: NonNullable<NonNullable<ConverseRequest['toolConfig']>['tools']>
+): NonNullable<NonNullable<ConverseRequest['toolConfig']>['tools']> | undefined {
+    return (tools?.filter(tool => !('cachePoint' in (tool as object))) ?? undefined) as NonNullable<NonNullable<ConverseRequest['toolConfig']>['tools']> | undefined;
 }
 
 /**

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -376,6 +376,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 prompt: result.usage?.inputTokens,
                 result: result.usage?.outputTokens,
                 total: result.usage?.totalTokens,
+                prompt_cached: result.usage?.cacheReadInputTokens ?? undefined,
+                prompt_cache_write: result.usage?.cacheWriteInputTokens ?? undefined,
             },
             finish_reason: converseFinishReason(result.stopReason),
         };
@@ -467,6 +469,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 prompt: result.metadata.usage?.inputTokens,
                 result: result.metadata.usage?.outputTokens,
                 total: result.metadata.usage?.totalTokens,
+                prompt_cached: result.metadata.usage?.cacheReadInputTokens ?? undefined,
+                prompt_cache_write: result.metadata.usage?.cacheWriteInputTokens ?? undefined,
             }
         }
 
@@ -1028,6 +1032,16 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             // to text representations so the conversation data is preserved while satisfying
             // Bedrock's API requirements without making tools callable.
             request.messages = convertToolBlocksToText(request.messages);
+        }
+
+        // Prompt caching: mark the conversation history prefix so subsequent calls
+        // reuse cached input tokens instead of reprocessing the entire conversation.
+        // Only for Claude models which support the cachePoint content block.
+        if (options.model.includes('claude') && request.messages && request.messages.length >= 4) {
+            const pivotMsg = request.messages[request.messages.length - 2];
+            if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+                pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default' } }];
+            }
         }
 
         return request;

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1038,6 +1038,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         // reuse cached input tokens instead of reprocessing the entire conversation.
         // Only for Claude models which support the cachePoint content block.
         if (options.model.includes('claude') && request.messages && request.messages.length >= 4) {
+            request.messages = stripClaudeCachePoints(request.messages);
             const pivotMsg = request.messages[request.messages.length - 2];
             if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
                 pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default' } }];
@@ -1589,6 +1590,13 @@ function updateConversation(conversation: ConverseRequest, prompt: ConverseReque
         messages: fixedMessages.length > 0 ? fixedMessages : [],
         system: combinedSystem && combinedSystem.length > 0 ? combinedSystem : undefined,
     };
+}
+
+function stripClaudeCachePoints(messages: Message[]): Message[] {
+    return messages.map(message => ({
+        ...message,
+        content: message.content?.filter(block => !('cachePoint' in block)),
+    }));
 }
 
 /**

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -793,6 +793,7 @@ function mapUsage(usage?: OpenAI.Responses.ResponseUsage | null): ExecutionToken
         prompt: usage.input_tokens,
         result: usage.output_tokens,
         total: usage.total_tokens,
+        prompt_cached: usage.input_tokens_details?.cached_tokens ?? undefined,
     };
 }
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -794,6 +794,7 @@ function mapUsage(usage?: OpenAI.Responses.ResponseUsage | null): ExecutionToken
         result: usage.output_tokens,
         total: usage.total_tokens,
         prompt_cached: usage.input_tokens_details?.cached_tokens ?? undefined,
+        prompt_new: usage.input_tokens - (usage.input_tokens_details?.cached_tokens ?? 0),
     };
 }
 

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -335,7 +335,9 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             token_usage: {
                 prompt: result.usage.input_tokens,
                 result: result.usage.output_tokens,
-                total: result.usage.input_tokens + result.usage.output_tokens
+                total: result.usage.input_tokens + result.usage.output_tokens,
+                prompt_cached: result.usage.cache_read_input_tokens ?? undefined,
+                prompt_cache_write: result.usage.cache_creation_input_tokens ?? undefined,
             },
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),
@@ -380,7 +382,9 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
                         result: [{ type: "text", value: '' }],
                         token_usage: {
                             prompt: streamEvent.message.usage.input_tokens,
-                            result: streamEvent.message.usage.output_tokens
+                            result: streamEvent.message.usage.output_tokens,
+                            prompt_cached: (streamEvent.message.usage as any).cache_read_input_tokens ?? undefined,
+                            prompt_cache_write: (streamEvent.message.usage as any).cache_creation_input_tokens ?? undefined,
                         }
                     } satisfies CompletionChunkObject;
                 case "message_delta":
@@ -893,6 +897,21 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
     const hasTools = options.tools && options.tools.length > 0;
     if (!hasTools && claudeMessagesContainToolBlocks(sanitizedMessages)) {
         sanitizedMessages = convertClaudeToolBlocksToText(sanitizedMessages);
+    }
+
+    // Prompt caching: mark the conversation history prefix so subsequent calls
+    // reuse cached input tokens instead of reprocessing the entire conversation.
+    if (sanitizedMessages.length >= 4) {
+        const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
+        if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+            const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
+            // cache_control is supported on text, tool_use, tool_result, image, document blocks
+            // but not on thinking/redacted_thinking blocks
+            if (typeof lastBlock === 'object' && lastBlock !== null &&
+                'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
+                (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral' };
+            }
+        }
     }
 
     const payload = {

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -335,7 +335,9 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             token_usage: {
                 prompt: result.usage.input_tokens,
                 result: result.usage.output_tokens,
-                total: result.usage.input_tokens + result.usage.output_tokens
+                total: result.usage.input_tokens + result.usage.output_tokens,
+                prompt_cached: result.usage.cache_read_input_tokens ?? undefined,
+                prompt_cache_write: result.usage.cache_creation_input_tokens ?? undefined,
             },
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),
@@ -380,7 +382,9 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
                         result: [{ type: "text", value: '' }],
                         token_usage: {
                             prompt: streamEvent.message.usage.input_tokens,
-                            result: streamEvent.message.usage.output_tokens
+                            result: streamEvent.message.usage.output_tokens,
+                            prompt_cached: (streamEvent.message.usage as any).cache_read_input_tokens ?? undefined,
+                            prompt_cache_write: (streamEvent.message.usage as any).cache_creation_input_tokens ?? undefined,
                         }
                     } satisfies CompletionChunkObject;
                 case "message_delta":
@@ -887,6 +891,21 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
     const hasTools = options.tools && options.tools.length > 0;
     if (!hasTools && claudeMessagesContainToolBlocks(sanitizedMessages)) {
         sanitizedMessages = convertClaudeToolBlocksToText(sanitizedMessages);
+    }
+
+    // Prompt caching: mark the conversation history prefix so subsequent calls
+    // reuse cached input tokens instead of reprocessing the entire conversation.
+    if (sanitizedMessages.length >= 4) {
+        const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
+        if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+            const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
+            // cache_control is supported on text, tool_use, tool_result, image, document blocks
+            // but not on thinking/redacted_thinking blocks
+            if (typeof lastBlock === 'object' && lastBlock !== null &&
+                'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
+                (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral' };
+            }
+        }
     }
 
     const payload = {

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -864,6 +864,8 @@ interface RequestOptions {
     headers?: Record<string, string>;
 }
 
+type ClaudeTool = NonNullable<MessageCreateParamsBase['tools']>[number];
+
 function stripClaudeCacheControlFromMessages(messages: MessageParam[]): MessageParam[] {
     return messages.map(message => {
         if (typeof message.content === 'string') {
@@ -887,6 +889,14 @@ function stripClaudeCacheControlFromSystem(system?: TextBlockParam[]): TextBlock
     return system?.map(block => {
         const { cache_control: _cacheControl, ...rest } = block as TextBlockParam & { cache_control?: unknown };
         return rest as TextBlockParam;
+    });
+}
+
+function stripClaudeCacheControlFromTools(tools?: MessageCreateParamsBase['tools']): MessageCreateParamsBase['tools'] | undefined {
+    return tools?.map(tool => {
+        const cloned = { ...tool } as ClaudeTool & { cache_control?: unknown };
+        delete cloned.cache_control;
+        return cloned as ClaudeTool;
     });
 }
 
@@ -928,15 +938,26 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
 
     sanitizedMessages = stripClaudeCacheControlFromMessages(sanitizedMessages);
     const sanitizedSystem = stripClaudeCacheControlFromSystem(prompt.system);
+    const sanitizedTools = hasTools
+        ? stripClaudeCacheControlFromTools(options.tools as MessageCreateParamsBase['tools'])
+        : undefined;
 
-    // Prompt caching: mark the conversation history prefix so subsequent calls
-    // reuse cached input tokens instead of reprocessing the entire conversation.
+    // Prompt caching: use three breakpoints so stable system prompt, tool definitions,
+    // and the conversation history prefix can all be reused across calls.
+    if (sanitizedSystem && sanitizedSystem.length > 0) {
+        const lastSystemBlock = sanitizedSystem[sanitizedSystem.length - 1] as TextBlockParam & { cache_control?: unknown };
+        lastSystemBlock.cache_control = { type: 'ephemeral' };
+    }
+
+    if (sanitizedTools && sanitizedTools.length > 0) {
+        const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
+        lastTool.cache_control = { type: 'ephemeral' };
+    }
+
     if (sanitizedMessages.length >= 4) {
         const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
         if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
             const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
-            // cache_control is supported on text, tool_use, tool_result, image, document blocks
-            // but not on thinking/redacted_thinking blocks
             if (typeof lastBlock === 'object' && lastBlock !== null &&
                 'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
                 (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral' };
@@ -947,7 +968,7 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
     const payload = {
         messages: sanitizedMessages,
         system: sanitizedSystem,
-        tools: hasTools ? options.tools as MessageCreateParamsBase['tools'] : undefined,
+        tools: sanitizedTools,
         temperature: model_options?.temperature,
         model: modelName,
         max_tokens: maxToken(options),

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -334,11 +334,11 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             tool_use,
             token_usage: {
                 prompt_new: result.usage.input_tokens,
-                prompt: (result.usage.cache_read_input_tokens ?? 0) + result.usage.input_tokens,
+                prompt: result.usage.input_tokens + (result.usage.cache_read_input_tokens ?? 0) + (result.usage.cache_creation_input_tokens ?? 0),
                 result: result.usage.output_tokens,
                 prompt_cached: result.usage.cache_read_input_tokens ?? undefined,
                 prompt_cache_write: result.usage.cache_creation_input_tokens ?? undefined,
-                total: result.usage.input_tokens + result.usage.output_tokens + (result.usage.cache_read_input_tokens ?? 0),
+                total: result.usage.input_tokens + result.usage.output_tokens + (result.usage.cache_read_input_tokens ?? 0) + (result.usage.cache_creation_input_tokens ?? 0),
             },
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -863,6 +863,32 @@ interface RequestOptions {
     headers?: Record<string, string>;
 }
 
+function stripClaudeCacheControlFromMessages(messages: MessageParam[]): MessageParam[] {
+    return messages.map(message => {
+        if (typeof message.content === 'string') {
+            return message;
+        }
+
+        return {
+            ...message,
+            content: message.content.map(block => {
+                if (typeof block !== 'object' || block === null) {
+                    return block;
+                }
+                const { cache_control: _cacheControl, ...rest } = block as Record<string, unknown>;
+                return rest as typeof block;
+            }),
+        };
+    });
+}
+
+function stripClaudeCacheControlFromSystem(system?: TextBlockParam[]): TextBlockParam[] | undefined {
+    return system?.map(block => {
+        const { cache_control: _cacheControl, ...rest } = block as TextBlockParam & { cache_control?: unknown };
+        return rest as TextBlockParam;
+    });
+}
+
 function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { payload: MessageCreateParamsBase, requestOptions: RequestOptions | undefined } {
     const modelName = options.model; // Model name is already extracted in the calling methods
     const model_options = options.model_options as VertexAIClaudeOptions;
@@ -899,6 +925,9 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
         sanitizedMessages = convertClaudeToolBlocksToText(sanitizedMessages);
     }
 
+    sanitizedMessages = stripClaudeCacheControlFromMessages(sanitizedMessages);
+    const sanitizedSystem = stripClaudeCacheControlFromSystem(prompt.system);
+
     // Prompt caching: mark the conversation history prefix so subsequent calls
     // reuse cached input tokens instead of reprocessing the entire conversation.
     if (sanitizedMessages.length >= 4) {
@@ -916,7 +945,7 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
 
     const payload = {
         messages: sanitizedMessages,
-        system: prompt.system,
+        system: sanitizedSystem,
         tools: hasTools ? options.tools as MessageCreateParamsBase['tools'] : undefined,
         temperature: model_options?.temperature,
         model: modelName,

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -333,11 +333,12 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
             result: text ? [{ type: "text", value: text }] : [{ type: "text", value: '' }],
             tool_use,
             token_usage: {
-                prompt: result.usage.input_tokens,
+                prompt_new: result.usage.input_tokens,
+                prompt: (result.usage.cache_read_input_tokens ?? 0) + result.usage.input_tokens,
                 result: result.usage.output_tokens,
-                total: result.usage.input_tokens + result.usage.output_tokens,
                 prompt_cached: result.usage.cache_read_input_tokens ?? undefined,
                 prompt_cache_write: result.usage.cache_creation_input_tokens ?? undefined,
+                total: result.usage.input_tokens + result.usage.output_tokens + (result.usage.cache_read_input_tokens ?? 0),
             },
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -871,15 +871,15 @@ function stripClaudeCacheControlFromMessages(messages: MessageParam[]): MessageP
 
         return {
             ...message,
-            content: message.content.map(block => {
-                if (typeof block !== 'object' || block === null) {
-                    return block;
-                }
-                const { cache_control: _cacheControl, ...rest } = block as Record<string, unknown>;
-                return rest as typeof block;
-            }),
+            content: message.content.map(block => stripClaudeCacheControlFromBlock(block)),
         };
     });
+}
+
+function stripClaudeCacheControlFromBlock<T extends ContentBlockParam>(block: T): T {
+    const cloned = { ...block } as T & { cache_control?: unknown };
+    delete cloned.cache_control;
+    return cloned as T;
 }
 
 function stripClaudeCacheControlFromSystem(system?: TextBlockParam[]): TextBlockParam[] | undefined {

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -787,6 +787,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             total: usageMetadata.totalTokenCount,
             prompt: usageMetadata.promptTokenCount,
             prompt_cached: usageMetadata.cachedContentTokenCount ?? undefined,
+            prompt_new: (usageMetadata.promptTokenCount ?? 0) - (usageMetadata.cachedContentTokenCount ?? 0),
         };
 
         //Output/Response side

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -783,7 +783,11 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         if (!usageMetadata || !usageMetadata.totalTokenCount) {
             return {};
         }
-        const tokenUsage: ExecutionTokenUsage = { total: usageMetadata.totalTokenCount, prompt: usageMetadata.promptTokenCount };
+        const tokenUsage: ExecutionTokenUsage = {
+            total: usageMetadata.totalTokenCount,
+            prompt: usageMetadata.promptTokenCount,
+            prompt_cached: usageMetadata.cachedContentTokenCount ?? undefined,
+        };
 
         //Output/Response side
         tokenUsage.result = (usageMetadata.candidatesTokenCount ?? 0)

--- a/drivers/test/conversation.test.ts
+++ b/drivers/test/conversation.test.ts
@@ -98,6 +98,8 @@ if (process.env.XAI_API_KEY) {
     console.warn("xAI tests are skipped: XAI_API_KEY environment variable is not set");
 }
 
+const hasClaudeDrivers = drivers.some(driver => driver.name.includes("claude"));
+
 /**
  * DataSource implementation that fetches image from URL and provides it as a stream.
  * This simulates how Studio sends images - fetched and converted to base64/bytes.
@@ -203,6 +205,11 @@ function getTextOptions(model: string): ExecutionOptions {
     };
 }
 
+function buildCacheableContext(): string {
+    const repeatedSection = "Prompt caching verification context. Preserve this exact context across turns and do not summarize it unless explicitly asked. ";
+    return `You are participating in a prompt caching verification test.\n\n${repeatedSection.repeat(180)}`;
+}
+
 /**
  * Verify that a conversation object can survive JSON serialization.
  * This catches Uint8Array corruption issues where bytes become { "0": 137, "1": 80, ... }
@@ -246,6 +253,13 @@ const hasDrivers = drivers.length > 0;
 describe.skipIf(hasDrivers)("Multi-turn Conversations (no drivers configured)", () => {
     test("skipped - no API keys configured", () => {
         console.warn("All conversation tests skipped: No API keys configured for any driver");
+        expect(true).toBe(true);
+    });
+});
+
+describe.skipIf(hasClaudeDrivers)("Claude prompt caching (no Claude drivers configured)", () => {
+    test("skipped - no Claude drivers configured", () => {
+        console.warn("Claude prompt caching tests skipped: No Claude drivers configured");
         expect(true).toBe(true);
     });
 });
@@ -302,6 +316,63 @@ describe.concurrent.skipIf(!hasDrivers).each(drivers)("Driver $name - Multi-turn
 
         // Final verification
         verifyConversationSerializable(result3.conversation, name);
+    });
+
+    test.skipIf(!name.includes('claude'))(`${name}: multi-turn prompt caching reports token usage`, { timeout: TIMEOUT, retry: 1 }, async () => {
+        const options = getTextOptions(textModel);
+        const basePrompt = buildCacheableContext();
+
+        const turn1 = await driver.execute([
+            {
+                role: PromptRole.system,
+                content: "Respond briefly. Preserve conversation context across turns."
+            },
+            {
+                role: PromptRole.user,
+                content: `${basePrompt}\n\nAcknowledge with exactly: TURN-1-OK`
+            }
+        ], options);
+        expect(turn1.conversation).toBeDefined();
+        expect(turn1.token_usage).toBeDefined();
+        verifyConversationSerializable(turn1.conversation, name);
+
+        const storedConversation1 = JSON.parse(JSON.stringify(turn1.conversation));
+
+        const turn2 = await driver.execute([
+            {
+                role: PromptRole.user,
+                content: "Reply with exactly: TURN-2-OK"
+            }
+        ], { ...options, conversation: storedConversation1 });
+        expect(turn2.conversation).toBeDefined();
+        expect(turn2.token_usage).toBeDefined();
+        verifyConversationSerializable(turn2.conversation, name);
+
+        const storedConversation2 = JSON.parse(JSON.stringify(turn2.conversation));
+
+        const turn3 = await driver.execute([
+            {
+                role: PromptRole.user,
+                content: "Reply with exactly: TURN-3-OK"
+            }
+        ], { ...options, conversation: storedConversation2 });
+        expect(turn3.conversation).toBeDefined();
+        expect(turn3.token_usage).toBeDefined();
+        verifyConversationSerializable(turn3.conversation, name);
+        expect(turn3.token_usage?.prompt_cache_write ?? 0).toBeGreaterThan(0);
+
+        const storedConversation3 = JSON.parse(JSON.stringify(turn3.conversation));
+
+        const turn4 = await driver.execute([
+            {
+                role: PromptRole.user,
+                content: "Reply with exactly: TURN-4-OK"
+            }
+        ], { ...options, conversation: storedConversation3 });
+        expect(turn4.conversation).toBeDefined();
+        expect(turn4.token_usage).toBeDefined();
+        verifyConversationSerializable(turn4.conversation, name);
+        expect(turn4.token_usage?.prompt_cached ?? 0).toBeGreaterThan(0);
     });
 
     test.skipIf(!visionModel)(`${name}: multi-turn conversation with image`, { timeout: TIMEOUT }, async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
   drivers:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.78.0
-        version: 0.78.0(zod@3.25.63)
+        specifier: ^0.85.0
+        version: 0.85.0(zod@3.25.63)
       '@anthropic-ai/vertex-sdk':
         specifier: ^0.14.4
         version: 0.14.4(zod@3.25.63)
@@ -184,8 +184,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       openai:
-        specifier: ^6.22.0
-        version: 6.22.0(ws@8.18.2)(zod@3.25.63)
+        specifier: ^6.33.0
+        version: 6.33.0(ws@8.18.2)(zod@3.25.63)
       replicate:
         specifier: ^1.4.0
         version: 1.4.0
@@ -227,8 +227,8 @@ importers:
 
 packages:
 
-  '@anthropic-ai/sdk@0.78.0':
-    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+  '@anthropic-ai/sdk@0.85.0':
+    resolution: {integrity: sha512-nmwwB1zYSOwDSKtw+HXUzx+SKfBekTknt92R63tGZAZkppwyHw+cMHugjCvWZ9G92I965tz0062VKeUnzVJZlA==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -2014,8 +2014,8 @@ packages:
       zod:
         optional: true
 
-  openai@6.22.0:
-    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
+  openai@6.33.0:
+    resolution: {integrity: sha512-xAYN1W3YsDXJWA5F277135YfkEk6H7D3D6vWwRhJ3OEkzRgcyK8z/P5P9Gyi/wB4N8kK9kM5ZjprfvyHagKmpw==}
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
@@ -2424,7 +2424,7 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.78.0(zod@3.25.63)':
+  '@anthropic-ai/sdk@0.85.0(zod@3.25.63)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -2432,7 +2432,7 @@ snapshots:
 
   '@anthropic-ai/vertex-sdk@0.14.4(zod@3.25.63)':
     dependencies:
-      '@anthropic-ai/sdk': 0.78.0(zod@3.25.63)
+      '@anthropic-ai/sdk': 0.85.0(zod@3.25.63)
       google-auth-library: 10.5.0
     transitivePeerDependencies:
       - supports-color
@@ -4944,7 +4944,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  openai@6.22.0(ws@8.18.2)(zod@3.25.63):
+  openai@6.33.0(ws@8.18.2)(zod@3.25.63):
     optionalDependencies:
       ws: 8.18.2
       zod: 3.25.63


### PR DESCRIPTION
## Summary
- Add `prompt_new`, `prompt_cached`, `prompt_cache_write` fields to `ExecutionTokenUsage`
- Implement prompt caching for Claude (Vertex AI + Bedrock): system prompts, tool definitions, and conversation history
- Add cache metrics to all drivers: OpenAI, Bedrock, Vertex AI Claude, Gemini
- Fix token usage calculation: `prompt` and `total` now include `cache_creation_input_tokens`

## Changes
- **common/types.ts**: Add `prompt_new` field to `ExecutionTokenUsage`
- **drivers/bedrock**: Add `prompt_new` and prompt caching breakpoints for Claude messages
- **drivers/openai**: Add `prompt_new` to token usage mapping
- **drivers/vertexai/claude**: Implement cache control for system blocks and tool definitions, fix `prompt`/`total` calculation to include cached+cache_write tokens
- **drivers/vertexai/gemini**: Add `prompt_new` to token usage mapping
- **drivers/test/conversation**: Add tests for caching metrics

## Test plan
- [x] Existing conversation tests pass
- [x] New caching metrics tests added
- [ ] Manual verification with Claude models on Vertex AI and Bedrock

🤖 Generated with [Claude Code](https://claude.com/claude-code)