### PR TITLE
feat: add cache_enabled / cache_ttl model options for Claude (VertexAI + Bedrock)

### DIFF
--- a/common/src/options/bedrock.ts
+++ b/common/src/options/bedrock.ts
@@ -35,6 +35,8 @@ export interface BedrockClaudeOptions extends BaseConverseOptions {
     thinking_mode?: boolean;
     thinking_budget_tokens?: number;
     include_thoughts?: boolean;
+    cache_enabled?: boolean;
+    cache_ttl?: '5m' | '1h';
 }
 
 export interface BedrockPalmyraOptions extends BaseConverseOptions {
@@ -271,6 +273,23 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
                     description: "Limits token sampling to the top k tokens"
                 },
             ];
+            const claudeCacheOptions: ModelOptionInfoItem[] = [
+                {
+                    name: "cache_enabled",
+                    type: OptionType.boolean,
+                    default: false,
+                    description: "Enable prompt caching. Injects cache breakpoints at the system prompt, tools, and conversation pivot.",
+                },
+            ];
+            const claudeCacheTtlOptions: ModelOptionInfoItem[] = (option as BedrockClaudeOptions)?.cache_enabled ? [
+                {
+                    name: "cache_ttl",
+                    type: OptionType.enum,
+                    enum: { "5 minutes (default)": "5m", "1 hour": "1h" },
+                    default: "5m",
+                    description: "TTL for cache breakpoints. '1h' requires extended caching to be enabled on your account.",
+                }
+            ] : [];
             if (model.includes("-3-7-") || model.includes("-4-")) {
                 const claudeModeOptions: ModelOptionInfoItem[] = [
                     {
@@ -304,12 +323,15 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
                         ...baseConverseOptions,
                         ...claudeConverseOptions,
                         ...claudeModeOptions,
-                        ...claudeThinkingOptions]
+                        ...claudeThinkingOptions,
+                        ...claudeCacheOptions,
+                        ...claudeCacheTtlOptions,
+                    ]
                 }
             }
             return {
                 _option_id: "bedrock-claude",
-                options: [...baseConverseOptions, ...claudeConverseOptions]
+                options: [...baseConverseOptions, ...claudeConverseOptions, ...claudeCacheOptions, ...claudeCacheTtlOptions]
             }
         }
         else if (model.includes("amazon")) {

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -70,6 +70,8 @@ export interface VertexAIClaudeOptions {
     thinking_mode?: boolean;
     thinking_budget_tokens?: number;
     include_thoughts?: boolean;
+    cache_enabled?: boolean;
+    cache_ttl?: '5m' | '1h';
 }
 
 export interface VertexAIGeminiOptions {
@@ -651,6 +653,24 @@ function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInf
         integer: true, step: 200, description: "The maximum number of tokens to generate"
     }];
 
+    const claudeCacheOptions: ModelOptionInfoItem[] = [
+        {
+            name: "cache_enabled",
+            type: OptionType.boolean,
+            default: false,
+            description: "Enable prompt caching. Injects cache breakpoints at the system prompt, tools, and conversation pivot.",
+        },
+    ];
+    const claudeCacheTtlOptions: ModelOptionInfoItem[] = (option as VertexAIClaudeOptions)?.cache_enabled ? [
+        {
+            name: "cache_ttl",
+            type: OptionType.enum,
+            enum: { "5 minutes (default)": "5m", "1 hour": "1h" },
+            default: "5m",
+            description: "TTL for cache breakpoints. '1h' requires extended caching to be enabled on your account.",
+        }
+    ] : [];
+
     if (model.includes("-3-7") || model.includes("-4")) {
         const claudeModeOptions: ModelOptionInfoItem[] = [
             {
@@ -685,6 +705,8 @@ function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInf
                 ...commonOptions,
                 ...claudeModeOptions,
                 ...claudeThinkingOptions,
+                ...claudeCacheOptions,
+                ...claudeCacheTtlOptions,
             ]
         };
     }
@@ -693,6 +715,8 @@ function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInf
         options: [
             ...max_tokens,
             ...commonOptions,
+            ...claudeCacheOptions,
+            ...claudeCacheTtlOptions,
         ]
     };
 }

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -35,6 +35,9 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
         let finish_reason: string | undefined = undefined;
         let promptTokens: number = 0;
         let resultTokens: number | undefined = undefined;
