### PR TITLE
fix: Invalid model options, change to debug and clearer message

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1082,7 +1082,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
     async requestImageGeneration(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "bedrock-nova-canvas") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         const model_options = options.model_options as NovaCanvasOptions;
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1081,7 +1081,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     }
 
     async requestImageGeneration(prompt: NovaMessagesPrompt, options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "bedrock-nova-canvas") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "bedrock-nova-canvas") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         const model_options = options.model_options as NovaCanvasOptions;

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -106,7 +106,9 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
     }
 
     async requestTextCompletion(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "text-fallback" && options.model_options?._option_id !== "groq-deepseek-thinking") {
+        if (options.model_options?._option_id !== undefined &&
+            options.model_options?._option_id !== "text-fallback" &&
+            options.model_options?._option_id !== "groq-deepseek-thinking") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
@@ -162,7 +164,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
     }
 
     async requestTextCompletionStream(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -1,11 +1,10 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions, ToolDefinition, ToolUse } from "@llumiverse/core";
+import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions, ToolDefinition, ToolUse } from "@llumiverse/core";
 import { transformAsyncIterator } from "@llumiverse/core/async";
-import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
-
 import Groq from "groq-sdk";
-import type OpenAI from "openai";
 import type { ChatCompletionMessageParam, ChatCompletionTool } from "groq-sdk/resources/chat/completions";
 import type { FunctionParameters } from "groq-sdk/resources/shared";
+import type OpenAI from "openai";
+import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
@@ -108,7 +107,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
 
     async requestTextCompletion(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback" && options.model_options?._option_id !== "groq-deepseek-thinking") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -164,7 +163,7 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
 
     async requestTextCompletionStream(messages: ChatCompletionMessageParam[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -68,7 +68,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     }
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions) {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
@@ -100,7 +100,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     }
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions) {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -3,9 +3,9 @@ import {
     TextGenerationStreamOutput,
 } from "@huggingface/inference";
 import {
+    AbstractDriver,
     AIModel,
     AIModelStatus,
-    AbstractDriver,
     CompletionChunkObject,
     DriverOptions,
     EmbeddingsResult,
@@ -69,7 +69,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions) {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -101,7 +101,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions) {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -63,7 +63,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
     }
 
     async requestTextCompletion(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
@@ -97,7 +97,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
     }
 
     async requestTextCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,8 +1,8 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions } from "@llumiverse/core";
+import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, PromptSegment, TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { getJSONSafetyNotice } from "@llumiverse/core/formatters";
-import { formatOpenAILikeTextPrompt, OpenAITextMessage } from "../openai/openai_format.js";
 import { FetchClient } from "@vertesia/api-fetch-client";
+import { formatOpenAILikeTextPrompt, OpenAITextMessage } from "../openai/openai_format.js";
 import { ChatCompletionResponse, CompletionRequestParams, ListModelsResponse, ResponseFormat } from "./types.js";
 
 //TODO retry on 429
@@ -64,7 +64,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
 
     async requestTextCompletion(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -98,7 +98,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
 
     async requestTextCompletionStream(messages: OpenAITextMessage[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -132,8 +132,9 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     }
 
     async requestTextCompletionStream(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "openai-text" && 
-            options.model_options?._option_id !== "openai-thinking" && 
+        if (options.model_options?._option_id !== undefined &&
+            options.model_options?._option_id !== "openai-text" &&
+            options.model_options?._option_id !== "openai-thinking" &&
             options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
@@ -196,7 +197,9 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     }
 
     async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "openai-text" && options.model_options?._option_id !== "openai-thinking") {
+        if (options.model_options?._option_id !== undefined &&
+            options.model_options?._option_id !== "openai-text" &&
+            options.model_options?._option_id !== "openai-thinking") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1,6 +1,6 @@
 import {
-    AIModel,
     AbstractDriver,
+    AIModel,
     Completion,
     CompletionChunkObject,
     CompletionResult,
@@ -10,26 +10,26 @@ import {
     EmbeddingsResult,
     ExecutionOptions,
     ExecutionTokenUsage,
+    getConversationMeta,
+    getModelCapabilities,
+    incrementConversationTurn,
     JSONSchema,
     LlumiverseError,
     LlumiverseErrorContext,
+    modelModalitiesToArray,
     ModelType,
     OpenAiDalleOptions,
     OpenAiGptImageOptions,
     Providers,
+    stripBase64ImagesFromConversation,
+    stripHeartbeatsFromConversation,
+    supportsToolUse,
     ToolDefinition,
     ToolUse,
     TrainingJob,
     TrainingJobStatus,
     TrainingOptions,
     TrainingPromptOptions,
-    getConversationMeta,
-    getModelCapabilities,
-    incrementConversationTurn,
-    modelModalitiesToArray,
-    stripBase64ImagesFromConversation,
-    stripHeartbeatsFromConversation,
-    supportsToolUse,
     truncateLargeTextInConversation,
     unwrapConversationArray,
 } from "@llumiverse/core";
@@ -132,8 +132,10 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     }
 
     async requestTextCompletionStream(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "openai-text" && options.model_options?._option_id !== "openai-thinking") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+        if (options.model_options?._option_id !== "openai-text" && 
+            options.model_options?._option_id !== "openai-thinking" && 
+            options.model_options?._option_id !== "text-fallback") {
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
 
         // Include conversation history (same as non-streaming)
@@ -195,7 +197,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
 
     async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "openai-text" && options.model_options?._option_id !== "openai-thinking") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
 
         convertRoles(prompt, options.model);

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -1,6 +1,6 @@
 import {
-    AIModel,
     AbstractDriver,
+    AIModel,
     Completion,
     CompletionChunkObject,
     DataSource,
@@ -66,7 +66,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -111,7 +111,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions) {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
         const model = ReplicateDriver.parseModelId(options.model);

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -65,7 +65,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
     }
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
@@ -110,7 +110,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
     }
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions) {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -30,7 +30,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
     }
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
@@ -72,7 +72,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
     }
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
+import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DriverOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { FetchClient } from "@vertesia/api-fetch-client";
 import { TextCompletion, TogetherModelInfo } from "./interfaces.js";
