### PR TITLE
fix: normalize prompt_new cache semantics

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -665,8 +665,8 @@ export interface ExecutionTokenUsage {
      */
     prompt_cache_write?: number;
 
-    /* Number of new input tokens not from cache. This is useful for providers with prompt caching to understand how many tokens were actually newly processed in the prompt, separate from any cached tokens. Calculated as prompt - prompt_cached. */
-    prompt_new?: number; // Number of new input tokens not from cache (calculated as prompt - prompt_cached)
+    /* Number of input tokens not served from cache reads. This is useful for providers with prompt caching to understand how many input tokens were newly processed for the call. Calculated as prompt - prompt_cached, so it may include tokens written to cache. */
+    prompt_new?: number; // Number of input tokens not served from cache reads (calculated as prompt - prompt_cached)
 }
 
 /**

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -376,11 +376,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         const completionResult: CompletionChunkObject = {
             result: reasoning + resultText ? [{ type: "text", value: reasoning + resultText }] : [],
             token_usage: {
-                // Bedrock's inputTokens already excludes cache-read tokens,
-                // so prompt_new is inputTokens directly (no subtraction needed).
-                // prompt is the total including cached + cache_write for consistency
-                // with the Vertex Claude driver.
-                prompt_new: result.usage?.inputTokens,
+                // Normalize prompt_new to prompt - prompt_cached so it matches the
+                // shared ExecutionTokenUsage contract across providers.
+                prompt_new: result.usage ? (result.usage.inputTokens ?? 0) + (result.usage.cacheWriteInputTokens ?? 0) : undefined,
                 prompt: result.usage ? (result.usage.inputTokens ?? 0) + (result.usage.cacheReadInputTokens ?? 0) + (result.usage.cacheWriteInputTokens ?? 0) : undefined,
                 result: result.usage?.outputTokens,
                 total: result.usage?.totalTokens,
@@ -474,7 +472,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         if (result.metadata) {
             token_usage = {
-                prompt_new: result.metadata.usage?.inputTokens,
+                prompt_new: result.metadata.usage ? (result.metadata.usage.inputTokens ?? 0) + (result.metadata.usage.cacheWriteInputTokens ?? 0) : undefined,
                 prompt: result.metadata.usage ? (result.metadata.usage.inputTokens ?? 0) + (result.metadata.usage.cacheReadInputTokens ?? 0) + (result.metadata.usage.cacheWriteInputTokens ?? 0) : undefined,
                 result: result.metadata.usage?.outputTokens,
                 total: result.metadata.usage?.totalTokens,

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -59,11 +59,12 @@ interface AnthropicUsageLike {
 function anthropicUsageToTokenUsage(usage: AnthropicUsageLike): ExecutionTokenUsage {
     const cacheRead = usage.cache_read_input_tokens ?? 0;
     const cacheWrite = usage.cache_creation_input_tokens ?? 0;
+    const prompt = usage.input_tokens + cacheRead + cacheWrite;
     return {
-        prompt_new: usage.input_tokens,
-        prompt: usage.input_tokens + cacheRead + cacheWrite,
+        prompt_new: prompt - cacheRead,
+        prompt,
         result: usage.output_tokens,
-        total: usage.input_tokens + usage.output_tokens + cacheRead + cacheWrite,
+        total: prompt + usage.output_tokens,
         prompt_cached: usage.cache_read_input_tokens ?? undefined,
         prompt_cache_write: usage.cache_creation_input_tokens ?? undefined,
     };


### PR DESCRIPTION
## Summary
- update the shared token usage contract so `prompt_new` consistently means `prompt - prompt_cached`
- normalize Vertex Claude and Bedrock token usage mappings to match that shared contract

## Test Plan
- [ ] Not run in this environment