+        let promptCachedTokens: number | undefined = undefined;
+        let promptCacheWriteTokens: number | undefined = undefined;
+        let promptNewTokens: number | undefined = undefined;
 
         try {
             const stream = await this.driver.requestTextCompletionStream(this.prompt, this.options);
@@ -53,6 +56,9 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                             //Math.max used as some models report final token count at beginning of stream
                             promptTokens = Math.max(promptTokens, chunk.token_usage.prompt ?? 0);
                             resultTokens = Math.max(resultTokens ?? 0, chunk.token_usage.result ?? 0);
+                            if (chunk.token_usage.prompt_cached != null) promptCachedTokens = chunk.token_usage.prompt_cached;
+                            if (chunk.token_usage.prompt_cache_write != null) promptCacheWriteTokens = chunk.token_usage.prompt_cache_write;
+                            if (chunk.token_usage.prompt_new != null) promptNewTokens = chunk.token_usage.prompt_new;
                         }
                         // Accumulate tool_use from chunks
                         // Note: During streaming, tool_input comes as string chunks that need concatenation
@@ -165,8 +171,14 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
 
         // Return undefined only if we never received any token data from the provider.
         // Use !== undefined (not truthiness) because resultTokens === 0 is valid (e.g. empty output with stop).
-        const tokens: ExecutionTokenUsage | undefined = resultTokens !== undefined ?
-            { prompt: promptTokens, result: resultTokens, total: resultTokens + promptTokens, } : undefined
+        const tokens: ExecutionTokenUsage | undefined = resultTokens !== undefined ? {
+            prompt: promptTokens,
+            result: resultTokens,
+            total: resultTokens + promptTokens,
+            ...(promptCachedTokens != null && { prompt_cached: promptCachedTokens }),
+            ...(promptCacheWriteTokens != null && { prompt_cache_write: promptCacheWriteTokens }),
+            ...(promptNewTokens != null && { prompt_new: promptNewTokens }),
+        } : undefined
 
         // Convert accumulated tool_use Map to array
         let toolUseArray = accumulatedToolUse.size > 0 ? Array.from(accumulatedToolUse.values()) : undefined;

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1058,20 +1058,20 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
 
             if (request.system && request.system.length > 0) {
-                request.system = [...request.system, { cachePoint: { type: 'default' } } as BedrockSystemBlock];
+                request.system = [...request.system, { cachePoint: { type: 'default', ttl: "1h" } } satisfies BedrockSystemBlock];
             }
 
             if (request.toolConfig?.tools && request.toolConfig.tools.length > 0) {
                 request.toolConfig.tools = [
                     ...request.toolConfig.tools,
-                    { cachePoint: { type: 'default' } } as BedrockToolEntry,
+                    { cachePoint: { type: 'default', ttl: "1h" } } satisfies BedrockToolEntry,
                 ];
             }
 
             if (request.messages && request.messages.length >= 4) {
                 const pivotMsg = request.messages[request.messages.length - 2];
                 if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
-                    pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default' } }];
+                    pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default', ttl: "1h" } }];
                 }
             }
         }

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1046,6 +1046,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         // Prompt caching: use three breakpoints so stable system blocks, tool definitions,
         // and the conversation history prefix can all be reused across Claude turns.
         if (options.model.includes('claude')) {
+            // Always strip stale markers from prior turns
             if (request.messages) {
                 request.messages = stripClaudeCachePoints(request.messages);
             }
@@ -1057,21 +1058,28 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 };
             }
 
