### PR TITLE
fix(common): stabilize JSON schema properties type

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -466,10 +466,14 @@ export interface JSONSchemaObject {
 
 export interface JSONSchemaArray extends Array<JSONSchemaType> { }
 
+export interface JSONSchemaProperties {
+    [key: string]: JSONSchema;
+}
+
 export interface JSONSchema {
     type?: JSONSchemaTypeName | JSONSchemaTypeName[];
     description?: string;
-    properties?: Record<string, JSONSchema>;
+    properties?: JSONSchemaProperties;
     required?: string[];
     [k: string]: any;
 }


### PR DESCRIPTION
Stabilizes the OpenAPI schema generated for JSONSchema.properties by replacing the anonymous Record<string, JSONSchema> type with a named JSONSchemaProperties interface. This avoids platform-dependent component names in generated specs.