### PR TITLE
Fix JSON schema option typing

### DIFF
--- a/common/src/options/bedrock.ts
+++ b/common/src/options/bedrock.ts
@@ -9,8 +9,22 @@ import {
 } from "./shared-parsing.js";
 import { hasSamplingParameterRestriction } from "./version-parsing.js";
 
-// Union type of all Bedrock options
-export type BedrockOptions = NovaCanvasOptions | BaseConverseOptions | BedrockClaudeOptions | BedrockPalmyraOptions | BedrockGptOssOptions | TwelvelabsPegasusOptions;
+/**
+ * Union type of all Bedrock options
+ *
+ * @discriminator _option_id
+ */
+export type BedrockOptions =
+    | NovaCanvasOptions
+    | BedrockConverseOptions
+    | BedrockNovaOptions
+    | BedrockMistralOptions
+    | BedrockAI21Options
+    | BedrockCohereCommandOptions
+    | BedrockClaudeOptions
+    | BedrockPalmyraOptions
+    | BedrockGptOssOptions
+    | TwelvelabsPegasusOptions;
 
 export interface NovaCanvasOptions {
     _option_id: "bedrock-nova-canvas"
@@ -28,16 +42,21 @@ export interface NovaCanvasOptions {
     outPaintingMode?: "DEFAULT" | "PRECISE";
 }
 
-export interface BaseConverseOptions {
-    _option_id: "bedrock-converse" | "bedrock-claude" | "bedrock-nova" | "bedrock-mistral" | "bedrock-ai21" | "bedrock-cohere-command" | "bedrock-palmyra" | "bedrock-gpt-oss";
+export interface BaseConverseOptions<TOptionId extends string = string> {
+    _option_id: TOptionId;
     max_tokens?: number;
     temperature?: number;
     top_p?: number;
     stop_sequence?: string[];
 }
 
-export interface BedrockClaudeOptions extends BaseConverseOptions {
-    _option_id: "bedrock-claude";
+export type BedrockConverseOptions = BaseConverseOptions<"bedrock-converse">;
+export type BedrockNovaOptions = BaseConverseOptions<"bedrock-nova">;
+export type BedrockMistralOptions = BaseConverseOptions<"bedrock-mistral">;
+export type BedrockAI21Options = BaseConverseOptions<"bedrock-ai21">;
+export type BedrockCohereCommandOptions = BaseConverseOptions<"bedrock-cohere-command">;
+
+export interface BedrockClaudeOptions extends BaseConverseOptions<"bedrock-claude"> {
     top_k?: number;
     thinking_budget_tokens?: number;
     include_thoughts?: boolean;
@@ -46,16 +65,14 @@ export interface BedrockClaudeOptions extends BaseConverseOptions {
     cache_ttl?: '5m' | '1h';
 }
 
-export interface BedrockPalmyraOptions extends BaseConverseOptions {
-    _option_id: "bedrock-palmyra";
+export interface BedrockPalmyraOptions extends BaseConverseOptions<"bedrock-palmyra"> {
     min_tokens?: number;
     seed?: number;
     frequency_penalty?: number;
     presence_penalty?: number;
 }
 
-export interface BedrockGptOssOptions extends BaseConverseOptions {
-    _option_id: "bedrock-gpt-oss";
+export interface BedrockGptOssOptions extends BaseConverseOptions<"bedrock-gpt-oss"> {
     reasoning_effort?: "low" | "medium" | "high";
     frequency_penalty?: number;
     presence_penalty?: number;

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -2,6 +2,9 @@ import { ModelOptionInfoItem, ModelOptions, ModelOptionsInfo, OptionType, Reason
 import { textOptionsFallback } from "./fallback.js";
 
 // Union type of all OpenAI options
+/**
+ * @discriminator _option_id
+ */
 export type OpenAiOptions = OpenAiThinkingOptions | OpenAiTextOptions | OpenAiDalleOptions | OpenAiGptImageOptions;
 
 export interface OpenAiThinkingOptions {

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -14,6 +14,9 @@ import {
 } from "./version-parsing.js";
 
 // Union type of all VertexAI options
+/**
+ * @discriminator _option_id
+ */
 export type VertexAIOptions = ImagenOptions | VertexAIClaudeOptions | VertexAIGeminiOptions;
 
 export enum ImagenTaskType {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -477,6 +477,7 @@ export interface JSONSchema {
     type?: JSONSchemaTypeName | JSONSchemaTypeName[];
     description?: string;
     properties?: JSONSchemaProperties;
+    additionalProperties?: boolean | JSONSchema;
     required?: string[];
     [k: string]: any;
 }

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -324,6 +324,9 @@ export interface ImageResult extends BaseResult {
     value: string; // base64 data url or real url
 }
 
+/**
+ * @discriminator type
+ */
 export type CompletionResult = TextResult | JsonResult | ImageResult;
 
 
@@ -581,6 +584,9 @@ export type ReasoningEffort = "low" | "medium" | "high";
 
 // ============== Model Options ===============
 
+/**
+ * @discriminator _option_id
+ */
 export type ModelOptions = TextFallbackOptions | VertexAIOptions | BedrockOptions | OpenAiOptions | GroqOptions;
 
 // ============== Option Info ===============


### PR DESCRIPTION
## Summary
- Add explicit JSON Schema option metadata for provider model settings.
- Tighten `additionalProperties` typing so generated OpenAPI clients can consume the schemas cleanly.

## Test Plan
- [x] `pnpm run build`
- [x] `pnpm run lint` attempted; failed because standalone submodule dependencies are not installed (`eslint: command not found`, local `node_modules` missing)
- [x] Parent repo `pnpm run build`
- [x] Parent repo `pnpm run lint` passed with warnings only
