### PR TITLE
chore(vertexai): route Gemini recoverable-tool-call warning through driver.logger

### DIFF
--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -482,7 +482,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         return { contents, system };
     }
 
-    usageMetadataToTokenUsage(usageMetadata: GenerateContentResponseUsageMetadata | undefined): ExecutionTokenUsage {
+    usageMetadataToTokenUsage(driver: VertexAIDriver, usageMetadata: GenerateContentResponseUsageMetadata | undefined): ExecutionTokenUsage {
         if (!usageMetadata || !usageMetadata.totalTokenCount) {
             return {};
         }
@@ -499,11 +499,14 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             + (usageMetadata.toolUsePromptTokenCount ?? 0);
 
         if ((tokenUsage.total ?? 0) !== (tokenUsage.prompt ?? 0) + tokenUsage.result) {
-            console.warn("[VertexAI] Gemini token usage mismatch: total does not equal prompt + result", {
-                total: tokenUsage.total,
-                prompt: tokenUsage.prompt,
-                result: tokenUsage.result
-            });
+            // Token-accounting mismatch: warn-level diagnostic (the call still
+            // returns the best-effort tokenUsage). Use the driver's structured
+            // logger so we don't promote stderr writes to ERROR in serverless
+            // log aggregators — see the recoverable-tool-call sites below.
+            driver.logger.warn(
+                { total: tokenUsage.total, prompt: tokenUsage.prompt, result: tokenUsage.result },
+                "[VertexAI] Gemini token usage mismatch: total does not equal prompt + result",
+            );
         }
 
         if (!tokenUsage.result) {
@@ -545,7 +548,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const payload = getGeminiPayload(options, prompt);
         const response = await client.models.generateContent(payload);
 
-        const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(response.usageMetadata);
+        const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, response.usageMetadata);
 
         let tool_use: ToolUse[] | undefined;
         let finish_reason: string | undefined, result: any;
@@ -659,7 +662,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const response = await client.models.generateContentStream(payload);
 
         const stream = asyncMap(response, async (item) => {
-            const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(item.usageMetadata);
+            const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, item.usageMetadata);
             if (item.candidates && item.candidates.length > 0) {
                 for (const candidate of item.candidates) {
                     let tool_use: ToolUse[] | undefined;

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -570,10 +570,15 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                 tool_use = collectToolUseParts(content);
 
                 // For recoverable tool call issues, log warning but continue processing
-                // The workflow will handle the invalid tool call gracefully
+                // The workflow will handle the invalid tool call gracefully.
+                // Route through the driver's structured logger instead of `console.warn`
+                // so downstream runtimes (e.g. Cloud Run) don't promote stderr writes
+                // to ERROR severity for what is, by definition, a recoverable event.
                 if (isRecoverableToolCall && tool_use && tool_use.length > 0) {
-                    console.warn(`[Gemini] Recoverable tool call issue (${candidate.finishReason}): ` +
-                        `Model tried to call undeclared tool(s): ${tool_use.map(t => t.tool_name).join(', ')}`);
+                    driver.logger.warn(
+                        `[Gemini] Recoverable tool call issue (${candidate.finishReason}): ` +
+                        `Model tried to call undeclared tool(s): ${tool_use.map(t => t.tool_name).join(', ')}`,
+                    );
                 }
 
                 result = extractCompletionResults(content);
@@ -677,10 +682,15 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
                         tool_use = collectToolUseParts(candidate.content);
                         if (tool_use) {
                             finish_reason = "tool_use";
-                            // Log warning for recoverable tool call issues
+                            // Log warning for recoverable tool call issues — see the
+                            // matching site in `requestTextCompletion` above for why
+                            // we route through the driver's logger instead of
+                            // `console.warn`.
                             if (isRecoverableToolCall) {
-                                console.warn(`[Gemini] Recoverable tool call issue (${candidate.finishReason}): ` +
-                                    `Model tried to call undeclared tool(s): ${tool_use.map(t => t.tool_name).join(', ')}`);
+                                driver.logger.warn(
+                                    `[Gemini] Recoverable tool call issue (${candidate.finishReason}): ` +
+                                    `Model tried to call undeclared tool(s): ${tool_use.map(t => t.tool_name).join(', ')}`,
+                                );
                             }
                         }
                         return {


### PR DESCRIPTION
## Summary

Three log sites in the Gemini driver were emitting via bare `console.warn`. In serverless runtimes that pipe stderr into an aggregator (Cloud Run → Datadog in our case), stderr writes get promoted to **ERROR** severity regardless of the inline label — so events the code itself labels "Recoverable" or "mismatch" were paging on-call.

All three now route through `driver.logger.warn(...)`, which keeps the message at the warn level the code (and the surrounding comments) already intended:

1. `requestTextCompletion` (~line 575) — `[Gemini] Recoverable tool call issue (UNEXPECTED_TOOL_CALL)`. Driver was already in scope.
2. `requestTextCompletionStream` (~line 682) — same message, streaming path. Driver in scope.
3. `usageMetadataToTokenUsage` (~line 502) — `[VertexAI] Gemini token usage mismatch ...`. Method didn't receive a driver — added it as a parameter and threaded it through from the two internal callers. No external callers (verified by repo-wide grep), so the signature change is contained.

## Companion PRs
- [vertesia/studio#5117](https://github.com/vertesia/studio/pull/5117) — main worker/workflow log-level re-classification.
- [vertesia/composableai#1293](https://github.com/vertesia/composableai/pull/1293) — companion recovery-failure log enrichment.

## Verification
- `cd drivers && npx tsc --noEmit` — clean.
- `grep -n "console\.warn" drivers/src/vertexai/models/gemini.ts` — only comment references remain.

## Test plan
- [ ] Trigger a Gemini interaction with a prompt that elicits `UNEXPECTED_TOOL_CALL`. Confirm the log entry appears at `warn` level in Datadog (was `error`); message text otherwise unchanged.
- [ ] Trigger a token-usage mismatch path (rare, usually only when an API returns inconsistent counts). Confirm the same downgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>