### PR TITLE
feat: add effort support for reasoning models

### DIFF
--- a/common/src/options/bedrock.ts
+++ b/common/src/options/bedrock.ts
@@ -1,4 +1,4 @@
-import { ModelOptionsInfo, ModelOptions, OptionType, ModelOptionInfoItem } from "../types.js";
+import { ModelOptionsInfo, ModelOptions, OptionType, ModelOptionInfoItem, ReasoningEffort, SharedOptions } from "../types.js";
 import { getMaxOutputTokens } from "./context-windows.js";
 import { textOptionsFallback } from "./fallback.js";
 
@@ -32,6 +32,7 @@ export interface BaseConverseOptions {
 export interface BedrockClaudeOptions extends BaseConverseOptions {
     _option_id: "bedrock-claude";
     top_k?: number;
+    effort?: ReasoningEffort;
     thinking_mode?: boolean;
     thinking_budget_tokens?: number;
     include_thoughts?: boolean;
@@ -293,29 +294,20 @@ export function getBedrockOptions(model: string, option?: ModelOptions): ModelOp
             if (model.includes("-3-7-") || model.includes("-4-")) {
                 const claudeModeOptions: ModelOptionInfoItem[] = [
                     {
-                        name: "thinking_mode",
-                        type: OptionType.boolean,
-                        default: false,
-                        description: "If true, use the extended reasoning mode"
+                        name: SharedOptions.effort,
+                        type: OptionType.enum,
+                        enum: { "Low": "low", "Medium": "medium", "High": "high" },
+                        description: "Controls Claude extended thinking effort. Clear this to leave extended thinking disabled."
                     },
                 ];
-                const claudeThinkingOptions: ModelOptionInfoItem[] = (option as BedrockClaudeOptions)?.thinking_mode ? [
-                    {
-                        name: "thinking_budget_tokens",
-                        type: OptionType.numeric,
-                        min: 1024,
-                        default: 1024,
-                        integer: true,
-                        step: 100,
-                        description: "The target number of tokens to use for reasoning, not a hard limit."
-                    },
+                const claudeThinkingOptions: ModelOptionInfoItem[] = [
                     {
                         name: "include_thoughts",
                         type: OptionType.boolean,
                         default: false,
                         description: "If true, include the reasoning in the response"
                     },
-                ] : [];
+                ];
 
                 return {
                     _option_id: "bedrock-claude",

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -1,4 +1,4 @@
-import { ModelOptionInfoItem, ModelOptions, ModelOptionsInfo, OptionType, SharedOptions } from "../types.js";
+import { ModelOptionInfoItem, ModelOptions, ModelOptionsInfo, OptionType, ReasoningEffort, SharedOptions } from "../types.js";
 import { textOptionsFallback } from "./fallback.js";
 
 // Union type of all OpenAI options
@@ -8,7 +8,8 @@ export interface OpenAiThinkingOptions {
     _option_id: "openai-thinking",
     max_tokens?: number,
     stop_sequence?: string[],
-    reasoning_effort?: "low" | "medium" | "high",
+    effort?: ReasoningEffort,
+    reasoning_effort?: ReasoningEffort,
     image_detail?: "low" | "high" | "auto",
 }
 
@@ -150,7 +151,7 @@ export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOp
         };
     }
 
-    if (model.includes("o1") || model.includes("o3")) {
+    if (isReasoningModel(model)) {
         //Is thinking text model
         let max_tokens_limit = 4096;
         if (model.includes("o1")) {
@@ -167,6 +168,9 @@ export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOp
         else if (model.includes("o3")) {
             max_tokens_limit = 100000;
         }
+        else if (model.includes("o4") || model.includes("gpt-5")) {
+            max_tokens_limit = 128000;
+        }
 
         const commonOptions: ModelOptionInfoItem[] = [
             {
@@ -179,9 +183,14 @@ export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOp
             },
         ];
 
-        const reasoningOptions: ModelOptionInfoItem[] = model.includes("o3") || isO1Full(model) ? [
+        const reasoningOptions: ModelOptionInfoItem[] = isGpt5ProModel(model) ? [
             {
-                name: "reasoning_effort", type: OptionType.enum, enum: { "Low": "low", "Medium": "medium", "High": "high" },
+                name: SharedOptions.effort, type: OptionType.enum, enum: { "High": "high" },
+                default: "high", description: "GPT-5 Pro only supports high reasoning effort."
+            },
+        ] : model.includes("o3") || model.includes("o4") || model.includes("gpt-5") || isO1Full(model) ? [
+            {
+                name: SharedOptions.effort, type: OptionType.enum, enum: { "Low": "low", "Medium": "medium", "High": "high" },
                 default: "medium", description: "How much effort the model should put into reasoning, lower values result in faster responses and less tokens used."
             },
         ] : [];
@@ -263,6 +272,19 @@ function isO1Full(model: string): boolean {
         return true;
     }
     return false;
+}
+
+function isReasoningModel(model: string): boolean {
+    const normalized = model.toLowerCase();
+    return normalized.includes("o1")
+        || normalized.includes("o3")
+        || normalized.includes("o4")
+        || normalized.includes("gpt-5");
+}
+
+function isGpt5ProModel(model: string): boolean {
+    const modelName = model.toLowerCase().split('/').pop() ?? model.toLowerCase();
+    return /^gpt-5(?:\.\d+)?-pro/.test(modelName);
 }
 
 function isVisionModel(model: string): boolean {

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -1,4 +1,4 @@
-import { ModelOptionInfoItem, ModelOptions, ModelOptionsInfo, OptionType, SharedOptions } from "../types.js";
+import { ModelOptionInfoItem, ModelOptions, ModelOptionsInfo, OptionType, ReasoningEffort, SharedOptions } from "../types.js";
 import { getMaxOutputTokens } from "./context-windows.js";
 import { textOptionsFallback } from "./fallback.js";
 
@@ -67,6 +67,7 @@ export interface VertexAIClaudeOptions {
     top_p?: number;
     top_k?: number;
     stop_sequence?: string[];
+    effort?: ReasoningEffort;
     thinking_mode?: boolean;
     thinking_budget_tokens?: number;
     include_thoughts?: boolean;
@@ -84,6 +85,7 @@ export interface VertexAIGeminiOptions {
     presence_penalty?: number;
     frequency_penalty?: number;
     seed?: number;
+    effort?: ReasoningEffort;
     include_thoughts?: boolean;
     thinking_budget_tokens?: number;
     thinking_level?: ThinkingLevel;
@@ -169,95 +171,6 @@ export function isGeminiModelVersionGte(modelId: string, minVersion: string): bo
     }
 
     return current.minor >= target.minor;
-}
-
-function getGeminiThinkingLevels(model: string): {
-    levels: Record<string, ThinkingLevel>;
-    defaultLevel: ThinkingLevel;
-} {
-    const normalized = model.toLowerCase();
-    const isGemini3OrLater = isGeminiModelVersionGte(model, "3.0");
-    const isGemini31OrLater = isGeminiModelVersionGte(model, "3.1");
-    const isFlashLite = normalized.includes("flash-lite");
-    const isFlash = normalized.includes("flash") && !isFlashLite;
-    const isPro = normalized.includes("pro");
-
-    // Gemini 3 / 3.1 thinking_level support summary:
-    // - MINIMAL: Gemini 3 Flash and Gemini 3.1 Flash-Lite only.
-    //   Gemini 3.1 Flash-Lite defaults to MINIMAL.
-    // - LOW: Supported by Gemini 3+ models.
-    // - MEDIUM: Gemini 3 Flash, Gemini 3.1 Pro, Gemini 3.1 Flash-Lite.
-    // - HIGH: Supported by Gemini 3+ models.
-    // - Thinking cannot be turned off for Gemini 3 Pro and Gemini 3.1 Pro.
-    if (isFlashLite && isGemini31OrLater) {
-        return {
-            levels: {
-                "Minimal": ThinkingLevel.MINIMAL,
-                "Low": ThinkingLevel.LOW,
-                "Medium": ThinkingLevel.MEDIUM,
-                "High": ThinkingLevel.HIGH,
-            },
-            defaultLevel: ThinkingLevel.MINIMAL,
-        };
-    }
-
-    // Gemini 3+ Flash supports MINIMAL and MEDIUM in addition to LOW/HIGH.
-    if (isFlash) {
-        return {
-            levels: {
-                "Minimal": ThinkingLevel.MINIMAL,
-                "Low": ThinkingLevel.LOW,
-                "Medium": ThinkingLevel.MEDIUM,
-                "High": ThinkingLevel.HIGH,
-            },
-            defaultLevel: ThinkingLevel.MINIMAL,
-        };
-    }
-
-    // Gemini 3.1 Pro adds MEDIUM, but does not support turning thinking off.
-    if (isPro && isGemini31OrLater) {
-        return {
-            levels: {
-                "Low": ThinkingLevel.LOW,
-                "Medium": ThinkingLevel.MEDIUM,
-                "High": ThinkingLevel.HIGH,
-            },
-            defaultLevel: ThinkingLevel.LOW,
-        };
-    }
-
-    // Gemini 3 Pro supports LOW/HIGH. Thinking cannot be turned off.
-    if (isPro) {
-        return {
-            levels: {
-                "Low": ThinkingLevel.LOW,
-                "High": ThinkingLevel.HIGH,
-            },
-            defaultLevel: ThinkingLevel.LOW,
-        };
-    }
-
-    // Fallback for unknown Gemini 3+/4+ families:
-    // prefer future-safe propagation by enabling the guaranteed baseline levels.
-    if (isGemini3OrLater) {
-        return {
-            levels: {
-                "Low": ThinkingLevel.LOW,
-                "Medium": ThinkingLevel.MEDIUM,
-                "High": ThinkingLevel.HIGH,
-            },
-            defaultLevel: ThinkingLevel.LOW,
-        };
-    }
-
-    // Non-3.x models should not reach this helper in normal flow.
-    return {
-        levels: {
-            "Low": ThinkingLevel.LOW,
-            "High": ThinkingLevel.HIGH,
-        },
-        defaultLevel: ThinkingLevel.LOW,
-    };
 }
 
 function getImagenOptions(model: string, option?: ModelOptions): ModelOptionsInfo {
@@ -414,8 +327,17 @@ function getImagenOptions(model: string, option?: ModelOptions): ModelOptionsInf
     return textOptionsFallback;
 }
 
+function getGeminiEffortOptions(model: string): Record<string, string> {
+    if (model.includes("gemini-3-pro-image")) {
+        return { "High": "high" };
+    }
+    if (model.includes("gemini-3.1-flash-image")) {
+        return { "Low": "low", "High": "high" };
+    }
+    return { "Low": "low", "Medium": "medium", "High": "high" };
+}
+
 function getGeminiThinkingOptionItems(model: string): ModelOptionInfoItem[] {
-    const thinkingLevelConfig = getGeminiThinkingLevels(model);
     return [
         {
             name: "include_thoughts",
@@ -424,10 +346,9 @@ function getGeminiThinkingOptionItems(model: string): ModelOptionInfoItem[] {
             description: "Include the model's reasoning process in the response"
         },
         {
-            name: "thinking_level",
+            name: SharedOptions.effort,
             type: OptionType.enum,
-            enum: thinkingLevelConfig.levels,
-            default: thinkingLevelConfig.defaultLevel,
+            enum: getGeminiEffortOptions(model),
             description: "Higher thinking levels may improve quality, but increase response times and token costs"
         }
     ];
@@ -696,29 +617,20 @@ function getClaudeOptions(model: string, option?: ModelOptions): ModelOptionsInf
     if (model.includes("-3-7") || model.includes("-4")) {
         const claudeModeOptions: ModelOptionInfoItem[] = [
             {
-                name: "thinking_mode",
-                type: OptionType.boolean,
-                default: false,
-                description: "If true, use the extended reasoning mode"
+                name: SharedOptions.effort,
+                type: OptionType.enum,
+                enum: { "Low": "low", "Medium": "medium", "High": "high" },
+                description: "Controls Claude extended thinking effort. Clear this to leave extended thinking disabled."
             },
         ];
-        const claudeThinkingOptions: ModelOptionInfoItem[] = (option as VertexAIClaudeOptions)?.thinking_mode ? [
-            {
-                name: "thinking_budget_tokens",
-                type: OptionType.numeric,
-                min: 1024,
-                default: 1024,
-                integer: true,
-                step: 100,
-                description: "The target number of tokens to use for reasoning, not a hard limit."
-            },
+        const claudeThinkingOptions: ModelOptionInfoItem[] = [
             {
                 name: "include_thoughts",
                 type: OptionType.boolean,
                 default: false,
                 description: "Include the model's reasoning process in the response"
             }
-        ] : [];
+        ];
 
         return {
             _option_id: "vertexai-claude",

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -559,6 +559,7 @@ export enum SharedOptions {
     presence_penalty = "presence_penalty",
     frequency_penalty = "frequency_penalty",
     stop_sequence = "stop_sequence",
+    effort = "effort",
 
     //Image
     seed = "seed",
@@ -571,6 +572,8 @@ export enum OptionType {
     boolean = "boolean",
     string_list = "string_list"
 }
+
+export type ReasoningEffort = "low" | "medium" | "high";
 
 // ============== Model Options ===============
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -107,6 +107,19 @@ function maxTokenFallbackClaude(option: StatelessExecutionOptions): number {
     }
 }
 
+function claudeThinkingBudgetForEffort(effort: BedrockClaudeOptions["effort"]): number | undefined {
+    switch (effort) {
+        case "low":
+            return 1024;
+        case "medium":
+            return 8192;
+        case "high":
+            return 32000;
+        default:
+            return undefined;
+    }
+}
+
 /**
  * Parse Claude model version from model string.
  * @param modelString - The model identifier string
@@ -882,7 +895,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         } else if (options.model.includes("claude")) {
             const claude_options = model_options as ModelOptions as BedrockClaudeOptions;
-            const thinking = claude_options.thinking_mode ?? false;
+            const effortBudget = claudeThinkingBudgetForEffort(claude_options.effort);
+            const thinking = claude_options.thinking_mode === true || effortBudget !== undefined;
+            const thinkingBudget = claude_options.thinking_budget_tokens ?? effortBudget ?? 1024;
             supportsJSONPrefill = !thinking
 
             if (options.model.includes("claude-3-7") || options.model.includes("-4-")) {
@@ -890,11 +905,11 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     ...additionalField,
                     reasoning_config: {
                         type: thinking ? "enabled" : "disabled",
-                        budget_tokens: thinking ? (claude_options.thinking_budget_tokens ?? 1024) : undefined,
+                        budget_tokens: thinking ? thinkingBudget : undefined,
                     }
                 };
                 if (thinking && options.model.includes("claude-3-7-sonnet") &&
-                    ((claude_options.max_tokens ?? 0) > 64000 || (claude_options.thinking_budget_tokens ?? 0) > 64000)) {
+                    ((claude_options.max_tokens ?? 0) > 64000 || thinkingBudget > 64000)) {
                     additionalField = {
                         ...additionalField,
                         anthropic_beta: ["output-128k-2025-02-19"]

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -61,6 +61,29 @@ function textToCompletionResult(text: string): CompletionResult[] {
     return text ? [{ type: "text", value: text }] : [];
 }
 
+function isOpenAIReasoningModel(model: string): boolean {
+    const normalized = model.toLowerCase();
+    return normalized.includes("o1")
+        || normalized.includes("o3")
+        || normalized.includes("o4")
+        || normalized.includes("gpt-5");
+}
+
+function isGpt5ProModel(model: string): boolean {
+    const modelName = model.toLowerCase().split('/').pop() ?? model.toLowerCase();
+    return /^gpt-5(?:\.\d+)?-pro/.test(modelName);
+}
+
+function openAIReasoningEffort(model: string, effort: string | undefined): "low" | "medium" | "high" | undefined {
+    if (!effort || !isOpenAIReasoningModel(model)) {
+        return undefined;
+    }
+    if (isGpt5ProModel(model)) {
+        return "high";
+    }
+    return effort === "low" || effort === "medium" || effort === "high" ? effort : undefined;
+}
+
 //TODO: Do we need a list?, replace with if statements and modernize?
 const supportFineTunning = new Set([
     "gpt-3.5-turbo-1106",
@@ -144,8 +167,9 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             }
         }
 
-        const reasoning = model_options?.reasoning_effort ? { effort: model_options.reasoning_effort } : undefined;
-        const isReasoningModel = /\b(o1|o3|o4)\b/.test(options.model);
+        const isReasoningModel = isOpenAIReasoningModel(options.model);
+        const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
+        const reasoning = effort ? { effort } : undefined;
 
         const stream = await this.service.responses.create({
             stream: true,
@@ -204,8 +228,9 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             }
         }
 
-        const reasoning = model_options?.reasoning_effort ? { effort: model_options.reasoning_effort } : undefined;
-        const isReasoningModel = /\b(o1|o3|o4)\b/.test(options.model);
+        const isReasoningModel = isOpenAIReasoningModel(options.model);
+        const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
+        const reasoning = effort ? { effort } : undefined;
 
         const res = await this.service.responses.create({
             stream: false,

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -136,6 +136,19 @@ function maxToken(option: StatelessExecutionOptions): number {
     }
 }
 
+function claudeThinkingBudgetForEffort(effort: VertexAIClaudeOptions["effort"]): number | undefined {
+    switch (effort) {
+        case "low":
+            return 1024;
+        case "medium":
+            return 8192;
+        case "high":
+            return 32000;
+        default:
+            return undefined;
+    }
+}
+
 // Type-safe overloads for collectFileBlocks
 async function collectFileBlocks(segment: PromptSegment, restrictedTypes: true): Promise<Array<TextBlockParam | ImageBlockParam>>;
 async function collectFileBlocks(segment: PromptSegment, restrictedTypes?: false): Promise<ContentBlockParam[]>;
@@ -979,6 +992,10 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
         }
     }
 
+    const effortBudget = claudeThinkingBudgetForEffort(model_options?.effort);
+    const thinkingEnabled = model_options?.thinking_mode === true || effortBudget !== undefined;
+    const thinkingBudget = model_options?.thinking_budget_tokens ?? effortBudget ?? 1024;
+
     const payload = {
         messages: sanitizedMessages,
         system: sanitizedSystem,
@@ -989,9 +1006,9 @@ function getClaudePayload(options: ExecutionOptions, prompt: ClaudePrompt): { pa
         top_p: model_options?.temperature != null ? undefined : model_options?.top_p,
         top_k: model_options?.top_k,
         stop_sequences: model_options?.stop_sequence,
-        thinking: model_options?.thinking_mode ?
+        thinking: thinkingEnabled ?
             {
-                budget_tokens: model_options?.thinking_budget_tokens ?? 1024,
+                budget_tokens: thinkingBudget,
                 type: "enabled" as const
             } : {
                 type: "disabled" as const

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -243,8 +243,11 @@ const recoverableToolCallReasons = [
 function geminiThinkingBudget(option: StatelessExecutionOptions) {
     const model_options = option.model_options as VertexAIGeminiOptions | undefined;
     // If thinking_budget_tokens is explicitly set in model options, use it directly
-    if (model_options?.thinking_budget_tokens) {
+    if (model_options?.thinking_budget_tokens !== undefined) {
         return model_options.thinking_budget_tokens;
+    }
+    if (model_options?.effort) {
+        return geminiBudgetForEffort(option.model, model_options.effort);
     }
     // Set minimum thinking level by default.
     // Docs: https://ai.google.dev/gemini-api/docs/thinking#set-budget
@@ -257,16 +260,66 @@ function geminiThinkingBudget(option: StatelessExecutionOptions) {
     return undefined;
 }
 
+function geminiThinkingLevelForEffort(model: string, effort: VertexAIGeminiOptions["effort"]): ThinkingLevel | undefined {
+    if (model.includes("gemini-3-pro-image")) {
+        return ThinkingLevel.HIGH;
+    }
+    if (model.includes("gemini-3.1-flash-image")) {
+        return effort === "low" ? ThinkingLevel.MINIMAL : ThinkingLevel.HIGH;
+    }
+    switch (effort) {
+        case "low":
+            return ThinkingLevel.LOW;
+        case "medium":
+            return ThinkingLevel.MEDIUM;
+        case "high":
+            return ThinkingLevel.HIGH;
+        default:
+            return undefined;
+    }
+}
+
+function geminiBudgetForEffort(model: string, effort: NonNullable<VertexAIGeminiOptions["effort"]>): number {
+    const isFlashLite = model.includes("flash-lite");
+    const isFlash = model.includes("flash") && !isFlashLite;
+    const isPro = model.includes("pro");
+
+    if (effort === "low") {
+        if (isPro) return 128;
+        if (isFlashLite) return 512;
+        if (isFlash) return 1;
+        return 1024;
+    }
+    if (effort === "medium") {
+        return 8192;
+    }
+    if (isPro) return 32768;
+    if (isFlash || isFlashLite) return 24576;
+    return 8192;
+}
+
 function geminiThinkingConfig(option: StatelessExecutionOptions): ThinkingConfig | undefined {
     const model_options = option.model_options as VertexAIGeminiOptions | undefined;
 
     // If thinking options are explicitly set in model options, use them directly
     const include_thoughts = model_options?.include_thoughts ?? false;
-    if (model_options?.thinking_budget_tokens || model_options?.thinking_level) {
+    if (model_options?.thinking_budget_tokens !== undefined || model_options?.thinking_level) {
         return {
             includeThoughts: include_thoughts,
             thinkingBudget: model_options.thinking_budget_tokens,
             thinkingLevel: model_options.thinking_level,
+        };
+    }
+    if (model_options?.effort) {
+        if (isGeminiModelVersionGte(option.model, '3.0')) {
+            return {
+                includeThoughts: include_thoughts,
+                thinkingLevel: geminiThinkingLevelForEffort(option.model, model_options.effort),
+            };
+        }
+        return {
+            includeThoughts: include_thoughts,
+            thinkingBudget: geminiBudgetForEffort(option.model, model_options.effort),
         };
     }
 
@@ -274,16 +327,9 @@ function geminiThinkingConfig(option: StatelessExecutionOptions): ThinkingConfig
     // Docs: https://ai.google.dev/gemini-api/docs/thinking#set-budget
     // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thinking
     if (isGeminiModelVersionGte(option.model, '3.0')) {
-        if (option.model.includes("gemini-3-pro-image")) {
-            // Does not support thinking level.
-            return {
-                includeThoughts: include_thoughts,
-                thinkingBudget: -1
-            };
-        }
         return {
             includeThoughts: include_thoughts,
-            thinkingLevel: ThinkingLevel.LOW
+            thinkingLevel: option.model.includes("gemini-3-pro-image") ? ThinkingLevel.HIGH : ThinkingLevel.LOW
         };
     }
     if (isGeminiModelVersionGte(option.model, '2.5')) {


### PR DESCRIPTION
## Summary
- Add shared effort model option for reasoning-capable OpenAI, Claude, and Gemini models.
- Map our low/medium/high effort values to provider-native OpenAI reasoning effort, Claude thinking budgets, and Gemini thinking budgets or levels.
- Preserve legacy provider-specific options where already supported.

## Verification
- PASS: git diff --check
- BLOCKED: pnpm --dir composableai/llumiverse --filter @llumiverse/common --filter @llumiverse/drivers build (node_modules missing; tsmod not found)

## Notes
- Base branch: preview