### PR TITLE
fix: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Actions are pinned to commit SHAs; Dependabot updates the SHA + version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,11 +15,11 @@ jobs:
       matrix:
         node-version: [24.x]
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           run_install: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -27,13 +27,13 @@ jobs:
       - run: pnpm build
 
       - name: Authenticate with Google Cloud
-        uses: "google-github-actions/auth@v3"
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         id: gauth
         with:
           project_id: "dengenlabs"
           workload_identity_provider: "projects/265888598630/locations/global/workloadIdentityPools/composable-cloud/providers/github"
 
-      - uses: "aws-actions/configure-aws-credentials@v6.1.0"
+      - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           audience: sts.amazonaws.com
           role-to-assume: arn:aws:iam::716085231028:role/ComposablePromptExecutor

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -33,7 +33,7 @@ jobs:
       sync_ref: ${{ steps.sync.outputs.SYNC_REF }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false
@@ -222,7 +222,7 @@ jobs:
     if: ${{ always() && needs.sync.outputs.should_cleanup != 'false' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Fetch all because we need to access info from different branches
           fetch-tags: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,11 +12,11 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:
           run_install: false
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: pnpm

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -36,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
 
-      - uses: pnpm/action-setup@v5
-      - uses: actions/setup-node@v6
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

Replace mutable major-version tags (e.g. `actions/checkout@v6`) on every third-party `uses:` reference with full 40-character commit SHAs and a trailing version comment.

**Why now:** Major-version tags are mutable — the action owner can move `@v6` to any commit at any time. This is exactly the vector exploited in the March 2025 `tj-actions/changed-files` supply-chain compromise (~23k repos affected). Several of our deploy/publish workflows hold AWS/GCP credentials and `GITHUB_TOKEN` with write scope, so a poisoned action would have direct access to those secrets.

**SHA selection policy:** every pinned SHA references a commit authored **on or before 2026-05-13** (>=7 days old at time of authoring). This is a defense-in-depth window: if a maintainer's account was compromised within the past week but the release hasn't yet been publicly reported, our pins won't have landed on the tainted commit.

## Changes

- 4 workflow files repinned to SHAs + version comment
- New `.github/dependabot.yml` with the `github-actions` ecosystem so Dependabot keeps the SHA *and* the trailing comment in sync on weekly bumps

## Verification

- All 5 modified/added YAML files parse cleanly with `yaml.safe_load` (no syntax breakage).
- No lint/typecheck/test apply to workflow-only changes — workflows are validated by GitHub Actions at runtime.

## Test plan

- [ ] Confirm the next push to `main` triggers `build-and-test.yml` and it succeeds with the pinned action SHAs.
- [ ] Confirm Dependabot opens a "github-actions" group PR within a week and the SHA + version comment update together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)