@@ -31,7 +31,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 
@@ -73,7 +73,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions;
 

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -316,8 +316,10 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         const client = await driver.getAnthropicClient(region);
         options.model_options = options.model_options as VertexAIClaudeOptions;
 
-        if (options.model_options?._option_id !== "vertexai-claude") {
-            driver.logger.warn({ options: options.model_options }, "Invalid model options");
+        if (options.model_options?._option_id !== "vertexai-claude" &&
+            options.model_options?._option_id !== "text-fallback"
+        ) {
+            driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
 
         let conversation = updateConversation(options.conversation as ClaudePrompt, prompt);
@@ -372,8 +374,10 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         const client = await driver.getAnthropicClient(region);
         const model_options = options.model_options as VertexAIClaudeOptions | undefined;
 
-        if (model_options?._option_id !== "vertexai-claude") {
-            driver.logger.warn({ options: options.model_options }, "Invalid model options");
+        if (model_options?._option_id !== "vertexai-claude" &&
+            model_options?._option_id !== "text-fallback"
+        ) {
+            driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
 
         // Include conversation history (same as non-streaming)

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -314,10 +314,11 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         options = { ...options, model: modelName };
 
         const client = await driver.getAnthropicClient(region);
-        options.model_options = options.model_options as VertexAIClaudeOptions;
+        const model_options = options.model_options as VertexAIClaudeOptions | undefined;
 
-        if (options.model_options?._option_id !== "vertexai-claude" &&
-            options.model_options?._option_id !== "text-fallback"
+        if (model_options?._option_id !== undefined &&
+            model_options?._option_id !== "vertexai-claude" &&
+            model_options?._option_id !== "text-fallback"
         ) {
             driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
@@ -331,7 +332,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         const result = await client.messages.create(nonStreamingPayload, requestOptions) satisfies Message;
 
         // Use the new function to collect text content, including thinking if enabled
-        const includeThoughts = options.model_options?.include_thoughts ?? false;
+        const includeThoughts = model_options?.include_thoughts ?? false;
         const text = collectAllTextContent(result.content, includeThoughts);
         const tool_use = collectTools(result.content);
 
@@ -374,8 +375,9 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         const client = await driver.getAnthropicClient(region);
         const model_options = options.model_options as VertexAIClaudeOptions | undefined;
 
-        if (model_options?._option_id !== "vertexai-claude" &&
-            model_options?._option_id !== "text-fallback"
+        if ((model_options?._option_id !== undefined &&
+            model_options?._option_id !== "vertexai-claude" &&
+            model_options?._option_id !== "text-fallback")
         ) {
             driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -324,7 +324,7 @@ export class ImagenModelDefinition {
 
     async requestImageGeneration(driver: VertexAIDriver, prompt: ImagenPrompt, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "vertexai-imagen") {
-            driver.logger.warn({ options: options.model_options }, "Invalid model options");
+            driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as ImagenOptions | undefined;
 

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -323,7 +323,7 @@ export class ImagenModelDefinition {
     }
 
     async requestImageGeneration(driver: VertexAIDriver, prompt: ImagenPrompt, options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "vertexai-imagen") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "vertexai-imagen") {
             driver.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as ImagenOptions | undefined;

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -30,7 +30,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
     }
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions | undefined;
@@ -65,7 +65,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
     }
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== "text-fallback") {
+        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== "text-fallback") {
             this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions | undefined;

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -1,4 +1,4 @@
-import { AIModel, AbstractDriver, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
+import { AbstractDriver, AIModel, Completion, CompletionChunkObject, DriverOptions, EmbeddingsOptions, EmbeddingsResult, ExecutionOptions, TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { FetchClient } from "@vertesia/api-fetch-client";
 import { GenerateEmbeddingPayload, GenerateEmbeddingResponse, WatsonAuthToken, WatsonxListModelResponse, WatsonxModelSpec, WatsonxTextGenerationPayload, WatsonxTextGenerationResponse } from "./interfaces.js";
@@ -31,7 +31,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
 
     async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions | undefined;
 
@@ -66,7 +66,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
 
     async requestTextCompletionStream(prompt: string, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         if (options.model_options?._option_id !== "text-fallback") {
-            this.logger.warn({ options: options.model_options }, "Invalid model options");
+            this.logger.debug({ options: options.model_options }, "Unexpected option id");
         }
         options.model_options = options.model_options as TextFallbackOptions | undefined;
         const payload: WatsonxTextGenerationPayload = {


### PR DESCRIPTION
Invalid model options warning was too noisy.
Changing to debug, and making it "Unexpected option id" instead.
Accept undefined.

This is a non-critical error that highlights potentially un-ideally constructed model options.
It is for debugging systems, not a critical thing and does not cause issues on it's own.

option id exists for:
a) The type system - differentiates between models/providers
b) Clarifies intent and checking of current valid form. 