-            if (request.system && request.system.length > 0) {
-                request.system = [...request.system, { cachePoint: { type: 'default', ttl: "1h" } } satisfies BedrockSystemBlock];
-            }
+            const claudeOptions = model_options as unknown as BedrockClaudeOptions;
+            const cacheEnabled = claudeOptions?.cache_enabled === true;
+            if (cacheEnabled) {
+                const cacheTtl = claudeOptions?.cache_ttl;
+                const cachePointBlock = { type: 'default' as const, ...(cacheTtl && { ttl: cacheTtl }) };
 
-            if (request.toolConfig?.tools && request.toolConfig.tools.length > 0) {
-                request.toolConfig.tools = [
-                    ...request.toolConfig.tools,
-                    { cachePoint: { type: 'default', ttl: "1h" } } satisfies BedrockToolEntry,
-                ];
-            }
+                if (request.system && request.system.length > 0) {
+                    request.system = [...request.system, { cachePoint: cachePointBlock } satisfies BedrockSystemBlock];
+                }
 
-            if (request.messages && request.messages.length >= 4) {
-                const pivotMsg = request.messages[request.messages.length - 2];
-                if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
-                    pivotMsg.content = [...pivotMsg.content, { cachePoint: { type: 'default', ttl: "1h" } }];
+                if (request.toolConfig?.tools && request.toolConfig.tools.length > 0) {
+                    request.toolConfig.tools = [
+                        ...request.toolConfig.tools,
+                        { cachePoint: cachePointBlock } satisfies BedrockToolEntry,
+                    ];
+                }
+
+                if (request.messages && request.messages.length >= 4) {
+                    const pivotMsg = request.messages[request.messages.length - 2];
+                    if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+                        pivotMsg.content = [...pivotMsg.content, { cachePoint: cachePointBlock }];
+                    }
                 }
             }
         }

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -954,12 +954,12 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
     // and the conversation history prefix can all be reused across calls.
     if (sanitizedSystem && sanitizedSystem.length > 0) {
         const lastSystemBlock = sanitizedSystem[sanitizedSystem.length - 1] as TextBlockParam & { cache_control?: unknown };
-        lastSystemBlock.cache_control = { type: 'ephemeral' };
+        lastSystemBlock.cache_control = { type: 'ephemeral', ttl: "1h" };
     }
 
     if (sanitizedTools && sanitizedTools.length > 0) {
         const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
-        lastTool.cache_control = { type: 'ephemeral' };
+        lastTool.cache_control = { type: 'ephemeral', ttl: "1h" };
     }
 
     if (sanitizedMessages.length >= 4) {
@@ -968,7 +968,7 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
             const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
             if (typeof lastBlock === 'object' && lastBlock !== null &&
                 'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
-                (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral' };
+                (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral', ttl: "1h" };
             }
         }
     }

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -952,23 +952,29 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
 
     // Prompt caching: use three breakpoints so stable system prompt, tool definitions,
     // and the conversation history prefix can all be reused across calls.
-    if (sanitizedSystem && sanitizedSystem.length > 0) {
-        const lastSystemBlock = sanitizedSystem[sanitizedSystem.length - 1] as TextBlockParam & { cache_control?: unknown };
-        lastSystemBlock.cache_control = { type: 'ephemeral', ttl: "1h" };
-    }
+    const cacheEnabled = model_options?.cache_enabled === true;
+    if (cacheEnabled) {
+        const cacheTtl = model_options?.cache_ttl;
+        const cacheControl = { type: 'ephemeral' as const, ...(cacheTtl && { ttl: cacheTtl }) };
 
-    if (sanitizedTools && sanitizedTools.length > 0) {
-        const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
-        lastTool.cache_control = { type: 'ephemeral', ttl: "1h" };
-    }
+        if (sanitizedSystem && sanitizedSystem.length > 0) {
+            const lastSystemBlock = sanitizedSystem[sanitizedSystem.length - 1] as TextBlockParam & { cache_control?: unknown };
+            lastSystemBlock.cache_control = cacheControl;
+        }
 
-    if (sanitizedMessages.length >= 4) {
-        const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
-        if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
-            const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
-            if (typeof lastBlock === 'object' && lastBlock !== null &&
-                'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
-                (lastBlock as TextBlockParam).cache_control = { type: 'ephemeral', ttl: "1h" };
+        if (sanitizedTools && sanitizedTools.length > 0) {
+            const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
+            lastTool.cache_control = cacheControl;
+        }
+
+        if (sanitizedMessages.length >= 4) {
+            const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
+            if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
+                const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];
+                if (typeof lastBlock === 'object' && lastBlock !== null &&
+                    'type' in lastBlock && lastBlock.type !== 'thinking' && lastBlock.type !== 'redacted_thinking') {
+                    (lastBlock as TextBlockParam).cache_control = cacheControl;
+                }
             }
         }
     }

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -15,7 +15,7 @@ import { ContentBlock, ContentBlockParam, DocumentBlockParam, ImageBlockParam, M
 import { MessageStreamParams } from "@anthropic-ai/sdk/resources/index.mjs";
 import { MessageCreateParamsBase, MessageCreateParamsNonStreaming, RawMessageStreamEvent } from "@anthropic-ai/sdk/resources/messages.js";
 import {
-    AIModel, Completion, CompletionChunkObject, ExecutionOptions,
+    AIModel, Completion, CompletionChunkObject, ExecutionOptions, ExecutionTokenUsage,
     getConversationMeta,
     getMaxTokensLimitVertexAi,
     incrementConversationTurn,
@@ -47,6 +47,26 @@ export const NON_GLOBAL_ANTHROPIC_MODELS = [
 interface ClaudePrompt {
     messages: MessageParam[];
     system?: TextBlockParam[];
+}
+
+interface AnthropicUsageLike {
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_input_tokens?: number | null;
+    cache_creation_input_tokens?: number | null;
+}
+
+function anthropicUsageToTokenUsage(usage: AnthropicUsageLike): ExecutionTokenUsage {
+    const cacheRead = usage.cache_read_input_tokens ?? 0;
+    const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    return {
+        prompt_new: usage.input_tokens,
+        prompt: usage.input_tokens + cacheRead + cacheWrite,
+        result: usage.output_tokens,
+        total: usage.input_tokens + usage.output_tokens + cacheRead + cacheWrite,
+        prompt_cached: usage.cache_read_input_tokens ?? undefined,
+        prompt_cache_write: usage.cache_creation_input_tokens ?? undefined,
+    };
 }
 
 function claudeFinishReason(reason: string | undefined) {
@@ -332,14 +352,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         return {
             result: text ? [{ type: "text", value: text }] : [{ type: "text", value: '' }],
             tool_use,
-            token_usage: {
-                prompt_new: result.usage.input_tokens,
-                prompt: result.usage.input_tokens + (result.usage.cache_read_input_tokens ?? 0) + (result.usage.cache_creation_input_tokens ?? 0),
-                result: result.usage.output_tokens,
-                prompt_cached: result.usage.cache_read_input_tokens ?? undefined,
-                prompt_cache_write: result.usage.cache_creation_input_tokens ?? undefined,
-                total: result.usage.input_tokens + result.usage.output_tokens + (result.usage.cache_read_input_tokens ?? 0) + (result.usage.cache_creation_input_tokens ?? 0),
-            },
+            token_usage: anthropicUsageToTokenUsage(result.usage),
             // make sure we set finish_reason to the correct value (claude is normally setting this by itself)
             finish_reason: tool_use ? "tool_use" : claudeFinishReason(result?.stop_reason ?? ''),
             conversation: processedConversation
@@ -381,12 +394,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
                 case "message_start":
                     return {
                         result: [{ type: "text", value: '' }],
-                        token_usage: {
-                            prompt: streamEvent.message.usage.input_tokens,
-                            result: streamEvent.message.usage.output_tokens,
-                            prompt_cached: (streamEvent.message.usage as any).cache_read_input_tokens ?? undefined,
-                            prompt_cache_write: (streamEvent.message.usage as any).cache_creation_input_tokens ?? undefined,
-                        }
+                        token_usage: anthropicUsageToTokenUsage(streamEvent.message.usage as AnthropicUsageLike),
                     } satisfies CompletionChunkObject;
                 case "message_delta":
                     return {

--- a/drivers/test/conversation.test.ts
+++ b/drivers/test/conversation.test.ts
@@ -205,6 +205,20 @@ function getTextOptions(model: string): ExecutionOptions {
     };
 }
 
+/** Returns execution options for a Claude model with prompt caching enabled. */
+function getClaudeOptionsWithCache(model: string, driverName: string): ExecutionOptions {
+    const optionId = driverName.includes('vertexai') ? 'vertexai-claude' : 'bedrock-claude';
+    return {
+        model,
+        model_options: {
+            _option_id: optionId,
+            max_tokens: 256,
+            cache_enabled: true,
+        } as any,
+        output_modality: Modalities.text,
+    };
+}
+
 function buildCacheableContext(): string {
     const repeatedSection = "Prompt caching verification context. Preserve this exact context across turns and do not summarize it unless explicitly asked. ";
     return `You are participating in a prompt caching verification test.\n\n${repeatedSection.repeat(180)}`;
@@ -319,7 +333,7 @@ describe.concurrent.skipIf(!hasDrivers).each(drivers)("Driver $name - Multi-turn
     });
 
     test.skipIf(!name.includes('claude'))(`${name}: multi-turn prompt caching reports token usage`, { timeout: TIMEOUT, retry: 1 }, async () => {
-        const options = getTextOptions(textModel);
+        const options = getClaudeOptionsWithCache(textModel, name);
         const basePrompt = buildCacheableContext();
 
         const turn1 = await driver.execute([


### PR DESCRIPTION
## Summary
- Add `cache_enabled` (boolean, default `false`) and `cache_ttl` (`'5m' | '1h'`, optional) to `VertexAIClaudeOptions` and `BedrockClaudeOptions` interfaces in `@llumiverse/common`
- Prompt caching is now **opt-in** at the driver level; all three cache breakpoints (system prompt, tool definitions, message pivot) are injected only when `cache_enabled === true`
- TTL is forwarded to the `cache_control` object (VertexAI) and `cachePoint` block (Bedrock) when set; omitting it uses the API default (5 min)
- Strip step remains unconditional so stale cache markers from prior turns are always cleaned
- Add `cache_enabled` toggle + conditional `cache_ttl` enum to the UI schema for both drivers (both thinking and non-thinking model paths)
- Fix integration test: `conversation.test.ts` cache test now uses `getClaudeOptionsWithCache()` which passes the correct driver-specific `_option_id` and `cache_enabled: true`

## Test Plan
- [ ] Direct call without `cache_enabled`: no cache markers sent, `prompt_cached = 0`
- [ ] Direct call with `cache_enabled: true`: markers present, `prompt_cached > 0` on turn 2+
- [ ] `cache_ttl: '1h'` propagates to `cache_control.ttl` / `cachePoint.ttl` in the request
- [ ] Run `pnpm test -- conversation.test.ts` — Claude cache test passes with `cache_enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>