### PR TITLE
chore: reduce prompt execution log noise

### DIFF
--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -218,7 +218,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     // by default no stream is supported. we block and we return all at once
     async stream(segments: PromptSegment[], options: ExecutionOptions): Promise<CompletionStream<PromptT>> {
-        this.logger.debug(options, `Executing prompt with provider ${this.provider}`);
+        this.logger.debug(options, `Executing prompt with provider ${this.provider} with options: ${JSON.stringify(options)}`);
         const prompt = await this.createPrompt(segments, options);
         const canStream = await this.canStream(options);
         if (canStream) {

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -218,7 +218,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     // by default no stream is supported. we block and we return all at once
     async stream(segments: PromptSegment[], options: ExecutionOptions): Promise<CompletionStream<PromptT>> {
-        this.logger.info(options, `Executing prompt with provider ${this.provider} with options: ${JSON.stringify(options)}`);
+        this.logger.debug(options, `Executing prompt with provider ${this.provider}`);
         const prompt = await this.createPrompt(segments, options);
         const canStream = await this.canStream(options);
         if (canStream) {


### PR DESCRIPTION
## Summary
- Demote the per-stream "Executing prompt with provider X with options: {...}" log in `AbstractDriver.stream` from `info` to `debug`. The serialized `options` payload is large, gets emitted on every prompt execution, and is operator-noise rather than an operational milestone.

## Verification
- Build: covered transitively by parent studio `turbo build` (the parent build succeeded with this commit pinned).
- Tests: not run locally for this one-line log-level change.

## Test Plan
- [ ] Confirm production driver logs no longer emit per-prompt "Executing prompt with provider..." at \`info\` level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>