### PR TITLE
chore: lint cleanup, any-type removal, test typecheck infra

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,6 +25,7 @@ jobs:
           cache: "pnpm"
       - run: pnpm install
       - run: pnpm build
+      - run: pnpm typecheck:test
 
       - name: Authenticate with Google Cloud
         uses: "google-github-actions/auth@v3"

--- a/biome.json
+++ b/biome.json
@@ -27,14 +27,14 @@
     "rules": {
       "recommended": false,
       "correctness": {
-        "noUnusedFunctionParameters": "warn",
-        "noUnusedImports": "warn",
-        "noUnusedVariables": "warn"
+        "noUnusedFunctionParameters": "error",
+        "noUnusedImports": "error",
+        "noUnusedVariables": "error"
       },
       "suspicious": {
-        "noExplicitAny": "warn",
-        "noImplicitAnyLet": "warn",
-        "noUnusedExpressions": "off"
+        "noExplicitAny": "error",
+        "noImplicitAnyLet": "error",
+        "noUnusedExpressions": "error"
       }
     }
   },

--- a/common/package.json
+++ b/common/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.test.json --noEmit",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo"
   },

--- a/common/package.json
+++ b/common/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo"
   },

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -390,7 +390,7 @@ export class LlumiverseError extends Error {
 
 export interface BaseResult {
     type: "text" | "json" | "image";
-    value: any;
+    value: unknown;
 }
 
 export interface TextResult extends BaseResult {
@@ -400,6 +400,7 @@ export interface TextResult extends BaseResult {
 
 export interface JsonResult extends BaseResult {
     type: "json";
+    value: JSONValue;
 }
 
 export interface ImageResult extends BaseResult {
@@ -422,7 +423,7 @@ export interface CompletionChunkObject {
      * Tool calls returned by the model during streaming.
      * Each chunk may contain partial tool call information that needs to be aggregated.
      */
-    tool_use?: ToolUse[];
+    tool_use?: ToolUse<unknown>[];
 }
 
 /**
@@ -464,7 +465,7 @@ export interface Completion {
     /**
      * Contains the tools from which the model awaits information.
      */
-    tool_use?: ToolUse[];
+    tool_use?: ToolUse<unknown>[];
     /**
      * The finish reason as reported by the model: stop | length or other model specific values
      */
@@ -479,7 +480,7 @@ export interface Completion {
     /**
      * The original response. Only included if the option include_original_response is set to true and the request is made using execute. Not supported when streaming.
      */
-    original_response?: Record<string, any>;
+    original_response?: unknown;
 
     /**
      * The conversation context. This is an opaque structure that can be passed to the next request to restore the context.
@@ -487,7 +488,7 @@ export interface Completion {
     conversation?: unknown;
 }
 
-export interface ExecutionResponse<PromptT = any> extends Completion {
+export interface ExecutionResponse<PromptT = unknown> extends Completion {
     prompt: PromptT;
     /**
      * The time it took to execute the request in seconds
@@ -500,7 +501,7 @@ export interface ExecutionResponse<PromptT = any> extends Completion {
 }
 
 
-export interface CompletionStream<PromptT = any> extends AsyncIterable<string> {
+export interface CompletionStream<PromptT = unknown> extends AsyncIterable<string> {
     completion: ExecutionResponse<PromptT> | undefined;
 }
 
@@ -560,12 +561,16 @@ export interface JSONSchema {
     type?: JSONSchemaTypeName | JSONSchemaTypeName[];
     description?: string;
     properties?: JSONSchemaProperties;
+    items?: JSONSchema;
+    format?: string;
+    editor?: unknown;
+    default?: unknown;
     additionalProperties?: boolean | JSONSchema;
     required?: string[];
-    [k: string]: any;
+    [k: string]: unknown;
 }
 
-export type PromptFormatter<T = any> = (messages: PromptSegment[], schema?: JSONSchema) => T;
+export type PromptFormatter<T = unknown> = (messages: PromptSegment[], schema?: JSONSchema) => T;
 
 //Options are split into PromptOptions, ModelOptions and ExecutionOptions.
 //ExecutionOptions are most often used within llumiverse as they are the most complete.

--- a/common/tsconfig.json
+++ b/common/tsconfig.json
@@ -32,6 +32,7 @@
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": true,
     "noPropertyAccessFromIndexSignature": false,
+    "noImplicitAny": true,
   },
   "include": [
     "src"

--- a/common/tsconfig.test.json
+++ b/common/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/core/package.json
+++ b/core/package.json
@@ -58,7 +58,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.test.json --noEmit",
+    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo"
   },

--- a/core/package.json
+++ b/core/package.json
@@ -58,6 +58,7 @@
   "scripts": {
     "lint": "biome lint src",
     "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.test.json --noEmit",
     "build": "pnpm exec tsmod build",
     "clean": "rimraf ./lib tsconfig.tsbuildinfo"
   },

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -4,12 +4,15 @@ import {
     ExecutionOptions,
     ExecutionResponse,
     ExecutionTokenUsage,
+    CompletionResult,
     ToolUse,
     LlumiverseError
 } from "@llumiverse/common";
 import { AbstractDriver } from "./Driver.js";
 
-export class DefaultCompletionStream<PromptT = any> implements CompletionStream<PromptT> {
+type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
+
+export class DefaultCompletionStream<PromptT = unknown> implements CompletionStream<PromptT> {
 
     chunks: number; // Counter for number of chunks instead of storing strings
     completion: ExecutionResponse<PromptT> | undefined;
@@ -24,8 +27,8 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
         // reset state
         this.completion = undefined;
         this.chunks = 0;
-        const accumulatedResults: any[] = []; // Accumulate CompletionResult[] from chunks
-        const accumulatedToolUse: Map<string, ToolUse> = new Map(); // Accumulate tool_use by id
+        const accumulatedResults: CompletionResult[] = []; // Accumulate CompletionResult[] from chunks
+        const accumulatedToolUse: Map<string, StreamingToolUse> = new Map(); // Accumulate tool_use by id
 
         this.driver.logger.debug(
             `[${this.driver.provider}] Streaming Execution of ${this.options.model} with prompt`,
@@ -72,10 +75,10 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                                         const newInput = tool.tool_input as unknown;
                                         if (typeof existingInput === 'string' && typeof newInput === 'string') {
                                             // Concatenate string arguments
-                                            (existing as any).tool_input = existingInput + newInput;
+                                            existing.tool_input = existingInput + newInput;
                                         } else if (existingInput && typeof existingInput === 'object' && newInput && typeof newInput === 'object') {
                                             // Merge objects
-                                            existing.tool_input = { ...(existingInput as object), ...(newInput as object) } as any;
+                                            existing.tool_input = { ...(existingInput as Record<string, unknown>), ...(newInput as Record<string, unknown>) };
                                         } else {
                                             existing.tool_input = tool.tool_input;
                                         }
@@ -85,8 +88,9 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                                         existing.tool_name = tool.tool_name;
                                     }
                                     // Update actual ID if provided (OpenAI sends id only in first chunk)
-                                    if ((tool as any)._actual_id) {
-                                        (existing as any)._actual_id = (tool as any)._actual_id;
+                                    const streamingTool = tool as StreamingToolUse;
+                                    if (streamingTool._actual_id) {
+                                        existing._actual_id = streamingTool._actual_id;
                                     }
                                 } else {
                                     // New tool call
@@ -144,8 +148,10 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                                         // Show truncated image placeholder for streaming
                                         const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
                                         return `\n[Image: ${truncatedValue}...]\n`;
-                                    default:
-                                        return String((r as any).value || '');
+                                    default: {
+                                        const _exhaustive: never = r;
+                                        return String(_exhaustive);
+                                    }
                                 }
                             }).join('');
 
@@ -157,7 +163,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
                     }
                 }
             }
-        } catch (error: any) {
+        } catch (error: unknown) {
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;
@@ -188,9 +194,9 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
             const truncatedToolIds = new Set<string>();
             for (const tool of toolUseArray) {
                 // Restore actual ID from OpenAI (was stored in _actual_id during streaming)
-                if ((tool as any)._actual_id) {
-                    tool.id = (tool as any)._actual_id;
-                    delete (tool as any)._actual_id;
+                if (tool._actual_id) {
+                    tool.id = tool._actual_id;
+                    delete tool._actual_id;
                 }
                 // Parse tool_input strings as JSON if needed (streaming sends arguments as string chunks)
                 if (typeof tool.tool_input === 'string') {
@@ -240,7 +246,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
             if (this.completion) {
                 this.driver.validateResult(this.completion, this.options);
             }
-        } catch (error: any) {
+        } catch (error: unknown) {
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;
@@ -255,7 +261,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
 
 }
 
-export class FallbackCompletionStream<PromptT = any> implements CompletionStream<PromptT> {
+export class FallbackCompletionStream<PromptT = unknown> implements CompletionStream<PromptT> {
 
     completion: ExecutionResponse<PromptT> | undefined;
 
@@ -283,13 +289,15 @@ export class FallbackCompletionStream<PromptT = any> implements CompletionStream
                         // Show truncated image placeholder for streaming
                         const truncatedValue = typeof r.value === 'string' ? r.value.slice(0, 10) : String(r.value).slice(0, 10);
                         return `[Image: ${truncatedValue}...]`;
-                    default:
-                        return String((r as any).value || '');
+                    default: {
+                        const _exhaustive: never = r;
+                        return String(_exhaustive);
+                    }
                 }
             }).join('');
             yield content;
             this.completion = completion; // Return the original completion with untouched CompletionResult[]
-        } catch (error: any) {
+        } catch (error: unknown) {
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;

--- a/core/src/Driver.error.test.ts
+++ b/core/src/Driver.error.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@llumiverse/common';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { AbstractDriver } from './Driver.js';
+import { errorWith, getProp } from '../test/__helpers__/test-utils.js';
 
 // Simple test driver implementation
 class TestDriver extends AbstractDriver<DriverOptions, string> {
@@ -133,8 +134,7 @@ describe('AbstractDriver Error Formatting', () => {
 
     describe('formatLlumiverseError', () => {
         it('should format error with status code', () => {
-            const originalError = new Error('Rate limit exceeded');
-            (originalError as any).status = 429;
+            const originalError = errorWith('Rate limit exceeded', { status: 429 });
 
             const formatted = driver['formatLlumiverseError'](originalError, mockContext);
 
@@ -148,8 +148,7 @@ describe('AbstractDriver Error Formatting', () => {
         });
 
         it('should extract status from statusCode property', () => {
-            const originalError = new Error('Server error');
-            (originalError as any).statusCode = 500;
+            const originalError = errorWith('Server error', { statusCode: 500 });
 
             const formatted = driver['formatLlumiverseError'](originalError, mockContext);
 
@@ -158,8 +157,7 @@ describe('AbstractDriver Error Formatting', () => {
         });
 
         it('should extract status from code property', () => {
-            const originalError = new Error('Timeout');
-            (originalError as any).code = 408;
+            const originalError = errorWith('Timeout', { code: 408 });
 
             const formatted = driver['formatLlumiverseError'](originalError, mockContext);
 
@@ -195,14 +193,12 @@ describe('AbstractDriver Error Formatting', () => {
 
         it('should determine retryability based on status and message', () => {
             // Retryable by status
-            const retryableError = new Error('Error');
-            (retryableError as any).status = 429;
+            const retryableError = errorWith('Error', { status: 429 });
             const formatted1 = driver['formatLlumiverseError'](retryableError, mockContext);
             expect(formatted1.retryable).toBe(true);
 
             // Not retryable by status
-            const nonRetryableError = new Error('Error');
-            (nonRetryableError as any).status = 400;
+            const nonRetryableError = errorWith('Error', { status: 400 });
             const formatted2 = driver['formatLlumiverseError'](nonRetryableError, mockContext);
             expect(formatted2.retryable).toBe(false);
 
@@ -220,7 +216,7 @@ describe('AbstractDriver Error Formatting', () => {
                 context: LlumiverseErrorContext
             ): LlumiverseError {
                 // Custom logic: check for specific error type
-                if ((error as any).type === 'custom_retryable') {
+                if (getProp(error, 'type') === 'custom_retryable') {
                     return new LlumiverseError(
                         `[${this.provider}] Custom retryable error`,
                         true,
@@ -249,8 +245,7 @@ describe('AbstractDriver Error Formatting', () => {
 
         it('should fall back to default for non-custom errors', () => {
             const customDriver = new CustomDriver({});
-            const regularError = new Error('Regular error');
-            (regularError as any).status = 500;
+            const regularError = errorWith('Regular error', { status: 500 });
 
             const formatted = customDriver['formatLlumiverseError'](regularError, mockContext);
 

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -30,9 +30,16 @@ import { DefaultCompletionStream, FallbackCompletionStream } from "./CompletionS
 import { formatTextPrompt } from "./formatters/index.js";
 import { validateResult } from "./validation.js";
 
+function getObjectProperty(value: unknown, key: string): unknown {
+    if (value && typeof value === 'object' && key in value) {
+        return (value as Record<string, unknown>)[key];
+    }
+    return undefined;
+}
+
 // Helper to create logger methods that support both message-only and object-first signatures
 function createConsoleLoggerMethod(consoleMethod: (...args: unknown[]) => void): Logger['info'] {
-    return ((objOrMsg: any, msgOrNever?: any, ...args: (string | number | boolean)[]) => {
+    return ((objOrMsg: unknown, msgOrNever?: string, ...args: (string | number | boolean)[]) => {
         if (typeof objOrMsg === 'string') {
             // Message-only: logger.info("message", ...args)
             consoleMethod(objOrMsg, msgOrNever, ...args);
@@ -158,12 +165,15 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         if (!result.tool_use && !result.error && options.result_schema) {
             try {
                 result.result = validateResult(result.result, options.result_schema);
-            } catch (error: any) {
-                const errorMessage = `[${this.provider}] [${options.model}] ${error.code ? '[' + error.code + '] ' : ''}Result validation error: ${error.message}`;
+            } catch (error: unknown) {
+                const validationError = error instanceof Error ? error : new Error(String(error));
+                const rawCode = getObjectProperty(error, 'code');
+                const code = rawCode === 'json_error' || rawCode === 'validation_error' ? rawCode : undefined;
+                const errorMessage = `[${this.provider}] [${options.model}] ${code ? '[' + code + '] ' : ''}Result validation error: ${validationError.message}`;
                 this.logger.error({ err: error, data: result.result }, errorMessage);
                 result.error = {
-                    code: error.code || error.name,
-                    message: error.message,
+                    code: code || 'validation_error',
+                    message: validationError.message,
                     data: result.result,
                 }
             }
@@ -172,7 +182,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     async execute(segments: PromptSegment[], options: ExecutionOptions): Promise<ExecutionResponse<PromptT>> {
         const prompt = await this.createPrompt(segments, options);
-        return this._execute(prompt, options).catch((error: any) => {
+        return this._execute(prompt, options).catch((error: unknown) => {
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;
@@ -188,7 +198,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
     async _execute(prompt: PromptT, options: ExecutionOptions): Promise<ExecutionResponse<PromptT>> {
         try {
             const start = Date.now();
-            let result;
+            let result: Completion;
 
             if (this.isImageModel(options.model)) {
                 this.logger.debug(
@@ -247,7 +257,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
     }
 
     public async createPrompt(segments: PromptSegment[], opts: PromptOptions): Promise<PromptT> {
-        return await (opts.format ? opts.format(segments, opts.result_schema) : this.formatPrompt(segments, opts));
+        return await (opts.format ? opts.format(segments, opts.result_schema) as PromptT : this.formatPrompt(segments, opts));
     }
 
     /**
@@ -313,16 +323,17 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
     ): LlumiverseError {
         // Extract status code from common locations (only if numeric)
         let code: number | undefined;
-        const rawCode = (error as any)?.status
-            || (error as any)?.statusCode
-            || (error as any)?.code;
+        const rawCode = getObjectProperty(error, 'status')
+            || getObjectProperty(error, 'statusCode')
+            || getObjectProperty(error, 'code');
 
         if (typeof rawCode === 'number') {
             code = rawCode;
         }
 
         // Extract error name if available
-        const errorName = (error as any)?.name;
+        const rawErrorName = getObjectProperty(error, 'name');
+        const errorName = typeof rawErrorName === 'string' ? rawErrorName : undefined;
 
         // Extract message
         const message = error instanceof Error

--- a/core/src/async.ts
+++ b/core/src/async.ts
@@ -26,7 +26,7 @@ export function transformSSEStream(stream: ReadableStream<ServerSentEvent>, tran
                 try {
                     const result = transform(event.data) ?? ''
                     controller.enqueue(result);
-                } catch (err) {
+                } catch {
                     // double check for the last event which is not a JSON - at this time togetherai and mistralai returns the string [DONE]
                     // do nothing - happens if data is not a JSON - the last event data is the [DONE] string
                 }
@@ -35,12 +35,12 @@ export function transformSSEStream(stream: ReadableStream<ServerSentEvent>, tran
     })) satisfies ReadableStream<CompletionChunkObject> & AsyncIterable<CompletionChunkObject>;
 }
 
-export class EventStream<T, ReturnT = any> implements AsyncIterable<T> {
+export class EventStream<T, ReturnT = unknown> implements AsyncIterable<T> {
 
     private queue: T[] = [];
     private pending?: {
         resolve: (result: IteratorResult<T, ReturnT | undefined>) => void,
-        reject: (err: any) => void
+        reject: (err: unknown) => void
     };
     private done = false;
 

--- a/core/src/json.ts
+++ b/core/src/json.ts
@@ -15,11 +15,11 @@ export function parseJSON(text: string): JSONValue {
     text = text.trim();
     try {
         return JSON.parse(text);
-    } catch (err: any) {
+    } catch (err: unknown) {
         // use a relaxed parser
         try {
             return JSON.parse(jsonrepair(text));
-        } catch (err2: any) { // throw the original error
+        } catch { // throw the original error
             throw err;
         }
     }

--- a/core/src/resolver.ts
+++ b/core/src/resolver.ts
@@ -6,26 +6,28 @@
  * @param name the name of the property.
  * @returns the property value
  */
-function _prop(object: any, name: string) {
-    if (object === undefined) {
+function _prop(object: unknown, name: string): unknown {
+    if (object === undefined || object === null) {
         return undefined;
     }
     if (Array.isArray(object)) {
         const index = +name;
         if (isNaN(index)) {
             // map array to property
-            return object.map(item => item[name]);
+            return object.map(item => item && typeof item === 'object' ? (item as Record<string, unknown>)[name] : undefined);
         } else {
             return object[index];
         }
+    } else if (typeof object === 'object') {
+        return (object as Record<string, unknown>)[name];
     } else {
-        return object[name];
+        return undefined;
     }
 
 }
 
-export function resolveField(object: any, path: string[]) {
-    let p = object as any;
+export function resolveField(object: unknown, path: string[]): unknown {
+    let p: unknown = object;
     if (!p) return p;
     if (!path.length) return p;
     const last = path.length - 1;

--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -1,4 +1,4 @@
-import { CompletionResult, ResultValidationError } from "@llumiverse/common";
+import { CompletionResult, JSONValue, ResultValidationError } from "@llumiverse/common";
 import { Ajv } from 'ajv';
 import addFormats from 'ajv-formats';
 import { extractAndParseJSON } from "./json.js";
@@ -16,6 +16,18 @@ const ajv = new Ajv({
 //use ts ignore to avoid error with ESM and ajv-formats
 // @ts-ignore This expression is not callable
 addFormats(ajv)
+
+function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+}
+
+function getRequiredFields(schemaField: unknown): string[] {
+    if (!schemaField || typeof schemaField !== 'object') {
+        return [];
+    }
+    const required = (schemaField as Record<string, unknown>).required;
+    return Array.isArray(required) ? required.filter((field): field is string => typeof field === 'string') : [];
+}
 
 
 export class ValidationError extends Error implements ResultValidationError {
@@ -35,8 +47,8 @@ function parseCompletionAsJson(data: CompletionResult[]) {
             const text = part.value.trim();
             try {
                 return extractAndParseJSON(text);
-            } catch (error: any) {
-                lastError = new ValidationError("json_error", error.message);
+            } catch (error: unknown) {
+                lastError = new ValidationError("json_error", errorMessage(error));
             }
         }
     }
@@ -48,7 +60,7 @@ function parseCompletionAsJson(data: CompletionResult[]) {
 
 
 export function validateResult(data: CompletionResult[], schema: object): CompletionResult[] {
-    let json;
+    let json: JSONValue;
     if (Array.isArray(data)) {
         const jsonResults = data.filter(r => r.type === "json");
         if (jsonResults.length > 0) {
@@ -56,8 +68,8 @@ export function validateResult(data: CompletionResult[], schema: object): Comple
         } else {
             try {
                 json = parseCompletionAsJson(data);
-            } catch (error: any) {
-                throw new ValidationError("json_error", error.message)
+            } catch (error: unknown) {
+                throw new ValidationError("json_error", errorMessage(error))
             }
         }
     } else {
@@ -79,8 +91,9 @@ export function validateResult(data: CompletionResult[], schema: object): Comple
 
             //ignore date if empty or null
             if (!value
+                && typeof schemaFieldFormat === 'string'
                 && ["date", "date-time"].includes(schemaFieldFormat)
-                && !schemaField?.required?.includes(path[path.length - 1])) {
+                && !getRequiredFields(schemaField).includes(path[path.length - 1])) {
                 continue;
             } else {
                 errors.push(e);

--- a/core/test/__helpers__/test-utils.ts
+++ b/core/test/__helpers__/test-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared helpers for tests in @llumiverse/core. These avoid repeated `as unknown` casts
+ * and centralize the patterns we need when asserting on untyped/dynamic values in tests.
+ */
+
+/**
+ * Create an Error with extra typed properties (e.g. `status`, `code`).
+ * Replaces the `(err as unknown).status = 429` pattern.
+ *
+ * @example
+ *   const err = errorWith('Rate limit exceeded', { status: 429 });
+ *   err.status; // typed as number
+ */
+export function errorWith<T extends object>(message: string, extra: T): Error & T {
+    return Object.assign(new Error(message), extra);
+}
+
+/**
+ * Safely read a property from an unknown value. Returns `undefined` if `obj` is null/undefined,
+ * not an object, or doesn't have the key. The return type can be narrowed via the generic.
+ *
+ * @example
+ *   const status = getProp<number>(error, 'status');
+ */
+export function getProp<T = unknown>(obj: unknown, key: string): T | undefined {
+    if (obj != null && typeof obj === 'object' && key in obj) {
+        return (obj as Record<string, unknown>)[key] as T;
+    }
+    return undefined;
+}
+
+/**
+ * Cast an object to expose its private members for testing. The caller defines the shape
+ * (typically a `type DriverInternals = { privateMethod: (...) => ReturnT; ... }`).
+ *
+ * @example
+ *   type Internals = { isErrorRetryable: (err: unknown) => boolean };
+ *   exposePrivate<Internals>(driver).isErrorRetryable(err);
+ */
+export function exposePrivate<T>(obj: object): T {
+    return obj as unknown as T;
+}
+
+/**
+ * Recursive "navigable" type for asserting on results of structure-preserving
+ * transformations (e.g. stripping/serialization). Each property access returns the same
+ * type, letting tests navigate deeply without per-test interfaces. For sites that call
+ * string/array methods on a leaf (e.g. `.substring`), add a targeted `as string` cast.
+ */
+export type Tree = { readonly [key: string]: Tree };

--- a/core/test/conversation-strip.test.ts
+++ b/core/test/conversation-strip.test.ts
@@ -10,6 +10,8 @@ import {
     deserializeBinaryFromStorage
 } from "../src/conversation-utils";
 
+import { Tree } from "./__helpers__/test-utils";
+
 const IMAGE_PLACEHOLDER = '[Image removed from conversation history]';
 const DOCUMENT_PLACEHOLDER = '[Document removed from conversation history]';
 const VIDEO_PLACEHOLDER = '[Video removed from conversation history]';
@@ -36,7 +38,7 @@ describe('stripBinaryFromConversation', () => {
             }]
         };
 
-        const result = stripBinaryFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBinaryFromConversation(input, FORCE_STRIP) as Tree;
 
         expect(result.messages[0].content[0].toolResult.content[0].text).toBe('Image loaded');
         // Image block should be replaced with text block
@@ -56,7 +58,7 @@ describe('stripBinaryFromConversation', () => {
         };
 
         // Default keepForTurns=Infinity means serialize for safe JSON storage
-        const result = stripBinaryFromConversation(input) as any;
+        const result = stripBinaryFromConversation(input) as Tree;
         expect(result.messages[0].content[0].image.source.bytes._base64).toBeDefined();
     });
 
@@ -89,7 +91,7 @@ describe('stripBinaryFromConversation', () => {
             new Uint8Array([4, 5, 6])
         ];
 
-        const result = stripBinaryFromConversation(input, FORCE_STRIP) as any[];
+        const result = stripBinaryFromConversation(input, FORCE_STRIP) as unknown as Tree[];
 
         expect(result[0].text).toBe('normal');
         expect(result[1]).toBe(IMAGE_PLACEHOLDER);
@@ -109,7 +111,7 @@ describe('stripBinaryFromConversation', () => {
             }
         }];
 
-        const result = stripBinaryFromConversation(input, FORCE_STRIP) as any[];
+        const result = stripBinaryFromConversation(input, FORCE_STRIP) as unknown as Tree[];
         expect(result[0]).toEqual({ text: DOCUMENT_PLACEHOLDER });
     });
 
@@ -121,7 +123,7 @@ describe('stripBinaryFromConversation', () => {
             }
         }];
 
-        const result = stripBinaryFromConversation(input, FORCE_STRIP) as any[];
+        const result = stripBinaryFromConversation(input, FORCE_STRIP) as unknown as Tree[];
         expect(result[0]).toEqual({ text: VIDEO_PLACEHOLDER });
     });
 
@@ -136,7 +138,7 @@ describe('stripBinaryFromConversation', () => {
             ]
         };
 
-        const result = stripBinaryFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBinaryFromConversation(input, FORCE_STRIP) as Tree;
 
         expect(result.content[0]).toEqual({ text: 'First' });
         expect(result.content[1]).toEqual({ text: IMAGE_PLACEHOLDER });
@@ -159,7 +161,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
         // Should be replaced with text block
         expect(result.messages[0].content[0]).toEqual({ type: 'text', text: IMAGE_PLACEHOLDER });
     });
@@ -175,7 +177,7 @@ describe('stripBase64ImagesFromConversation', () => {
         };
 
         // Default keepForTurns=Infinity means don't strip
-        const result = stripBase64ImagesFromConversation(input) as any;
+        const result = stripBase64ImagesFromConversation(input) as Tree;
         expect(result.messages[0].content[0].image_url.url).toBe('data:image/png;base64,abc123');
     });
 
@@ -191,7 +193,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
         // Should be replaced with text block
         expect(result.parts[0]).toEqual({ text: IMAGE_PLACEHOLDER });
     });
@@ -206,7 +208,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
         expect(result.parts[0].inlineData.data).toBe('short');
     });
 
@@ -220,7 +222,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
         // Should NOT be stripped - only base64 data URLs are stripped
         expect(result.messages[0].content[0].image_url.url).toBe('https://example.com/image.jpg');
     });
@@ -235,7 +237,7 @@ describe('stripBase64ImagesFromConversation', () => {
             url: 'data:text/plain;base64,SGVsbG8gV29ybGQ='
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
         expect(result.url).toBe('data:text/plain;base64,SGVsbG8gV29ybGQ=');
     });
 
@@ -257,7 +259,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
 
         expect(result.messages[0].content[0]).toEqual({ type: 'text', text: 'Here is an image' });
         expect(result.messages[0].content[1]).toEqual({ type: 'text', text: IMAGE_PLACEHOLDER });
@@ -281,7 +283,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
 
         expect(result.messages[0].content[0]).toEqual({ type: 'text', text: 'Here is a document' });
         expect(result.messages[0].content[1]).toEqual({ type: 'text', text: DOCUMENT_PLACEHOLDER });
@@ -301,7 +303,7 @@ describe('stripBase64ImagesFromConversation', () => {
             }]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
 
         // URL-based images should not be stripped
         expect(result.messages[0].content[0].source.url).toBe('https://example.com/image.png');
@@ -316,7 +318,7 @@ describe('stripBase64ImagesFromConversation', () => {
             ]
         };
 
-        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as any;
+        const result = stripBase64ImagesFromConversation(input, FORCE_STRIP) as Tree;
 
         expect(result.content[0]).toEqual({ type: 'text', text: 'Hello' });
         expect(result.content[1]).toEqual({ type: 'text', text: IMAGE_PLACEHOLDER });
@@ -372,7 +374,7 @@ describe('turn-based stripping', () => {
             const result = stripBinaryFromConversation(input, {
                 keepForTurns: 3,
                 currentTurn: 1
-            }) as any;
+            }) as Tree;
 
             // Should have serialized format (bytes._base64), not placeholder
             expect(result.content[0].image.source.bytes._base64).toBeDefined();
@@ -393,7 +395,7 @@ describe('turn-based stripping', () => {
             const result = stripBinaryFromConversation(input, {
                 keepForTurns: 2,
                 currentTurn: 2
-            }) as any;
+            }) as Tree;
 
             expect(result.content[0]).toEqual({ text: IMAGE_PLACEHOLDER });
         });
@@ -412,7 +414,7 @@ describe('turn-based stripping', () => {
             const result = stripBinaryFromConversation(input, {
                 keepForTurns: 2,
                 currentTurn: 5
-            }) as any;
+            }) as Tree;
 
             expect(result.content[0]).toEqual({ text: IMAGE_PLACEHOLDER });
         });
@@ -430,13 +432,13 @@ describe('turn-based stripping', () => {
             const result = stripBinaryFromConversation(input, {
                 keepForTurns: 0,
                 currentTurn: 0
-            }) as any;
+            }) as Tree;
 
             expect(result.content[0]).toEqual({ text: IMAGE_PLACEHOLDER });
         });
 
         test('should use turn number from metadata when currentTurn not provided', () => {
-            let conversation: any = {
+            let conversation: unknown = {
                 content: [{
                     image: {
                         format: 'png',
@@ -451,7 +453,7 @@ describe('turn-based stripping', () => {
             // Keep for 3 turns - should serialize (turn 1 < 3)
             const result = stripBinaryFromConversation(conversation, {
                 keepForTurns: 3
-            }) as any;
+            }) as Tree;
 
             expect(result.content[0].image.source.bytes._base64).toBeDefined();
         });
@@ -473,7 +475,7 @@ describe('turn-based stripping', () => {
             const serialized = stripBinaryFromConversation(input, {
                 keepForTurns: 5,
                 currentTurn: 1
-            }) as any;
+            }) as Tree;
 
             // Should be base64 encoded (bytes becomes { _base64: ... })
             expect(serialized.content[0].image.source.bytes._base64).toBeDefined();
@@ -484,9 +486,9 @@ describe('turn-based stripping', () => {
             expect(parsed.content[0].image.source.bytes._base64).toBe(serialized.content[0].image.source.bytes._base64);
 
             // Should be deserializable back to Uint8Array
-            const deserialized = deserializeBinaryFromStorage(parsed) as any;
+            const deserialized = deserializeBinaryFromStorage(parsed) as Tree;
             expect(deserialized.content[0].image.source.bytes).toBeInstanceOf(Uint8Array);
-            expect(Array.from(deserialized.content[0].image.source.bytes)).toEqual(Array.from(originalBytes));
+            expect(Array.from(deserialized.content[0].image.source.bytes as unknown as Uint8Array)).toEqual(Array.from(originalBytes));
         });
 
         test('should strip serialized images when threshold exceeded', () => {
@@ -506,7 +508,7 @@ describe('turn-based stripping', () => {
             const result = stripBinaryFromConversation(serializedConversation, {
                 keepForTurns: 2,
                 currentTurn: 3
-            }) as any;
+            }) as Tree;
 
             // Should be stripped to placeholder
             expect(result.content[0]).toEqual({ text: IMAGE_PLACEHOLDER });
@@ -526,7 +528,7 @@ describe('turn-based stripping', () => {
             const result = stripBase64ImagesFromConversation(input, {
                 keepForTurns: 3,
                 currentTurn: 1
-            }) as any;
+            }) as Tree;
 
             // Should still have the image URL
             expect(result.content[0].image_url.url).toBe('data:image/png;base64,abc123');
@@ -544,7 +546,7 @@ describe('turn-based stripping', () => {
             const result = stripBase64ImagesFromConversation(input, {
                 keepForTurns: 2,
                 currentTurn: 3
-            }) as any;
+            }) as Tree;
 
             expect(result.content[0]).toEqual({ type: 'text', text: IMAGE_PLACEHOLDER });
         });
@@ -559,7 +561,7 @@ describe('truncateLargeTextInConversation', () => {
             content: [{ text: 'a'.repeat(100000) }]
         };
 
-        const result = truncateLargeTextInConversation(input) as any;
+        const result = truncateLargeTextInConversation(input) as Tree;
 
         expect(result.content[0].text.length).toBe(100000);
     });
@@ -569,7 +571,7 @@ describe('truncateLargeTextInConversation', () => {
             content: [{ text: 'a'.repeat(100000) }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 0 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 0 }) as Tree;
 
         expect(result.content[0].text.length).toBe(100000);
     });
@@ -581,12 +583,12 @@ describe('truncateLargeTextInConversation', () => {
             content: [{ text: longText }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         // Should be truncated to ~40000 chars + marker
         expect(result.content[0].text.length).toBeLessThan(50000);
         expect(result.content[0].text).toContain(TEXT_TRUNCATED_MARKER);
-        expect(result.content[0].text.substring(0, 40000)).toBe('a'.repeat(40000));
+        expect((result.content[0].text as unknown as string).substring(0, 40000)).toBe('a'.repeat(40000));
     });
 
     test('should not truncate text within token limit', () => {
@@ -595,7 +597,7 @@ describe('truncateLargeTextInConversation', () => {
             content: [{ text: shortText }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.content[0].text).toBe(shortText);
     });
@@ -615,7 +617,7 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         const resultText = result.messages[0].content[0].toolResult.content[0].text;
         expect(resultText.length).toBeLessThan(50000);
@@ -632,7 +634,7 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.messages[0].content.length).toBeLessThan(50000);
         expect(result.messages[0].content).toContain(TEXT_TRUNCATED_MARKER);
@@ -645,7 +647,7 @@ describe('truncateLargeTextInConversation', () => {
             _llumiverse_meta: { turnNumber: 5 }
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result._llumiverse_meta).toEqual({ turnNumber: 5 });
         expect(result.content[0].text).toContain(TEXT_TRUNCATED_MARKER);
@@ -660,7 +662,7 @@ describe('truncateLargeTextInConversation', () => {
             ]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.items[0].text).toBe('short');
         expect(result.items[1].text).toContain(TEXT_TRUNCATED_MARKER);
@@ -695,7 +697,7 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         const toolResult = result.messages[0].content[0];
         // Text should be truncated
@@ -721,7 +723,7 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.messages[0].content[0].source.data).toBe(largeBase64);
     });
@@ -737,7 +739,7 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.messages[0].content[0].image_url.url).toBe(largeBase64);
     });
@@ -755,14 +757,14 @@ describe('truncateLargeTextInConversation', () => {
             }]
         };
 
-        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as any;
+        const result = truncateLargeTextInConversation(input, { textMaxTokens: 10000 }) as Tree;
 
         expect(result.messages[0].content[0].image.source.bytes._base64).toBe(largeBase64);
     });
 
     test('should not truncate retained OpenAI base64 image payloads before image stripping threshold', () => {
         const originalUrl = `data:image/png;base64,${'a'.repeat(50000)}`;
-        let conversation: any = {
+        let conversation: unknown = {
             messages: [{
                 role: 'user',
                 content: [{
@@ -777,16 +779,16 @@ describe('truncateLargeTextInConversation', () => {
         const retainedConversation = stripBase64ImagesFromConversation(conversation, {
             keepForTurns: 3,
             currentTurn,
-        }) as any;
+        }) as Tree;
 
-        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as any;
+        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as Tree;
 
         expect(result.messages[0].content[0].image_url.url).toBe(originalUrl);
     });
 
     test('should not truncate retained Gemini inlineData image payloads before image stripping threshold', () => {
         const originalData = 'b'.repeat(50000);
-        let conversation: any = {
+        let conversation: unknown = {
             contents: [{
                 role: 'user',
                 parts: [{
@@ -803,16 +805,16 @@ describe('truncateLargeTextInConversation', () => {
         const retainedConversation = stripBase64ImagesFromConversation(conversation, {
             keepForTurns: 3,
             currentTurn,
-        }) as any;
+        }) as Tree;
 
-        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as any;
+        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as Tree;
 
         expect(result.contents[0].parts[0].inlineData.data).toBe(originalData);
     });
 
     test('should not truncate retained Claude base64 image payloads before image stripping threshold', () => {
         const originalData = 'c'.repeat(50000);
-        let conversation: any = {
+        let conversation: unknown = {
             messages: [{
                 role: 'user',
                 content: [{
@@ -831,9 +833,9 @@ describe('truncateLargeTextInConversation', () => {
         const retainedConversation = stripBase64ImagesFromConversation(conversation, {
             keepForTurns: 3,
             currentTurn,
-        }) as any;
+        }) as Tree;
 
-        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as any;
+        const result = truncateLargeTextInConversation(retainedConversation, { textMaxTokens: 5000 }) as Tree;
 
         expect(result.messages[0].content[0].source.data).toBe(originalData);
     });
@@ -896,7 +898,7 @@ describe('conversation serialization safety', () => {
     });
 
     test('metadata should be preserved through serialization and stripping', () => {
-        let conversation: any = { messages: [] };
+        let conversation: unknown = { messages: [] };
         conversation = incrementConversationTurn(conversation);
         conversation = incrementConversationTurn(conversation);
 
@@ -930,7 +932,7 @@ describe('stripHeartbeatsFromConversation', () => {
             }]
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
         expect(result.messages[0].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
     });
 
@@ -946,7 +948,7 @@ describe('stripHeartbeatsFromConversation', () => {
         const result = stripHeartbeatsFromConversation(input, {
             keepForTurns: 3,
             currentTurn: 1,
-        }) as any;
+        }) as Tree;
 
         expect(result.messages[0].content[0].text).toBe(HEARTBEAT_MSG);
     });
@@ -962,7 +964,7 @@ describe('stripHeartbeatsFromConversation', () => {
         const result = stripHeartbeatsFromConversation(input, {
             keepForTurns: 1,
             currentTurn: 2,
-        }) as any;
+        }) as Tree;
 
         expect(result.messages[0].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
     });
@@ -973,7 +975,7 @@ describe('stripHeartbeatsFromConversation', () => {
         };
 
         // Default keepForTurns is 1, currentTurn 1 means strip
-        const result = stripHeartbeatsFromConversation(input, { currentTurn: 1 }) as any;
+        const result = stripHeartbeatsFromConversation(input, { currentTurn: 1 }) as Tree;
         expect(result.content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
     });
 
@@ -983,7 +985,7 @@ describe('stripHeartbeatsFromConversation', () => {
         };
 
         // Default keepForTurns is 1, currentTurn 0 means keep
-        const result = stripHeartbeatsFromConversation(input, { currentTurn: 0 }) as any;
+        const result = stripHeartbeatsFromConversation(input, { currentTurn: 0 }) as Tree;
         expect(result.content[0].text).toBe(HEARTBEAT_MSG);
     });
 
@@ -995,7 +997,7 @@ describe('stripHeartbeatsFromConversation', () => {
         const result = stripHeartbeatsFromConversation(input, {
             keepForTurns: Infinity,
             currentTurn: 100,
-        }) as any;
+        }) as Tree;
 
         expect(result.content[0].text).toBe(HEARTBEAT_MSG);
     });
@@ -1009,7 +1011,7 @@ describe('stripHeartbeatsFromConversation', () => {
             ]
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
 
         expect(result.messages[0].content[0].text).toBe('Hello, how are you?');
         expect(result.messages[1].content[0].text).toBe('[System] Some other system message');
@@ -1022,7 +1024,7 @@ describe('stripHeartbeatsFromConversation', () => {
             { role: 'assistant', content: [{ type: 'text', text: 'Acknowledged.' }] },
         ];
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any[];
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as unknown as Tree[];
 
         expect(result[0].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
         expect(result[1].content[0].text).toBe('Acknowledged.');
@@ -1036,7 +1038,7 @@ describe('stripHeartbeatsFromConversation', () => {
             ]
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
 
         expect(result.messages[0].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
         expect(result.messages[1].content[0].text).toBe('Acknowledged.');
@@ -1048,7 +1050,7 @@ describe('stripHeartbeatsFromConversation', () => {
             { role: 'model', parts: [{ text: 'Acknowledged.' }] },
         ];
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any[];
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as unknown as Tree[];
 
         expect(result[0].parts[0].text).toBe(HEARTBEAT_PLACEHOLDER);
         expect(result[1].parts[0].text).toBe('Acknowledged.');
@@ -1065,7 +1067,7 @@ describe('stripHeartbeatsFromConversation', () => {
             _llumiverse_meta: { turnNumber: 5 },
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
 
         expect(result._llumiverse_meta).toEqual({ turnNumber: 5 });
         expect(result.messages[0].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
@@ -1083,7 +1085,7 @@ describe('stripHeartbeatsFromConversation', () => {
             ]
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
 
         expect(result.messages[0].content[0].text).toBe('Analyze this data');
         expect(result.messages[1].content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
@@ -1094,7 +1096,7 @@ describe('stripHeartbeatsFromConversation', () => {
     });
 
     test('should use turn number from metadata when currentTurn not provided', () => {
-        let conversation: any = {
+        let conversation: unknown = {
             content: [{ text: HEARTBEAT_MSG }]
         };
 
@@ -1104,7 +1106,7 @@ describe('stripHeartbeatsFromConversation', () => {
         // keepForTurns 1, turn 2 from metadata → should strip
         const result = stripHeartbeatsFromConversation(conversation, {
             keepForTurns: 1,
-        }) as any;
+        }) as Tree;
 
         expect(result.content[0].text).toBe(HEARTBEAT_PLACEHOLDER);
     });
@@ -1118,7 +1120,7 @@ describe('stripHeartbeatsFromConversation', () => {
             ]
         };
 
-        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as any;
+        const result = stripHeartbeatsFromConversation(input, FORCE_STRIP_HB) as Tree;
 
         // None of these should be stripped - they don't have both opening and closing tags
         expect(result.content[0].text).toBe('<heartbeat>partial tag without close');

--- a/core/test/stream.test.ts
+++ b/core/test/stream.test.ts
@@ -13,7 +13,6 @@ function createStreamFromString(text: string): ReadableStream {
 }
 
 function createStreamFromChunks(chunks: string[]): ReadableStream {
-    let index = 0;
     return new ReadableStream({
         start(controller) {
             const encoder = new TextEncoder();

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -1,4 +1,3 @@
-import Ajv from 'ajv';
 import fs, { readFileSync } from 'fs';
 import { describe, expect, test } from "vitest";
 import { extractAndParseJSON, parseJSON } from "../src/json";
@@ -30,57 +29,55 @@ describe('Core Utilities', () => {
     });
 
     test('Validate JSON against schema', () => {
-        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false });
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('Validate JSON against complex schema', () => {
-        const ajv = new Ajv({ coerceTypes: true, allowDate: true, strict: false });
-        const schema = parseJSON(readDataFile('complex-schema.json')) as any;
+        const schema = parseJSON(readDataFile('complex-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('complex-document.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('Fail at validating JSON against schema', () => {
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-wrong.json')) }];
         expect(() => validateResult(content, schema)).toThrowError(ValidationError);
     });
 
     test('JSON parser should coerce types', () => {
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-wrong-types.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is empty string', () => {
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should validate if date is null', () => {
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-null.json')) }];
         const res = validateResult(content, schema);
         console.debug(res);
     });
 
     test('JSON parser should not validate if date is wrong', () => {
-        const schema = parseJSON(readDataFile('ciia-schema.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-wrong.json')) }];
         expect(() => validateResult(content, schema)).toThrowError(ValidationError);
         console.debug(content, schema);
     });
 
     test('JSON parser should not validate if date is required but null', () => {
-        const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as any;
+        const schema = parseJSON(readDataFile('ciia-schema-date-required.json')) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile('ciia-data-date-empty.json')) }];
         expect(() => validateResult(content, schema)).toThrowError(ValidationError);
         console.debug(content, schema);
@@ -91,7 +88,7 @@ describe('Core Utilities', () => {
 
     test.each(dataFiles)('Validate JSON against schema: %s', (dataFile) => {
         const base = dataFile.replace('.data.json', '');
-        const schema = parseJSON(readDataFile(`${base}.schema.json`)) as any;
+        const schema = parseJSON(readDataFile(`${base}.schema.json`)) as object;
         const content: JsonResult[] = [{ type: "json", value: parseJSON(readDataFile(dataFile)) }];
         const res = validateResult(content, schema);
         console.debug(res);

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -34,6 +34,7 @@
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": true,
     "noPropertyAccessFromIndexSignature": false,
+    "noImplicitAny": true,
   },
   "include": [
     "src"

--- a/core/tsconfig.test.json
+++ b/core/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "test"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -16,7 +16,7 @@
     "scripts": {
         "lint": "biome lint src",
         "test": "vitest run --retry 3",
-        "typecheck": "tsc -p tsconfig.test.json --noEmit",
+        "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
         "build": "pnpm exec tsmod build",
         "clean": "rimraf ./lib tsconfig.tsbuildinfo"
     },

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -16,6 +16,7 @@
     "scripts": {
         "lint": "biome lint src",
         "test": "vitest run --retry 3",
+        "typecheck": "tsc -p tsconfig.test.json --noEmit",
         "build": "pnpm exec tsmod build",
         "clean": "rimraf ./lib tsconfig.tsbuildinfo"
     },

--- a/drivers/src/adobe/firefly.ts
+++ b/drivers/src/adobe/firefly.ts
@@ -133,13 +133,17 @@ export class FireflyDriver extends AbstractDriver<FireflyDriverOptions> {
                 }))
             };
 
-        } catch (error: any) {
+        } catch (error: unknown) {
             this.logger.error({ error }, "[Firefly] Image generation failed");
+            const generationError = error instanceof Error ? error : new Error(String(error));
+            const errorCode = (error as { code?: unknown })?.code === 'content_policy_violation'
+                ? 'content_policy_violation'
+                : 'validation_error';
             return {
                 result: [],
                 error: {
-                    message: error.message,
-                    code: error.code || 'GENERATION_FAILED'
+                    message: generationError.message,
+                    code: errorCode
                 }
             };
         }

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -7,13 +7,20 @@ import { isUnexpected } from "@azure-rest/ai-inference";
 import { AIProjectClient, type DeploymentUnion, type ModelDeployment } from '@azure/ai-projects';
 import { createSseStream, type NodeJSReadableStream } from "@azure/core-sse";
 import { DefaultAzureCredential, getBearerTokenProvider, type TokenCredential } from "@azure/identity";
-import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, dataSourceToBase64, type DriverOptions, type EmbeddingResultItem, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, getModelCapabilities, type ImageEmbeddingInput, LlumiverseError, modelModalitiesToArray, normalizeEmbeddingsOptions, Providers, type TextEmbeddingInput } from "@llumiverse/core";
+import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, dataSourceToBase64, type DriverOptions, type EmbeddingResultItem, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, getModelCapabilities, type ImageEmbeddingInput, LlumiverseError, modelModalitiesToArray, normalizeEmbeddingsOptions, Providers, type TextEmbeddingInput, type TextFallbackOptions } from "@llumiverse/core";
 import type OpenAI from "openai";
 import { AzureOpenAIDriver } from "../openai/azure_openai.js";
 import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
+type SSEMessage = { data?: string };
+type ErrorWithStatus = Error & { status?: unknown };
+
+function hasNumericStatus(error: unknown): boolean {
+    return error instanceof Error && typeof (error as ErrorWithStatus).status === 'number';
+}
+
 export interface AzureFoundryDriverOptions extends DriverOptions {
     /**
      * The credentials to use to access Azure AI Foundry
@@ -104,7 +111,7 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
 
     async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {
         const { deploymentName } = parseAzureFoundryModelId(options.model);
-        const model_options = options.model_options as any;
+        const model_options = options.model_options as TextFallbackOptions | undefined;
         const isOpenAI = await this.isOpenAIDeployment(options.model);
 
         if (isOpenAI) {
@@ -144,7 +151,7 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
 
     async requestTextCompletionStream(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>> {
         const { deploymentName } = parseAzureFoundryModelId(options.model);
-        const model_options = options.model_options as any;
+        const model_options = options.model_options as TextFallbackOptions | undefined;
         const isOpenAI = await this.isOpenAIDeployment(options.model);
 
         if (isOpenAI) {
@@ -189,10 +196,10 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
         }
     }
 
-    private async *processStreamResponse(sseStream: any): AsyncIterable<CompletionChunkObject> {
+    private async *processStreamResponse(sseStream: AsyncIterable<SSEMessage>): AsyncIterable<CompletionChunkObject> {
         try {
             for await (const event of sseStream) {
-                if (event.data === "[DONE]") {
+                if (!event.data || event.data === "[DONE]") {
                     break;
                 }
 
@@ -364,7 +371,7 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
             });
         } catch (error) {
             if (LlumiverseError.isLlumiverseError(error)) throw error;
-            if (error instanceof Error && typeof (error as any).status !== 'number') throw error;
+            if (error instanceof Error && !hasNumericStatus(error)) throw error;
             this.logger.error({ error }, `Azure Foundry ${kind} embeddings error:`);
             throw this.formatLlumiverseError(error, {
                 provider: this.provider,
@@ -383,7 +390,7 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
     }
 
     async _listModels(filter?: (m: ModelDeployment) => boolean): Promise<AIModel[]> {
-        let deploymentsIterable;
+        let deploymentsIterable: ReturnType<typeof this.service.deployments.list>;
         try {
             // List all deployments in the Azure AI Foundry project
             deploymentsIterable = this.service.deployments.list();

--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -139,7 +139,7 @@ async function processFile<T extends FileProcessingMode>(
                     // ContentBlock doesn't support JSON, so treat as text
                     return { text: jsonContent } satisfies ContentBlock.TextMember;
                 }
-            } catch (error) {
+            } catch {
                 const textBlock = { text: jsonContent };
                 return mode === 'content'
                     ? (textBlock satisfies ContentBlock.TextMember)

--- a/drivers/src/bedrock/error-handling.test.ts
+++ b/drivers/src/bedrock/error-handling.test.ts
@@ -1,6 +1,17 @@
 import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { BedrockDriver } from './index.js';
+import { exposePrivate } from '../../test/__helpers__/test-utils.js';
+
+type BedrockDriverInternals = {
+    isBedrockErrorRetryable: (
+        errorName: string,
+        httpStatusCode: number | undefined,
+        fault: string | undefined,
+    ) => boolean | undefined;
+};
+
+type AwsErrorMetadata = { $metadata: { requestId?: string; httpStatusCode?: number } };
 
 describe('BedrockDriver Error Handling', () => {
     let driver: BedrockDriver;
@@ -298,7 +309,7 @@ describe('BedrockDriver Error Handling', () => {
             });
 
             expect(error.originalError).toBe(awsError);
-            expect((error.originalError as any).$metadata.requestId).toBe('test-123');
+            expect((error.originalError as AwsErrorMetadata).$metadata.requestId).toBe('test-123');
         });
     });
 
@@ -312,7 +323,7 @@ describe('BedrockDriver Error Handling', () => {
             ];
 
             retryableErrors.forEach((errorName) => {
-                const result = (driver as any).isBedrockErrorRetryable(errorName, undefined, undefined);
+                const result = exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable(errorName, undefined, undefined);
                 expect(result, `${errorName} should be retryable`).toBe(true);
             });
         });
@@ -328,25 +339,25 @@ describe('BedrockDriver Error Handling', () => {
             ];
 
             nonRetryableErrors.forEach((errorName) => {
-                const result = (driver as any).isBedrockErrorRetryable(errorName, undefined, undefined);
+                const result = exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable(errorName, undefined, undefined);
                 expect(result, `${errorName} should not be retryable`).toBe(false);
             });
         });
 
         it('should use HTTP status codes when available', () => {
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 429, undefined)).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 408, undefined)).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 529, undefined)).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 500, undefined)).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 503, undefined)).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 400, undefined)).toBe(false);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 403, undefined)).toBe(false);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', 404, undefined)).toBe(false);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 429, undefined)).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 408, undefined)).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 529, undefined)).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 500, undefined)).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 503, undefined)).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 400, undefined)).toBe(false);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 403, undefined)).toBe(false);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', 404, undefined)).toBe(false);
         });
 
         it('should use fault type as fallback', () => {
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', undefined, 'server')).toBe(true);
-            expect((driver as any).isBedrockErrorRetryable('UnknownError', undefined, 'client')).toBe(false);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', undefined, 'server')).toBe(true);
+            expect(exposePrivate<BedrockDriverInternals>(driver).isBedrockErrorRetryable('UnknownError', undefined, 'client')).toBe(false);
         });
     });
 });

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1337,7 +1337,6 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 };
 
                 aiModels.push(model);
-                this.validateConnection;
             });
         }
 
@@ -1410,7 +1409,6 @@ function jobInfo(job: GetModelCustomizationJobCommandOutput, jobId: string): Tra
         status = TrainingJobStatus.running;
         details = jobStatus;
     }
-    job.baseModelArn
     return {
         id: jobId,
         model: job.outputModelArn,

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -48,6 +48,21 @@ import {
 
 const supportStreamingCache = new LRUCache<string, boolean>(4096);
 
+type AwsSdkError = {
+    name?: string;
+    message?: string;
+    $metadata?: {
+        httpStatusCode?: number;
+        requestId?: string;
+    };
+    $fault?: string;
+};
+type ReasoningBlockStart = {
+    reasoningContent?: {
+        redactedContent?: Uint8Array;
+    };
+};
+
 enum BedrockModelType {
     FoundationModel = "foundation-model",
     InferenceProfile = "inference-profile",
@@ -180,7 +195,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         context: LlumiverseErrorContext
     ): LlumiverseError {
         // Check if it's an AWS SDK error with $metadata
-        const awsError = error as any;
+        const awsError = error as AwsSdkError;
         const hasMetadata = awsError?.$metadata !== undefined;
 
         if (!hasMetadata) {
@@ -364,7 +379,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         let reasoning: string = "";
         let stop_reason = "";
         let token_usage: ExecutionTokenUsage | undefined;
-        let tool_use: ToolUse[] | undefined;
+        let tool_use: ToolUse<unknown>[] | undefined;
 
         // Check if we should include thoughts (always true for reasoning-only models like DeepSeek R1)
         const isReasoningModel = options?.model?.includes('deepseek') && options?.model?.includes('r1');
@@ -379,10 +394,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 const id = toolUseStart.toolUseId ?? '';
                 const name = toolUseStart.name ?? '';
                 streamingToolBlocks?.set(blockIndex, { id, name });
-                tool_use = [{ id, tool_name: name, tool_input: '' as any }];
+                tool_use = [{ id, tool_name: name, tool_input: '' }];
             } else if (result.contentBlockStart.start && 'reasoningContent' in result.contentBlockStart.start && shouldIncludeThoughts) {
                 // Handle redacted content at block start
-                const reasoningStart = result.contentBlockStart.start as any;
+                const reasoningStart = result.contentBlockStart.start as ReasoningBlockStart;
                 if (reasoningStart.reasoningContent?.redactedContent) {
                     const redactedData = new TextDecoder().decode(reasoningStart.reasoningContent.redactedContent);
                     reasoning = `[Redacted thinking: ${redactedData}]`;
@@ -398,7 +413,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 const blockIndex = result.contentBlockDelta.contentBlockIndex ?? -1;
                 const toolBlock = streamingToolBlocks?.get(blockIndex);
                 if (toolBlock && delta.toolUse.input !== undefined) {
-                    tool_use = [{ id: toolBlock.id, tool_name: '', tool_input: delta.toolUse.input as any }];
+                    tool_use = [{ id: toolBlock.id, tool_name: '', tool_input: delta.toolUse.input }];
                 }
             } else if (delta?.text) {
                 output = delta.text;
@@ -417,7 +432,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             } else if (delta) {
                 // Get content block type
                 const type = Object.keys(delta).find(
-                    key => key !== '$unknown' && (delta as any)[key] !== undefined
+                    key => key !== '$unknown' && (delta as unknown as Record<string, unknown>)[key] !== undefined
                 );
                 this.logger.info({ type }, "[Bedrock] Unsupported content response type:");
             }
@@ -477,7 +492,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
     private async getCanStream(model: string, type: BedrockModelType): Promise<boolean> {
         let canStream: boolean = false;
-        let error: any = null;
+            let error: unknown = null;
         const region = this.extractRegion(model, this.options.region);
         if (type === BedrockModelType.FoundationModel || type === BedrockModelType.Unknown) {
             try {
@@ -569,8 +584,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     case 'image':
                         // Skip images in conversation - they're in the result
                         return '';
-                    default:
-                        return String((r as any).value || '');
+                    default: {
+                        const _exhaustive: never = r;
+                        return String(_exhaustive);
+                    }
                 }
             })
             .join('');
@@ -582,7 +599,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         let conversation = updateConversation(incomingConversation, conversePrompt);
 
         // Build assistant message content
-        const messageContent: any[] = [];
+        const messageContent: ContentBlock[] = [];
         if (textContent) {
             messageContent.push({ text: textContent });
         }
@@ -653,7 +670,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         // (DeepSeek R1 returns reasoning blocks but rejects them in subsequent user turns)
         const assistantMsg = res.output?.message ?? { content: [{ text: "" }], role: "assistant" };
         if (assistantMsg.content) {
-            assistantMsg.content = assistantMsg.content.filter((c: any) => !c.reasoningContent);
+            assistantMsg.content = assistantMsg.content.filter(c => !('reasoningContent' in c));
         }
 
         conversation = updateConversation(conversation, {
@@ -664,15 +681,15 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         // Increment turn counter for deferred stripping
         conversation = incrementConversationTurn(conversation) as ConverseRequest;
 
-        let tool_use: ToolUse[] | undefined = undefined;
+        let tool_use: ToolUse<unknown>[] | undefined = undefined;
         //Get tool requests, we check tool use regardless of finish reason, as you can hit length and still get a valid response.
-        tool_use = res.output?.message?.content?.reduce((tools: ToolUse[], c) => {
+        tool_use = res.output?.message?.content?.reduce((tools: ToolUse<unknown>[], c) => {
             if (c.toolUse) {
                 tools.push({
                     tool_name: c.toolUse.name ?? "",
-                    tool_input: c.toolUse.input as any,
+                    tool_input: c.toolUse.input,
                     id: c.toolUse.toolUseId ?? "",
-                } satisfies ToolUse);
+                } satisfies ToolUse<unknown>);
             }
             return tools;
         }, []);
@@ -757,7 +774,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             throw new Error("[Bedrock] Stream not found in response");
         }
 
-        return transformAsyncIterator(res.body, (chunk: any) => {
+        return transformAsyncIterator(res.body, (chunk) => {
             if (chunk.chunk?.bytes) {
                 const decoder = new TextDecoder();
                 const body = decoder.decode(chunk.chunk.bytes);
@@ -784,7 +801,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                         result: result.delta || result.message ? [{ type: "text" as const, value: result.delta || result.message || "" }] : [],
                         finish_reason: finishReason,
                     } satisfies CompletionChunkObject;
-                } catch (error) {
+                } catch {
                     // If JSON parsing fails, return empty chunk
                     return {
                         result: [],
@@ -837,7 +854,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     preparePayload(prompt: ConverseRequest, options: ExecutionOptions) {
         const model_options: TextFallbackOptions = options.model_options as TextFallbackOptions ?? { _option_id: "text-fallback" };
 
-        let additionalField = {};
+        let additionalField: Record<string, unknown> = {};
         let supportsJSONPrefill = false;
 
         // Resolve thinking, effort, and sampling restrictions using shared Claude helper
@@ -1015,7 +1032,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         if (Object.keys(cleanedAdditionalFields).length > 0) {
-            request.additionalModelRequestFields = cleanedAdditionalFields;
+            request.additionalModelRequestFields = cleanedAdditionalFields as unknown as ConverseRequest["additionalModelRequestFields"];
         }
 
         if (tool_defs?.length) {
@@ -1112,7 +1129,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         return {
             error: bedrockResult.error,
-            result: bedrockResult.images.map((image: any) => ({
+            result: bedrockResult.images.map((image: string) => ({
                 type: "image" as const,
                 value: image
             }))
@@ -1412,8 +1429,8 @@ function getToolDefinition(tool: ToolDefinition): Tool.ToolSpecMember {
             name: tool.name,
             description: tool.description,
             inputSchema: {
-                json: tool.input_schema as any,
-            }
+                json: tool.input_schema,
+            } as NonNullable<NonNullable<Tool.ToolSpecMember["toolSpec"]>["inputSchema"]>
         }
     }
 }
@@ -1469,8 +1486,8 @@ export function convertToolBlocksToText(messages: Message[]): Message[] {
                 const resultTexts: string[] = [];
                 if (toolResult.content) {
                     for (const c of toolResult.content) {
-                        if ((c as any).text) {
-                            const text = (c as any).text as string;
+                        if ('text' in c && typeof c.text === 'string') {
+                            const text = c.text;
                             resultTexts.push(text.length > 500 ? text.substring(0, 500) + '...' : text);
                         }
                     }
@@ -1492,16 +1509,16 @@ export function convertToolBlocksToText(messages: Message[]): Message[] {
  * AWS Bedrock's additionalModelRequestFields must be valid JSON, and undefined is not valid JSON.
  * Any unrecognized parameters will cause an exception.
  */
-function removeUndefinedValues<T extends Record<string, any>>(obj: T): Partial<T> {
+function removeUndefinedValues(obj: Record<string, unknown>): Record<string, unknown> {
     if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
         return obj;
     }
 
-    const cleaned: any = {};
+    const cleaned: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj)) {
         if (value !== undefined) {
             if (value !== null && typeof value === 'object' && !Array.isArray(value)) {
-                const cleanedNested = removeUndefinedValues(value);
+                const cleanedNested = removeUndefinedValues(value as Record<string, unknown>);
                 // Only include nested objects if they have properties after cleaning
                 if (Object.keys(cleanedNested).length > 0) {
                     cleaned[key] = cleanedNested;

--- a/drivers/src/bedrock/s3.ts
+++ b/drivers/src/bedrock/s3.ts
@@ -5,8 +5,8 @@ export async function doesBucketExist(s3: S3Client, bucketName: string): Promise
     try {
         await s3.send(new HeadBucketCommand({ Bucket: bucketName }));
         return true;
-    } catch (err: any) {
-        if (err.name === 'NotFound') {
+    } catch (err: unknown) {
+        if (err && typeof err === 'object' && (err as { name?: unknown }).name === 'NotFound') {
             return false;
         }
         throw err;
@@ -74,7 +74,7 @@ export function parseS3UrlToUri(s3Url: URL) {
         const hostname = url.hostname;
 
         // Parse the hostname to extract the bucket name
-        let bucketName;
+        let bucketName: string | undefined;
         if (hostname.endsWith('.amazonaws.com')) {
             if (hostname.includes('.s3.')) {
                 // Format: bucket-name.s3.region.amazonaws.com

--- a/drivers/src/bedrock/s3.ts
+++ b/drivers/src/bedrock/s3.ts
@@ -39,7 +39,7 @@ export async function uploadFile(s3: S3Client, source: ReadableStream, bucketNam
         }
     });
 
-    onProgress && upload.on("httpUploadProgress", onProgress);
+    if (onProgress) upload.on("httpUploadProgress", onProgress);
 
     const result = await upload.done();
     return result;

--- a/drivers/src/bedrock/streaming-tool-use.test.ts
+++ b/drivers/src/bedrock/streaming-tool-use.test.ts
@@ -12,7 +12,8 @@ import {
 } from '@llumiverse/common';
 import { AbstractDriver } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { BedrockDriver } from './index.js';
+import { BedrockDriver, BedrockPrompt } from './index.js';
+import type { Tree } from '../../test/__helpers__/test-utils.js';
 
 // ---------------------------------------------------------------------------
 // Unit tests: getExtractedStream tool use handling
@@ -154,9 +155,9 @@ describe('driver.stream() — Bedrock tool use accumulation', () => {
 
         // Simulate what the fixed getExtractedStream emits for one tool call
         driver.chunks = [
-            { result: [], tool_use: [{ id: 'tool-1', tool_name: 'do_thing', tool_input: '' as any }] },
-            { result: [], tool_use: [{ id: 'tool-1', tool_name: '', tool_input: '{"param"' as any }] },
-            { result: [], tool_use: [{ id: 'tool-1', tool_name: '', tool_input: ':"hello"}' as any }] },
+            { result: [], tool_use: [{ id: 'tool-1', tool_name: 'do_thing', tool_input: '' as unknown }] },
+            { result: [], tool_use: [{ id: 'tool-1', tool_name: '', tool_input: '{"param"' as unknown }] },
+            { result: [], tool_use: [{ id: 'tool-1', tool_name: '', tool_input: ':"hello"}' as unknown }] },
             { result: [], finish_reason: 'tool_use' },
         ];
 
@@ -177,10 +178,10 @@ describe('driver.stream() — Bedrock tool use accumulation', () => {
         const options: ExecutionOptions = { model: 'test-model' };
 
         driver.chunks = [
-            { result: [], tool_use: [{ id: 'id-a', tool_name: 'tool_a', tool_input: '' as any }] },
-            { result: [], tool_use: [{ id: 'id-b', tool_name: 'tool_b', tool_input: '' as any }] },
-            { result: [], tool_use: [{ id: 'id-a', tool_name: '', tool_input: '{"x":1}' as any }] },
-            { result: [], tool_use: [{ id: 'id-b', tool_name: '', tool_input: '{"y":2}' as any }] },
+            { result: [], tool_use: [{ id: 'id-a', tool_name: 'tool_a', tool_input: '' as unknown }] },
+            { result: [], tool_use: [{ id: 'id-b', tool_name: 'tool_b', tool_input: '' as unknown }] },
+            { result: [], tool_use: [{ id: 'id-a', tool_name: '', tool_input: '{"x":1}' as unknown }] },
+            { result: [], tool_use: [{ id: 'id-b', tool_name: '', tool_input: '{"y":2}' as unknown }] },
             { result: [], finish_reason: 'tool_use' },
         ];
 
@@ -198,8 +199,8 @@ describe('driver.stream() — Bedrock tool use accumulation', () => {
         const options: ExecutionOptions = { model: 'test-model' };
 
         driver.chunks = [
-            { result: [], tool_use: [{ id: 'trunc', tool_name: 'tool_c', tool_input: '' as any }] },
-            { result: [], tool_use: [{ id: 'trunc', tool_name: '', tool_input: '{"incomplete' as any }] },
+            { result: [], tool_use: [{ id: 'trunc', tool_name: 'tool_c', tool_input: '' as unknown }] },
+            { result: [], tool_use: [{ id: 'trunc', tool_name: '', tool_input: '{"incomplete' as unknown }] },
             { result: [], finish_reason: 'length' },
         ];
 
@@ -221,15 +222,15 @@ describe('BedrockDriver buildStreamingConversation', () => {
         };
 
         const conversation = driver.buildStreamingConversation(
-            prompt as any,
-            [{ type: 'text', value: 'Let me check.' }] as any,
+            prompt as unknown as BedrockPrompt,
+            [{ type: 'text', value: 'Let me check.' }],
             [{
                 id: 'tool-1',
                 tool_name: 'get_weather',
                 tool_input: { location: 'Paris' },
             }],
             { model: 'anthropic.claude-sonnet' } as ExecutionOptions
-        ) as any;
+        ) as unknown as Tree;
 
         expect(conversation.messages).toHaveLength(2);
         expect(conversation.messages[0]).toEqual(prompt.messages[0]);

--- a/drivers/src/bedrock/twelvelabs.ts
+++ b/drivers/src/bedrock/twelvelabs.ts
@@ -1,4 +1,4 @@
-import { type DataSource, type ExecutionOptions, readStreamAsBase64 } from "@llumiverse/core";
+import { type DataSource, type ExecutionOptions, type JSONSchema, readStreamAsBase64, type TextFallbackOptions } from "@llumiverse/core";
 import { type PromptSegment, PromptRole } from "@llumiverse/core";
 
 // TwelveLabs Pegasus Request/Response Types
@@ -9,7 +9,7 @@ export interface TwelvelabsPegasusRequest {
         type: "json_schema";
         json_schema: {
             name: string;
-            schema: any;
+            schema: JSONSchema;
         };
     };
     mediaSource: {
@@ -111,7 +111,7 @@ export async function formatTwelvelabsPegasusPrompt(
                 base64String
             };
         }
-    } catch (error) {
+    } catch {
         // If getting URL fails, use base64 encoding
         const stream = await videoFile.getStream();
         const base64String = await readStreamAsBase64(stream);
@@ -127,7 +127,7 @@ export async function formatTwelvelabsPegasusPrompt(
     };
 
     // Add optional parameters from model options
-    const modelOptions = options.model_options as any;
+    const modelOptions = options.model_options as TextFallbackOptions | undefined;
     if (modelOptions?.temperature !== undefined) {
         request.temperature = modelOptions.temperature;
     }

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -8,6 +8,15 @@ import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
+type GroqToolCallMessage = {
+    tool_calls?: Array<{
+        id: string;
+        function: {
+            name: string;
+            arguments?: string;
+        };
+    }>;
+};
 
 interface GroqDriverOptions extends DriverOptions {
     apiKey: string;
@@ -76,12 +85,12 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
         }));
     }
 
-    private extractToolUse(message: any): ToolUse[] | undefined {
+    private extractToolUse(message: GroqToolCallMessage): ToolUse<unknown>[] | undefined {
         if (!message.tool_calls || message.tool_calls.length === 0) {
             return undefined;
         }
 
-        return message.tool_calls.map((toolCall: any) => ({
+        return message.tool_calls.map((toolCall) => ({
             id: toolCall.id,
             tool_name: toolCall.function.name,
             tool_input: JSON.parse(toolCall.function.arguments || '{}'),
@@ -91,17 +100,20 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
     private sanitizeMessagesForGroq(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
         return messages.map(message => {
             // Remove any reasoning field from message objects
-            const { reasoning, ...sanitizedMessage } = message as any;
+            const sanitizedMessage = { ...(message as unknown as Record<string, unknown>) };
+            delete sanitizedMessage.reasoning;
 
             // If message has content array, filter out reasoning content types
-            if (Array.isArray(sanitizedMessage.content)) {
-                sanitizedMessage.content = sanitizedMessage.content.filter((part: any) => {
+            const content = sanitizedMessage.content;
+            if (Array.isArray(content)) {
+                sanitizedMessage.content = content.filter((part) => {
                     // Filter out any reasoning-related content parts
-                    return part.type !== 'reasoning' && !('reasoning' in part);
+                    const typedPart = part as { type?: string; reasoning?: unknown };
+                    return typedPart.type !== 'reasoning' && !('reasoning' in typedPart);
                 });
             }
 
-            return sanitizedMessage as ChatCompletionMessageParam;
+            return sanitizedMessage as unknown as ChatCompletionMessageParam;
         });
     }
 

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -40,7 +40,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     async getModelURLEndpoint(
         modelId: string
     ): Promise<{ url: string; status: string; }> {
-        const res = (await this.service.get(`/${modelId}`)) as HuggingFaceIEModel;
+        const res = await this.service.get<HuggingFaceIEModel>(`/${modelId}`);
         return {
             url: res.status.url,
             status: getStatus(res),
@@ -132,8 +132,8 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     // ============== management API ==============
 
     async listModels(): Promise<AIModel[]> {
-        const res = await this.service.get("/");
-        const hfModels = res.items as HuggingFaceIEModel[];
+        const res = await this.service.get<{ items: HuggingFaceIEModel[] }>("/");
+        const hfModels = res.items;
         if (!hfModels || !hfModels.length) return [];
 
         const models: AIModel[] = hfModels.map((model: HuggingFaceIEModel) => ({
@@ -151,7 +151,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
         try {
             await this.service.get("/models");
             return true;
-        } catch (error) {
+        } catch {
             return false;
         }
     }

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -40,7 +40,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     async getModelURLEndpoint(
         modelId: string
     ): Promise<{ url: string; status: string; }> {
-        const res = (await this.service.get(`/${modelId}`)) as HuggingFaceIEModel;
+        const res = await this.service.get<HuggingFaceIEModel>(`/${modelId}`);
         return {
             url: res.status.url,
             status: getStatus(res),
@@ -132,8 +132,8 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     // ============== management API ==============
 
     async listModels(): Promise<AIModel[]> {
-        const res = await this.service.get("/");
-        const hfModels = res.items as HuggingFaceIEModel[];
+        const res = await this.service.get<{ items: HuggingFaceIEModel[] }>("/");
+        const hfModels = res.items;
         if (!hfModels || !hfModels.length) return [];
 
         const models: AIModel[] = hfModels.map((model: HuggingFaceIEModel) => ({

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -40,7 +40,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     async getModelURLEndpoint(
         modelId: string
     ): Promise<{ url: string; status: string; }> {
-        const res = await this.service.get<HuggingFaceIEModel>(`/${modelId}`);
+        const res = (await this.service.get(`/${modelId}`)) as HuggingFaceIEModel;
         return {
             url: res.status.url,
             status: getStatus(res),
@@ -132,8 +132,8 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     // ============== management API ==============
 
     async listModels(): Promise<AIModel[]> {
-        const res = await this.service.get<{ items: HuggingFaceIEModel[] }>("/");
-        const hfModels = res.items;
+        const res = await this.service.get("/");
+        const hfModels = res.items as HuggingFaceIEModel[];
         if (!hfModels || !hfModels.length) return [];
 
         const models: AIModel[] = hfModels.map((model: HuggingFaceIEModel) => ({

--- a/drivers/src/huggingface_ie.ts
+++ b/drivers/src/huggingface_ie.ts
@@ -40,7 +40,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     async getModelURLEndpoint(
         modelId: string
     ): Promise<{ url: string; status: string; }> {
-        const res = await this.service.get<HuggingFaceIEModel>(`/${modelId}`);
+        const res = await this.service.get(`/${modelId}`) as HuggingFaceIEModel;
         return {
             url: res.status.url,
             status: getStatus(res),
@@ -132,7 +132,7 @@ export class HuggingFaceIEDriver extends AbstractDriver<HuggingFaceIEDriverOptio
     // ============== management API ==============
 
     async listModels(): Promise<AIModel[]> {
-        const res = await this.service.get<{ items: HuggingFaceIEModel[] }>("/");
+        const res = await this.service.get("/") as { items: HuggingFaceIEModel[] };
         const hfModels = res.items;
         if (!hfModels || !hfModels.length) return [];
 

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,9 +1,9 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, MISTRAL_DEFAULT_EMBEDDING_MODEL, normalizeEmbeddingsOptions, type PromptSegment, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { getJSONSafetyNotice } from "@llumiverse/core/formatters";
-import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
+import { FetchClient } from "@vertesia/api-fetch-client";
 import { formatOpenAILikeTextPrompt, type OpenAITextMessage } from "../openai/openai_format.js";
-import type { ChatCompletionResponse, CompletionRequestParams, EmbeddingResponse, ListModelsResponse, ResponseFormat } from "./types.js";
+import type { ChatCompletionResponse, CompletionRequestParams, ListModelsResponse, ResponseFormat } from "./types.js";
 
 //TODO retry on 429
 //const RETRY_STATUS_CODES = [429, 500, 502, 503, 504];
@@ -114,7 +114,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
         this.logger.debug({ payload: JSON.stringify(streamPayload) }, "Mistral stream request payload");
 
-        const stream = await this.client.post<ReadableStream<ServerSentEvent>>('/v1/chat/completions', {
+        const stream = await this.client.post('/v1/chat/completions', {
             payload: streamPayload,
             reader: 'sse'
         });
@@ -166,7 +166,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
 
         try {
-            const r = await this.client.post<EmbeddingResponse>('/v1/embeddings', {
+            const r = await this.client.post('/v1/embeddings', {
                 payload: {
                     model,
                     input: texts,

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -114,10 +114,10 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
         this.logger.debug({ payload: JSON.stringify(streamPayload) }, "Mistral stream request payload");
 
-        const stream = await this.client.post<ReadableStream<ServerSentEvent>>('/v1/chat/completions', {
+        const stream = await this.client.post('/v1/chat/completions', {
             payload: streamPayload,
             reader: 'sse'
-        });
+        }) as ReadableStream<ServerSentEvent>;
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);
@@ -166,13 +166,13 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
 
         try {
-            const r = await this.client.post<EmbeddingResponse>('/v1/embeddings', {
+            const r = await this.client.post('/v1/embeddings', {
                 payload: {
                     model,
                     input: texts,
                     encoding_format: "float",
                 },
-            });
+            }) as EmbeddingResponse;
             const ordered: { index: number; embedding: number[] }[] = [...r.data].sort((a, b) => a.index - b.index);
             const promptTokens: number | undefined = r.usage?.total_tokens
                 ?? (r.usage ? (r.usage.prompt_tokens ?? 0) + (r.usage.completion_tokens ?? 0) : undefined);

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,9 +1,9 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, MISTRAL_DEFAULT_EMBEDDING_MODEL, normalizeEmbeddingsOptions, type PromptSegment, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { getJSONSafetyNotice } from "@llumiverse/core/formatters";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import { formatOpenAILikeTextPrompt, type OpenAITextMessage } from "../openai/openai_format.js";
-import type { ChatCompletionResponse, CompletionRequestParams, ListModelsResponse, ResponseFormat } from "./types.js";
+import type { ChatCompletionResponse, CompletionRequestParams, EmbeddingResponse, ListModelsResponse, ResponseFormat } from "./types.js";
 
 //TODO retry on 429
 //const RETRY_STATUS_CODES = [429, 500, 502, 503, 504];
@@ -114,7 +114,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
         this.logger.debug({ payload: JSON.stringify(streamPayload) }, "Mistral stream request payload");
 
-        const stream = await this.client.post('/v1/chat/completions', {
+        const stream = await this.client.post<ReadableStream<ServerSentEvent>>('/v1/chat/completions', {
             payload: streamPayload,
             reader: 'sse'
         });
@@ -166,7 +166,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
 
         try {
-            const r = await this.client.post('/v1/embeddings', {
+            const r = await this.client.post<EmbeddingResponse>('/v1/embeddings', {
                 payload: {
                     model,
                     input: texts,

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -1,9 +1,9 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, MISTRAL_DEFAULT_EMBEDDING_MODEL, normalizeEmbeddingsOptions, type PromptSegment, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
 import { getJSONSafetyNotice } from "@llumiverse/core/formatters";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import { formatOpenAILikeTextPrompt, type OpenAITextMessage } from "../openai/openai_format.js";
-import type { ChatCompletionResponse, CompletionRequestParams, ListModelsResponse, ResponseFormat } from "./types.js";
+import type { ChatCompletionResponse, CompletionRequestParams, EmbeddingResponse, ListModelsResponse, ResponseFormat } from "./types.js";
 
 //TODO retry on 429
 //const RETRY_STATUS_CODES = [429, 500, 502, 503, 504];
@@ -114,7 +114,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
         this.logger.debug({ payload: JSON.stringify(streamPayload) }, "Mistral stream request payload");
 
-        const stream = await this.client.post('/v1/chat/completions', {
+        const stream = await this.client.post<ReadableStream<ServerSentEvent>>('/v1/chat/completions', {
             payload: streamPayload,
             reader: 'sse'
         });
@@ -166,7 +166,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
         });
 
         try {
-            const r = await this.client.post('/v1/embeddings', {
+            const r = await this.client.post<EmbeddingResponse>('/v1/embeddings', {
                 payload: {
                     model,
                     input: texts,
@@ -188,7 +188,7 @@ export class MistralAIDriver extends AbstractDriver<MistralAIDriverOptions, Open
             };
         } catch (error) {
             if (LlumiverseError.isLlumiverseError(error)) throw error;
-            if (error instanceof Error && typeof (error as any).status !== 'number') throw error;
+            if (error instanceof Error && typeof (error as { status?: unknown }).status !== 'number') throw error;
             throw this.formatLlumiverseError(error, {
                 provider: this.provider,
                 model,

--- a/drivers/src/mistral/types.ts
+++ b/drivers/src/mistral/types.ts
@@ -112,6 +112,7 @@ export interface ChatCompletionResponseChunk {
 export interface Embedding {
     id: string;
     object: 'embedding';
+    index: number;
     embedding: number[];
 }
 

--- a/drivers/src/openai/azure_openai.ts
+++ b/drivers/src/openai/azure_openai.ts
@@ -8,7 +8,7 @@ export interface AzureOpenAIDriverOptions extends DriverOptions {
     /**
      * The credentials to use to access Azure OpenAI
      */
-    azureADTokenProvider?: any; //type with azure credentials
+    azureADTokenProvider?: (options?: unknown) => Promise<string>;
 
     apiKey?: string;
 

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { BaseOpenAIDriver } from './index.js';
-import { LlumiverseError, LlumiverseErrorContext, Providers } from '@llumiverse/core';
+import { LlumiverseError, Providers } from '@llumiverse/core';
 import OpenAI from 'openai';
 import {
     APIError,
@@ -16,8 +16,17 @@ import {
     APIConnectionTimeoutError,
     LengthFinishReasonError,
     ContentFilterFinishReasonError,
-    OpenAIError,
 } from 'openai/error';
+import { exposePrivate, getProp } from '../../test/__helpers__/test-utils.js';
+
+type BaseOpenAIDriverInternals = {
+    isOpenAIErrorRetryable: (
+        error: unknown,
+        httpStatusCode: number | undefined,
+        errorCode: string | null | undefined,
+        errorType: string | undefined,
+    ) => boolean | undefined;
+};
 
 // Test implementation of BaseOpenAIDriver
 class TestOpenAIDriver extends BaseOpenAIDriver {
@@ -385,7 +394,7 @@ describe('BaseOpenAIDriver Error Handling', () => {
             ];
 
             for (const error of retryableErrors) {
-                const result = (driver as any).isOpenAIErrorRetryable(error, error.status, null, undefined);
+                const result = exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(error, error.status, null, undefined);
                 expect(result, `${error.constructor.name} should be retryable`).toBe(true);
             }
         });
@@ -403,83 +412,83 @@ describe('BaseOpenAIDriver Error Handling', () => {
             ];
 
             for (const error of nonRetryableErrors) {
-                const status = 'status' in error ? (error as any).status : undefined;
-                const result = (driver as any).isOpenAIErrorRetryable(error, status, null, undefined);
+                const status = getProp<number>(error, 'status');
+                const result = exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(error, status, null, undefined);
                 expect(result, `${error.constructor.name} should not be retryable`).toBe(false);
             }
         });
 
         it('should classify retryable error codes correctly', () => {
-            const apiError = new APIError(undefined as any, {}, 'Error', new Headers());
+            const apiError = new APIError(undefined, {}, 'Error', new Headers());
             
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'timeout', undefined)).toBe(true);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'server_error', undefined)).toBe(true);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'service_unavailable', undefined)).toBe(true);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'rate_limit_exceeded', undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'timeout', undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'server_error', undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'service_unavailable', undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'rate_limit_exceeded', undefined)).toBe(true);
         });
 
         it('should classify non-retryable error codes correctly', () => {
-            const apiError = new APIError(undefined as any, {}, 'Error', new Headers());
+            const apiError = new APIError(undefined, {}, 'Error', new Headers());
             
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'invalid_api_key', undefined)).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'invalid_request_error', undefined)).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'model_not_found', undefined)).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'insufficient_quota', undefined)).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'invalid_model', undefined)).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, 'invalid_parameter', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'invalid_api_key', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'invalid_request_error', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'model_not_found', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'insufficient_quota', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'invalid_model', undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, 'invalid_parameter', undefined)).toBe(false);
         });
 
         it('should classify error types correctly', () => {
-            const apiError = new APIError(undefined as any, {}, 'Error', new Headers());
+            const apiError = new APIError(undefined, {}, 'Error', new Headers());
             
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, null, 'invalid_request_error')).toBe(false);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, null, 'authentication_error')).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, null, 'invalid_request_error')).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, null, 'authentication_error')).toBe(false);
         });
 
         it('should use HTTP status codes when available', () => {
             const apiError = new APIError(429, {}, 'Too many requests', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError, 429, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, 429, null, undefined)).toBe(true);
             
             const apiError2 = new APIError(408, {}, 'Request timeout', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError2, 408, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError2, 408, null, undefined)).toBe(true);
             
             const apiError3 = new APIError(502, {}, 'Bad gateway', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError3, 502, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError3, 502, null, undefined)).toBe(true);
             
             const apiError4 = new APIError(503, {}, 'Service unavailable', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError4, 503, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError4, 503, null, undefined)).toBe(true);
             
             const apiError5 = new APIError(504, {}, 'Gateway timeout', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError5, 504, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError5, 504, null, undefined)).toBe(true);
             
             const apiError6 = new APIError(529, {}, 'Overloaded', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError6, 529, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError6, 529, null, undefined)).toBe(true);
         });
 
         it('should classify 4xx as non-retryable', () => {
             const apiError = new APIError(400, {}, 'Bad request', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError, 400, null, undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, 400, null, undefined)).toBe(false);
             
             const apiError2 = new APIError(403, {}, 'Forbidden', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError2, 403, null, undefined)).toBe(false);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError2, 403, null, undefined)).toBe(false);
         });
 
         it('should classify 5xx as retryable', () => {
             const apiError = new APIError(500, {}, 'Internal error', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError, 500, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, 500, null, undefined)).toBe(true);
             
             const apiError2 = new APIError(502, {}, 'Bad gateway', new Headers());
-            expect((driver as any).isOpenAIErrorRetryable(apiError2, 502, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError2, 502, null, undefined)).toBe(true);
         });
 
         it('should classify APIConnectionError (non-timeout) as retryable', () => {
             const connectionError = new APIConnectionError({ message: 'Network failure' });
-            expect((driver as any).isOpenAIErrorRetryable(connectionError, undefined, null, undefined)).toBe(true);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(connectionError, undefined, null, undefined)).toBe(true);
         });
 
         it('should return undefined for unknown errors', () => {
-            const apiError = new APIError(undefined as any, {}, 'Unknown error', undefined as any);
-            expect((driver as any).isOpenAIErrorRetryable(apiError, undefined, null, undefined)).toBeUndefined();
+            const apiError = new APIError(undefined, {}, 'Unknown error', undefined);
+            expect(exposePrivate<BaseOpenAIDriverInternals>(driver).isOpenAIErrorRetryable(apiError, undefined, null, undefined)).toBeUndefined();
         });
     });
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -33,6 +33,7 @@ import {
     TrainingJobStatus,
     type TrainingOptions,
     type TrainingPromptOptions,
+    type TextFallbackOptions,
     truncateLargeTextInConversation,
     unwrapConversationArray,
 } from "@llumiverse/core";
@@ -59,10 +60,28 @@ import { formatOpenAILikeMultimodalPrompt } from "./openai_format.js";
 // Response API types
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
+type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
+    image_detail?: "low" | "high" | "auto";
+    effort?: string;
+    reasoning_effort?: string;
+};
+type OpenAIErrorWithStatus = Error & { status?: unknown };
+type MutableRoleItem = { role: "user" | "developer" | "system" | "assistant" };
+type MutableInputImagePart = { type: string; detail?: string };
+type OpenAIFunctionItem = ResponseInputItem & {
+    type?: string;
+    name?: string;
+    arguments?: string;
+    output?: string;
+};
 
 // Helper function to convert string to CompletionResult[]
 function textToCompletionResult(text: string): CompletionResult[] {
     return text ? [{ type: "text", value: text }] : [];
+}
+
+function hasNumericStatus(error: unknown): boolean {
+    return error instanceof Error && typeof (error as OpenAIErrorWithStatus).status === 'number';
 }
 
 function isOpenAIReasoningModel(model: string): boolean {
@@ -158,7 +177,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
 
         convertRoles(prompt, options.model);
 
-        const model_options = options.model_options as any;
+        const model_options = options.model_options as OpenAIRequestOptions | undefined;
         insert_image_detail(prompt, model_options?.image_detail ?? "auto");
 
         let parsedSchema: JSONSchema | undefined = undefined;
@@ -168,7 +187,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
                 parsedSchema = openAISchemaFormat(options.result_schema);
                 strictMode = true;
             }
-            catch (e) {
+            catch {
                 parsedSchema = limitedSchemaFormat(options.result_schema);
                 strictMode = false;
             }
@@ -209,7 +228,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
 
         convertRoles(prompt, options.model);
 
-        const model_options = options.model_options as any;
+        const model_options = options.model_options as OpenAIRequestOptions | undefined;
         insert_image_detail(prompt, model_options?.image_detail ?? "auto");
 
         const toolDefs = getToolDefinitions(options.tools);
@@ -231,7 +250,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
                 parsedSchema = openAISchemaFormat(options.result_schema);
                 strictMode = true;
             }
-            catch (e) {
+            catch {
                 parsedSchema = limitedSchemaFormat(options.result_schema);
                 strictMode = false;
             }
@@ -409,7 +428,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
         try {
             await this.service.models.list();
             return true;
-        } catch (error) {
+        } catch {
             return false;
         }
     }
@@ -503,7 +522,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
             return { model, results: items, usage };
         } catch (error) {
             if (LlumiverseError.isLlumiverseError(error)) throw error;
-            if (error instanceof Error && typeof (error as any).status !== 'number') throw error;
+            if (error instanceof Error && !hasNumericStatus(error)) throw error;
             throw this.formatLlumiverseError(error, {
                 provider: this.provider,
                 model,
@@ -602,13 +621,17 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
                 result: results
             };
 
-        } catch (error: any) {
+        } catch (error: unknown) {
             this.logger.error({ error }, `[${this.provider}] Image generation failed`);
+            const generationError = error instanceof Error ? error : new Error(String(error));
+            const errorCode = (error as { code?: unknown })?.code === 'content_policy_violation'
+                ? 'content_policy_violation'
+                : 'validation_error';
             return {
                 result: [],
                 error: {
-                    message: error.message,
-                    code: error.code || 'GENERATION_FAILED'
+                    message: generationError.message,
+                    code: errorCode
                 }
             };
         }
@@ -867,8 +890,10 @@ function completionResultsToText(completionResults: CompletionResult[] | undefin
                 case 'image':
                     // Skip images in conversation - they're in the result
                     return '';
-                default:
-                    return String((r as any).value || '');
+                default: {
+                    const _exhaustive: never = r;
+                    return String(_exhaustive);
+                }
             }
         })
         .join('');
@@ -921,11 +946,11 @@ export function mapResponseStream(stream: AsyncIterable<OpenAI.Responses.Respons
                     if (event.item.call_id) {
                         toolCallMetadata.set(event.item.call_id, metadata);
                     }
-                    const toolUse: ToolUse & { _actual_id?: string } = {
+                    const toolUse: ToolUse<unknown> & { _actual_id?: string } = {
                         id: syntheticId,
                         _actual_id: callId,
                         tool_name: event.item.name,
-                        tool_input: '' as any,
+                        tool_input: '',
                     };
                     yield {
                         result: [],
@@ -935,11 +960,11 @@ export function mapResponseStream(stream: AsyncIterable<OpenAI.Responses.Respons
                     const metadata = toolCallMetadata.get(event.item_id);
                     const syntheticId = metadata?.syntheticId ?? `tool_${event.output_index}`;
                     const callId = metadata?.callId ?? event.item_id;
-                    const toolUse: ToolUse & { _actual_id?: string } = {
+                    const toolUse: ToolUse<unknown> & { _actual_id?: string } = {
                         id: syntheticId,
                         _actual_id: callId,
                         tool_name: metadata?.name ?? '',
-                        tool_input: event.delta as any,
+                        tool_input: event.delta,
                     };
                     yield {
                         result: [],
@@ -986,7 +1011,7 @@ function insert_image_detail(items: ResponseInputItem[], detail_level: string): 
                 if (Array.isArray(content)) {
                     for (const part of content) {
                         if (typeof part === 'object' && part.type === 'input_image') {
-                            (part as any).detail = detail_level;
+                            (part as MutableInputImagePart).detail = detail_level;
                         }
                     }
                 }
@@ -1003,14 +1028,14 @@ function convertRoles(items: ResponseInputItem[], model: string): ResponseInputI
             //o1-mini and o1-preview support neither system nor developer
             for (const item of items) {
                 if ('role' in item && (item as EasyInputMessage).role === 'system') {
-                    (item as any).role = 'user';
+                    (item as MutableRoleItem).role = 'user';
                 }
             }
         } else {
             //Models newer than o1 use developer role
             for (const item of items) {
                 if ('role' in item && (item as EasyInputMessage).role === 'system') {
-                    (item as any).role = 'developer';
+                    (item as MutableRoleItem).role = 'developer';
                 }
             }
         }
@@ -1035,13 +1060,13 @@ function supportsSchema(model: string): boolean {
  */
 export function convertOpenAIFunctionItemsToText(items: ResponseInputItem[]): ResponseInputItem[] {
     const hasFunctionItems = items.some(item => {
-        const type = (item as any).type;
+        const type = (item as OpenAIFunctionItem).type;
         return type === 'function_call' || type === 'function_call_output';
     });
     if (!hasFunctionItems) return items;
 
     return items.map(item => {
-        const typed = item as any;
+        const typed = item as OpenAIFunctionItem;
         if (typed.type === 'function_call') {
             const argsStr = typed.arguments || '';
             const truncated = argsStr.length > 500 ? argsStr.substring(0, 500) + '...' : argsStr;
@@ -1074,7 +1099,7 @@ function getToolDefinition(toolDef: ToolDefinition): OpenAI.Responses.FunctionTo
             parsedSchema = openAISchemaFormat(toolDef.input_schema as JSONSchema);
             strictMode = true;
         }
-        catch (e) {
+        catch {
             //TODO: type assertion here is not safe, does not work with satisfies
             parsedSchema = limitedSchemaFormat(toolDef.input_schema as JSONSchema);
             strictMode = false;
@@ -1105,12 +1130,12 @@ function updateConversation(conversation: unknown, items: ResponseInputItem[]): 
     return [...convArray, ...items];
 }
 
-export function collectTools(output?: OpenAI.Responses.ResponseOutputItem[]): ToolUse[] | undefined {
+export function collectTools(output?: OpenAI.Responses.ResponseOutputItem[]): ToolUse<unknown>[] | undefined {
     if (!output) {
         return undefined;
     }
 
-    const tools: ToolUse[] = [];
+    const tools: ToolUse<unknown>[] = [];
     for (const item of output) {
         if (item.type === 'function_call') {
             const id = item.call_id || item.id;
@@ -1166,7 +1191,7 @@ function extractCompletionResults(output?: OpenAI.Responses.ResponseOutputItem[]
 
 //For strict mode false
 function limitedSchemaFormat(schema: JSONSchema): JSONSchema {
-    const formattedSchema = { ...schema };
+    const formattedSchema: JSONSchema = { ...schema };
 
     // Defaults not supported
     delete formattedSchema.default;
@@ -1210,7 +1235,7 @@ function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSONSchema
         throw new Error("OpenAI schema nesting too deep");
     }
 
-    const formattedSchema = { ...schema };
+    const formattedSchema: JSONSchema = { ...schema };
 
     // Defaults not supported
     delete formattedSchema.default;
@@ -1254,7 +1279,7 @@ function openAISchemaFormat(schema: JSONSchema, nesting: number = 0): JSONSchema
     return formattedSchema
 }
 
-function responseFinishReason(response: OpenAI.Responses.Response, tools?: ToolUse[] | undefined): string | undefined {
+function responseFinishReason(response: OpenAI.Responses.Response, tools?: ToolUse<unknown>[] | undefined): string | undefined {
     if (tools && tools.length > 0) {
         return "tool_use";
     }
@@ -1335,7 +1360,7 @@ export function fixOrphanedToolUse(items: ResponseInputItem[]): ResponseInputIte
     return result;
 }
 
-function safeJsonParse(value: unknown): any {
+function safeJsonParse(value: unknown): unknown {
     if (typeof value !== 'string') {
         return value;
     }

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -90,7 +90,7 @@ export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[]
                         if (typeof sysMsg.content === 'string') {
                             sysMsg.content = "TOOL: " + sysMsg.content;
                         } else if (Array.isArray(sysMsg.content)) {
-                            sysMsg.content.forEach((c: any) => {
+                            sysMsg.content.forEach((c) => {
                                 if (c.type === "input_text") c.text = "TOOL: " + c.text;
                             });
                         }
@@ -106,7 +106,7 @@ export async function formatOpenAILikeMultimodalPrompt(segments: PromptSegment[]
             };
 
             if (Array.isArray(safetyMsg.content)) {
-                safetyMsg.content.forEach((c: any) => {
+                safetyMsg.content.forEach((c) => {
                     if (c.type === "input_text") c.text = "DO NOT IGNORE - IMPORTANT: " + c.text;
                 });
             }

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -19,6 +19,22 @@ import Replicate, { Prediction, Training } from "replicate";
 
 let cachedTrainableModels: AIModel[] | undefined;
 let cachedTrainableModelsTimestamp: number = 0;
+type ReplicateEvent = { data: string };
+type ReplicateModelVersion = {
+    id: string;
+    cog_version: string;
+};
+type ReplicateVersionsResponse = {
+    results?: ReplicateModelVersion[];
+};
+type ReplicateSearchModel = {
+    name: string;
+    username: string;
+    description?: string;
+};
+type ReplicateSearchResponse = {
+    models: ReplicateSearchModel[];
+};
 
 const supportFineTunning = new Set([
     "meta/llama-2-70b-chat",
@@ -87,14 +103,14 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         const stream = new EventStream<CompletionChunkObject>();
 
         const source = new EventSource(prediction.urls.stream!);
-        source.addEventListener("output", (e: any) => {
+        source.addEventListener("output", (e: ReplicateEvent) => {
             stream.push({ result: [{ type: "text", value: e.data }] });
         });
-        source.addEventListener("error", (e: any) => {
-            let error: any;
+        source.addEventListener("error", (e: ReplicateEvent) => {
+            let error: unknown;
             try {
                 error = JSON.parse(e.data);
-            } catch (error) {
+            } catch {
                 error = JSON.stringify(e);
             }
             this.logger.error({ e, error }, "Error in SSE stream");
@@ -149,7 +165,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         }
         const { owner, model, version } = ReplicateDriver.parseModelId(options.model);
         const job = await this.service.trainings.create(owner, model, version, {
-            destination: options.name as any,
+            destination: options.name as `${string}/${string}`,
             input: {
                 train_data: await dataset.getURL(),
             },
@@ -185,7 +201,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         try {
             await this.service.predictions.list();
             return true;
-        } catch (error) {
+        } catch {
             return false;
         }
     }
@@ -236,11 +252,12 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
             this.service.models.versions.list(owner, model),
         ]);
 
-        if (!rModel || !versions || (versions as any).results?.length === 0) {
+        const versionResults = (versions as ReplicateVersionsResponse).results ?? [];
+        if (!rModel || !versions || versionResults.length === 0) {
             throw new Error("Model not found or no versions available");
         }
 
-        const models: AIModel[] = (versions as any).results.map((v: any) => {
+        const models: AIModel[] = versionResults.map((v) => {
             const fullName = rModel.owner + '/' + rModel.name;
             return {
                 id: fullName + ':' + v.id,
@@ -267,9 +284,9 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
             },
         });
 
-        const rModels = ((await res.json()) as any).models;
+        const rModels = ((await res.json()) as ReplicateSearchResponse).models;
 
-        const models: AIModel[] = rModels.map((v: any) => {
+        const models: AIModel[] = rModels.map((v) => {
             return {
                 id: v.name,
                 name: v.name,
@@ -298,7 +315,7 @@ function jobInfo(job: Prediction | Training, modelName?: string): TrainingJob {
         status = TrainingJobStatus.succeeded;
     } else if (jobStatus === 'failed') {
         status = TrainingJobStatus.failed;
-        const error = job.error as any;
+        const error = job.error as unknown;
         if (typeof error === 'string') {
             details = error;
         } else {

--- a/drivers/src/test-driver/utils.ts
+++ b/drivers/src/test-driver/utils.ts
@@ -1,8 +1,8 @@
 import { ExecutionResponse, PromptSegment } from "@llumiverse/core";
 
 export function throwError(message: string, prompt: PromptSegment[]): never {
-    const err = new Error(message);
-    (err as any).prompt = prompt;
+    const err = new Error(message) as Error & { prompt?: PromptSegment[] };
+    err.prompt = prompt;
     throw err;
 }
 

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import type { TextCompletion, TogetherModelInfo } from "./interfaces.js";
 
 interface TogetherAIDriverOptions extends DriverOptions {
@@ -21,7 +21,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         });
     }
 
-    getResponseFormat = (options: ExecutionOptions): { type: string; schema: any } | undefined => {
+    getResponseFormat = (options: ExecutionOptions): { type: string; schema: unknown } | undefined => {
         return options.result_schema ?
             {
                 type: "json_object",
@@ -78,7 +78,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         options.model_options = options.model_options as TextFallbackOptions;
 
         const stop_seq = options.model_options?.stop_sequence ?? [];
-        const stream = await this.fetchClient.post('/v1/completions', {
+        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>('/v1/completions', {
             payload: {
                 model: options.model,
                 prompt: prompt,

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
+import { FetchClient } from "@vertesia/api-fetch-client";
 import type { TextCompletion, TogetherModelInfo } from "./interfaces.js";
 
 interface TogetherAIDriverOptions extends DriverOptions {
@@ -78,7 +78,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         options.model_options = options.model_options as TextFallbackOptions;
 
         const stop_seq = options.model_options?.stop_sequence ?? [];
-        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>('/v1/completions', {
+        const stream = await this.fetchClient.post('/v1/completions', {
             payload: {
                 model: options.model,
                 prompt: prompt,

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -78,7 +78,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         options.model_options = options.model_options as TextFallbackOptions;
 
         const stop_seq = options.model_options?.stop_sequence ?? [];
-        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>('/v1/completions', {
+        const stream = await this.fetchClient.post('/v1/completions', {
             payload: {
                 model: options.model,
                 prompt: prompt,
@@ -98,7 +98,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
                 ],
             },
             reader: 'sse'
-        })
+        }) as ReadableStream<ServerSentEvent>;
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data);

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, type TextFallbackOptions } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import type { TextCompletion, TogetherModelInfo } from "./interfaces.js";
 
 interface TogetherAIDriverOptions extends DriverOptions {
@@ -78,7 +78,7 @@ export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, st
         options.model_options = options.model_options as TextFallbackOptions;
 
         const stop_seq = options.model_options?.stop_sequence ?? [];
-        const stream = await this.fetchClient.post('/v1/completions', {
+        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>('/v1/completions', {
             payload: {
                 model: options.model,
                 prompt: prompt,

--- a/drivers/src/togetherai/interfaces.ts
+++ b/drivers/src/togetherai/interfaces.ts
@@ -1,5 +1,5 @@
 interface ModelInstanceConfig {
-    appearsIn: any[];
+    appearsIn: unknown[];
     order: number;
 }
 

--- a/drivers/src/vertexai/debug.ts
+++ b/drivers/src/vertexai/debug.ts
@@ -1,6 +1,6 @@
 import util from 'util';
 
-export function logObject(prefix: string, obj: any) {
+export function logObject(prefix: string, obj: unknown) {
     const fullObj = util.inspect(obj, { showHidden: false, depth: null, colors: true });
     console.log(prefix, fullObj)
 }

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -14,6 +14,7 @@ import {
     type LlumiverseErrorContext,
     type ModelSearchPayload,
     type PromptSegment,
+    type ToolUse,
     getConversationMeta,
     getModelCapabilities,
     incrementConversationTurn,
@@ -28,6 +29,8 @@ import { type AuthClient, GoogleAuth, type GoogleAuthOptions } from "google-auth
 import { getModelDefinition } from "./models.js";
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from "./models/claude.js";
 import { ImagenModelDefinition, type ImagenPrompt } from "./models/imagen.js";
+import type { ClaudePrompt } from "../shared/claude-messages.js";
+import type { LLamaPrompt } from "./models/llama.js";
 import { generateVertexAiEmbeddings } from "./embeddings/embed.js";
 
 export interface VertexAIDriverOptions extends DriverOptions {
@@ -40,9 +43,15 @@ export interface GenerateContentPrompt {
     contents: Content[];
     system?: Content;
 }
+type ClaudeStreamingPrompt = { messages: unknown[]; system?: unknown[] };
+type ConversationWrapper = { messages?: unknown[]; system?: unknown[] };
+
+function isClaudeStreamingPrompt(prompt: unknown): prompt is ClaudeStreamingPrompt {
+    return prompt !== null && typeof prompt === 'object' && 'messages' in prompt && Array.isArray((prompt as ConversationWrapper).messages);
+}
 
 //General Prompt type for VertexAI
-export type VertexAIPrompt = ImagenPrompt | GenerateContentPrompt;
+export type VertexAIPrompt = ImagenPrompt | GenerateContentPrompt | ClaudePrompt | LLamaPrompt;
 
 export function trimModelName(model: string) {
     const i = model.lastIndexOf("@");
@@ -64,7 +73,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     imagenClient: PredictionServiceClient | undefined;
     predictionClient: PredictionServiceClient | undefined;
 
-    googleAuth: GoogleAuth<any>;
+    googleAuth: GoogleAuth<AuthClient>;
     private authClientPromise: Promise<AuthClient> | undefined;
 
     constructor(options: VertexAIDriverOptions) {
@@ -81,7 +90,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         this.imagenClient = undefined;
         this.predictionClient = undefined;
 
-        this.googleAuth = new GoogleAuth(options.googleAuthOptions) as GoogleAuth<any>;
+        this.googleAuth = new GoogleAuth(options.googleAuthOptions);
         this.authClientPromise = undefined;
     }
 
@@ -304,8 +313,8 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         options: ExecutionOptions
     ): Content[] | unknown | undefined {
         // Handle Claude-style prompts (has 'messages' array)
-        if ('messages' in prompt && Array.isArray((prompt as any).messages)) {
-            return this.buildClaudeStreamingConversation(prompt as any, result, toolUse, options);
+        if (isClaudeStreamingPrompt(prompt)) {
+            return this.buildClaudeStreamingConversation(prompt, result, toolUse, options);
         }
 
         // Only handle Gemini-style prompts with contents array
@@ -326,21 +335,23 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                     case 'image':
                         // Skip images in conversation - they're in the result
                         return '';
-                    default:
-                        return String((r as any).value || '');
+                    default: {
+                        const _exhaustive: never = r;
+                        return String(_exhaustive);
+                    }
                 }
             })
             .join('');
 
         // Build parts array for assistant message
-        const parts: any[] = [];
+        const parts: unknown[] = [];
         if (textContent) {
             parts.push({ text: textContent });
         }
         // Add function calls if present (Gemini format)
         if (toolUse && toolUse.length > 0) {
-            for (const tool of toolUse as any[]) {
-                const functionCallPart: any = {
+            for (const tool of toolUse as ToolUse<unknown>[]) {
+                const functionCallPart: Record<string, unknown> = {
                     functionCall: {
                         name: tool.tool_name,
                         args: tool.tool_input,
@@ -367,7 +378,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if (parts.length > 0) {
             conversation.push({
                 role: 'model',
-                parts: parts
+                parts: parts as Content['parts']
             });
         }
 
@@ -423,8 +434,10 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                         return typeof r.value === 'string' ? r.value : JSON.stringify(r.value);
                     case 'image':
                         return '';
-                    default:
-                        return String((r as any).value || '');
+                    default: {
+                        const _exhaustive: never = r;
+                        return String(_exhaustive);
+                    }
                 }
             })
             .join('');
@@ -442,7 +455,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
 
         // Add tool_use blocks in Claude format
         if (toolUse && toolUse.length > 0) {
-            for (const tool of toolUse as any[]) {
+            for (const tool of toolUse as ToolUse<unknown>[]) {
                 content.push({
                     type: 'tool_use',
                     id: tool.id,
@@ -454,8 +467,9 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
 
         // Claude's requestTextCompletionStream does NOT mutate prompt.messages
         // to include history, so we must prepend options.conversation here.
-        const existingMessages = (options.conversation as any)?.messages ?? [];
-        const existingSystem = (options.conversation as any)?.system ?? prompt.system;
+        const existingConversation = options.conversation as ConversationWrapper | undefined;
+        const existingMessages = existingConversation?.messages ?? [];
+        const existingSystem = existingConversation?.system ?? prompt.system;
 
         // Build the new messages array
         const newMessages = [
@@ -754,7 +768,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         if (modelDef.formatLlumiverseError) {
             try {
                 return modelDef.formatLlumiverseError(this, error, context);
-            } catch (formattingError) {
+            } catch {
                 // If model-specific handler throws, fall through to default handling
                 // This allows model handlers to explicitly opt out for certain errors
             }

--- a/drivers/src/vertexai/models.ts
+++ b/drivers/src/vertexai/models.ts
@@ -1,15 +1,15 @@
 import type { AIModel, Completion, CompletionChunkObject, ExecutionOptions, LlumiverseError, LlumiverseErrorContext, PromptSegment } from "@llumiverse/core";
-import { type VertexAIDriver, trimModelName } from "./index.js";
+import { type VertexAIDriver, type VertexAIPrompt, trimModelName } from "./index.js";
 import { ClaudeModelDefinition } from "./models/claude.js";
 import { GeminiModelDefinition } from "./models/gemini.js";
 import { LLamaModelDefinition } from "./models/llama.js";
 
-export interface ModelDefinition<PromptT = any> {
+export interface ModelDefinition<PromptT = VertexAIPrompt> {
     model: AIModel;
     versions?: string[]; // the versions of the model that are available. ex: ['001', '002']
-    createPrompt: (driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions) => Promise<PromptT>;
-    requestTextCompletion: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<Completion>;
-    requestTextCompletionStream: (driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions) => Promise<AsyncIterable<CompletionChunkObject>>;
+    createPrompt(driver: VertexAIDriver, segments: PromptSegment[], options: ExecutionOptions): Promise<PromptT>;
+    requestTextCompletion(driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions): Promise<Completion>;
+    requestTextCompletionStream(driver: VertexAIDriver, prompt: PromptT, options: ExecutionOptions): Promise<AsyncIterable<CompletionChunkObject>>;
     preValidationProcessing?(result: Completion, options: ExecutionOptions): { result: Completion, options: ExecutionOptions };
     /**
      * Format provider-specific errors into standardized LlumiverseError.

--- a/drivers/src/vertexai/models/claude-error-handling.test.ts
+++ b/drivers/src/vertexai/models/claude-error-handling.test.ts
@@ -15,6 +15,15 @@ import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type { VertexAIDriver } from '../index.js';
 import { ClaudeModelDefinition } from './claude.js';
+import { exposePrivate } from '../../../test/__helpers__/test-utils.js';
+
+type ClaudeModelInternals = {
+    isClaudeErrorRetryable: (
+        error: unknown,
+        httpStatusCode: number | undefined,
+        errorType: string | undefined,
+    ) => boolean | undefined;
+};
 
 describe('ClaudeModelDefinition Error Handling', () => {
     let modelDef: ClaudeModelDefinition;
@@ -25,7 +34,7 @@ describe('ClaudeModelDefinition Error Handling', () => {
         driver = {
             provider: 'vertexai',
             logger: { warn: () => { }, info: () => { }, error: () => { } },
-        } as any;
+        } as unknown as VertexAIDriver;
     });
 
     describe('formatLlumiverseError', () => {
@@ -307,7 +316,7 @@ describe('ClaudeModelDefinition Error Handling', () => {
             ];
 
             for (const error of retryableErrors) {
-                const result = (modelDef as any).isClaudeErrorRetryable(error, error.status, undefined);
+                const result = exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(error, error.status, undefined);
                 expect(result, `${error.constructor.name} should be retryable`).toBe(true);
             }
         });
@@ -322,54 +331,54 @@ describe('ClaudeModelDefinition Error Handling', () => {
             ];
 
             for (const error of nonRetryableErrors) {
-                const result = (modelDef as any).isClaudeErrorRetryable(error, error.status, undefined);
+                const result = exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(error, error.status, undefined);
                 expect(result, `${error.constructor.name} should not be retryable`).toBe(false);
             }
         });
 
         it('should use HTTP status codes when available', () => {
             const apiError = new APIError(429, {}, 'Too many requests', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError, 429, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError, 429, undefined)).toBe(true);
 
             const apiError2 = new APIError(408, {}, 'Request timeout', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError2, 408, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError2, 408, undefined)).toBe(true);
 
             const apiError3 = new APIError(529, {}, 'Overloaded', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError3, 529, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError3, 529, undefined)).toBe(true);
 
             const apiError4 = new APIError(503, {}, 'Service unavailable', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError4, 503, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError4, 503, undefined)).toBe(true);
         });
 
         it('should classify 4xx as non-retryable', () => {
             const apiError = new APIError(400, {}, 'Bad request', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError, 400, undefined)).toBe(false);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError, 400, undefined)).toBe(false);
 
             const apiError2 = new APIError(403, {}, 'Forbidden', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError2, 403, undefined)).toBe(false);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError2, 403, undefined)).toBe(false);
         });
 
         it('should classify 5xx as retryable', () => {
             const apiError = new APIError(500, {}, 'Internal error', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError, 500, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError, 500, undefined)).toBe(true);
 
             const apiError2 = new APIError(502, {}, 'Bad gateway', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError2, 502, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError2, 502, undefined)).toBe(true);
         });
 
         it('should classify invalid_request_error as non-retryable', () => {
             const apiError = new APIError(400, {}, 'Invalid request', new Headers());
-            expect((modelDef as any).isClaudeErrorRetryable(apiError, 400, 'invalid_request_error')).toBe(false);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError, 400, 'invalid_request_error')).toBe(false);
         });
 
         it('should classify APIConnectionError (non-timeout) as retryable', () => {
             const connectionError = new APIConnectionError({ message: 'Network failure' });
-            expect((modelDef as any).isClaudeErrorRetryable(connectionError, undefined, undefined)).toBe(true);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(connectionError, undefined, undefined)).toBe(true);
         });
 
         it('should return undefined for unknown errors', () => {
-            const apiError = new APIError(undefined, {}, 'Unknown error', undefined as any);
-            expect((modelDef as any).isClaudeErrorRetryable(apiError, undefined, undefined)).toBeUndefined();
+            const apiError = new APIError(undefined, {}, 'Unknown error', undefined);
+            expect(exposePrivate<ClaudeModelInternals>(modelDef).isClaudeErrorRetryable(apiError, undefined, undefined)).toBeUndefined();
         });
     });
 

--- a/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
+++ b/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
@@ -1,9 +1,10 @@
-import type { ExecutionOptions } from '@llumiverse/core';
+import type { CompletionChunkObject, ExecutionOptions } from '@llumiverse/core';
 import { describe, expect, it } from 'vitest';
 import type { VertexAIDriver } from '../index.js';
 import { ClaudeModelDefinition } from './claude.js';
+import type { ClaudePrompt } from '../../shared/claude-messages.js';
 
-function createAsyncStream(events: any[]): AsyncIterable<any> {
+function createAsyncStream(events: unknown[]): AsyncIterable<unknown> {
     return (async function* () {
         for (const event of events) {
             yield event;
@@ -11,8 +12,8 @@ function createAsyncStream(events: any[]): AsyncIterable<any> {
     })();
 }
 
-async function collectChunks(stream: AsyncIterable<any>) {
-    const chunks: any[] = [];
+async function collectChunks(stream: AsyncIterable<CompletionChunkObject>): Promise<CompletionChunkObject[]> {
+    const chunks: CompletionChunkObject[] = [];
     for await (const chunk of stream) {
         chunks.push(chunk);
     }
@@ -53,7 +54,7 @@ describe('ClaudeModelDefinition streaming spacing', () => {
 
         const prompt = {
             messages: [{ role: 'user', content: [{ type: 'text', text: 'Weather?' }] }],
-        } as any;
+        } as unknown as ClaudePrompt;
 
         const options = {
             model: 'publishers/anthropic/models/claude-sonnet-4-5',
@@ -101,7 +102,7 @@ describe('ClaudeModelDefinition streaming spacing', () => {
 
         const prompt = {
             messages: [{ role: 'user', content: [{ type: 'text', text: 'Question?' }] }],
-        } as any;
+        } as unknown as ClaudePrompt;
 
         const options = {
             model: 'publishers/anthropic/models/claude-sonnet-4-5',
@@ -155,7 +156,7 @@ describe('ClaudeModelDefinition streaming spacing', () => {
 
         const prompt = {
             messages: [{ role: 'user', content: [{ type: 'text', text: 'Weather?' }] }],
-        } as any;
+        } as unknown as ClaudePrompt;
 
         const options = {
             model: 'publishers/anthropic/models/claude-sonnet-4-5',

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -16,7 +16,7 @@
 import type { ExecutionOptions } from '@llumiverse/core';
 import { FinishReason } from '@google/genai';
 import { describe, expect, it } from 'vitest';
-import type { VertexAIDriver } from '../index.js';
+import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 import { convertGeminiFunctionPartsToText, GeminiModelDefinition } from './gemini.js';
 
 // ---------------------------------------------------------------------------
@@ -105,7 +105,7 @@ function makeContentsWithFunctionParts() {
     ];
 }
 
-function makeDriver(overrides: { generateContent?: () => Promise<any>; generateContentStream?: () => Promise<AsyncIterable<any>> }) {
+function makeDriver(overrides: { generateContent?: () => Promise<unknown>; generateContentStream?: () => Promise<AsyncIterable<unknown>> }) {
     return {
         logger: { warn: () => {}, info: () => {}, error: () => {} },
         getGoogleGenAIClient: () => ({
@@ -142,7 +142,7 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         const contentsSnapshot = JSON.stringify(originalContents);
 
         const driver = makeDriver({ generateContent: async () => mockNonStreamingResponse });
-        const prompt = { contents: originalContents, system: undefined } as any;
+        const prompt = { contents: originalContents, system: undefined } as unknown as GenerateContentPrompt;
         const options: ExecutionOptions = { model: 'publishers/google/models/gemini-2.0-flash', tools: [] };
 
         await modelDef.requestTextCompletion(driver, prompt, options);
@@ -160,7 +160,7 @@ describe('GeminiModelDefinition - no conversation mutation', () => {
         const driver = makeDriver({
             generateContentStream: async () => (async function* () { yield mockStreamingChunk; })(),
         });
-        const prompt = { contents: originalContents, system: undefined } as any;
+        const prompt = { contents: originalContents, system: undefined } as unknown as GenerateContentPrompt;
         const options: ExecutionOptions = { model: 'publishers/google/models/gemini-2.0-flash', tools: [] };
 
         const stream = await modelDef.requestTextCompletionStream(driver, prompt, options);

--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -2,6 +2,11 @@ import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { VertexAIDriver } from '../index.js';
 import { GeminiModelDefinition } from './gemini.js';
+import { exposePrivate, getProp } from '../../../test/__helpers__/test-utils.js';
+
+type GeminiModelInternals = {
+    isGeminiErrorRetryable: (httpStatusCode: number) => boolean | undefined;
+};
 
 describe('GeminiModelDefinition Error Handling', () => {
     let driver: VertexAIDriver;
@@ -202,7 +207,7 @@ describe('GeminiModelDefinition Error Handling', () => {
             });
 
             expect(error.originalError).toBe(googleError);
-            expect((error.originalError as any).status).toBe(429);
+            expect(getProp<number>(error.originalError, 'status')).toBe(429);
         });
 
         it('should throw for non-Google API errors', () => {
@@ -270,7 +275,7 @@ describe('GeminiModelDefinition Error Handling', () => {
             const retryableStatusCodes = [408, 429, 500, 502, 503, 504];
 
             retryableStatusCodes.forEach((statusCode) => {
-                const result = (modelDef as any).isGeminiErrorRetryable(statusCode);
+                const result = exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(statusCode);
                 expect(result, `Status code ${statusCode} should be retryable`).toBe(true);
             });
         });
@@ -279,21 +284,21 @@ describe('GeminiModelDefinition Error Handling', () => {
             const nonRetryableStatusCodes = [400, 401, 403, 404, 409];
 
             nonRetryableStatusCodes.forEach((statusCode) => {
-                const result = (modelDef as any).isGeminiErrorRetryable(statusCode);
+                const result = exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(statusCode);
                 expect(result, `Status code ${statusCode} should not be retryable`).toBe(false);
             });
         });
 
         it('should classify other 5xx errors as retryable', () => {
-            expect((modelDef as any).isGeminiErrorRetryable(501)).toBe(true);
-            expect((modelDef as any).isGeminiErrorRetryable(505)).toBe(true);
-            expect((modelDef as any).isGeminiErrorRetryable(599)).toBe(true);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(501)).toBe(true);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(505)).toBe(true);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(599)).toBe(true);
         });
 
         it('should classify other 4xx errors as non-retryable', () => {
-            expect((modelDef as any).isGeminiErrorRetryable(402)).toBe(false);
-            expect((modelDef as any).isGeminiErrorRetryable(405)).toBe(false);
-            expect((modelDef as any).isGeminiErrorRetryable(499)).toBe(false);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(402)).toBe(false);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(405)).toBe(false);
+            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(499)).toBe(false);
         });
     });
 

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -551,7 +551,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         const token_usage: ExecutionTokenUsage = this.usageMetadataToTokenUsage(driver, response.usageMetadata);
 
         let tool_use: ToolUse[] | undefined;
-        let finish_reason: string | undefined, result: any;
+        let finish_reason: string | undefined, result: CompletionResult[] | undefined;
         const candidate = response.candidates && response.candidates[0];
         if (candidate) {
             switch (candidate.finishReason) {
@@ -788,7 +788,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             error !== null &&
             typeof error === 'object' &&
             'status' in error &&
-            typeof (error as any).status === 'number' &&
+            typeof (error as { status?: unknown }).status === 'number' &&
             'message' in error
         );
     }
@@ -967,7 +967,7 @@ function formatFunctionResponse(response: string): JSONObject {
     if (response.startsWith("{") && response.endsWith("}")) {
         try {
             return JSON.parse(response);
-        } catch (e) {
+        } catch {
             return { output: response };
         }
     } else {

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -344,7 +344,7 @@ export class ImagenModelDefinition {
         }
         const instances = [instanceValue];
 
-        let parameter: any = getImagenParameters(taskType, options.model_options ?? { _option_id: "vertexai-imagen" });
+        let parameter = getImagenParameters(taskType, options.model_options ?? { _option_id: "vertexai-imagen" }) as ReturnType<typeof getImagenParameters> & { negativePrompt?: string };
         parameter.negativePrompt = prompt.negativePrompt ?? undefined;
 
         const numberOfImages = options.model_options?.number_of_images ?? 1;
@@ -352,7 +352,7 @@ export class ImagenModelDefinition {
         // Remove all undefined values
         parameter = Object.fromEntries(
             Object.entries(parameter).filter(([_, v]) => v !== undefined)
-        ) as any;
+        ) as typeof parameter;
 
         const parameters = helpers.toValue(parameter);
 

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -6,7 +6,6 @@ import {
 import { VertexAIDriver } from "../index.js";
 import { ModelDefinition } from "../models.js";
 import { transformSSEStream } from "@llumiverse/core/async";
-import type { ServerSentEvent } from "@vertesia/api-fetch-client";
 
 interface LLamaMessage {
     role: string;
@@ -240,7 +239,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         const region = this.getLlamaModelRegion(modelName);
         const client = driver.getLLamaClient(region);
         const openaiEndpoint = `endpoints/openapi/chat/completions`;
-        const stream = await client.post<ReadableStream<ServerSentEvent>>(openaiEndpoint, {
+        const stream = await client.post(openaiEndpoint, {
             payload,
             reader: 'sse'
         });

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -6,6 +6,7 @@ import {
 import { VertexAIDriver } from "../index.js";
 import { ModelDefinition } from "../models.js";
 import { transformSSEStream } from "@llumiverse/core/async";
+import type { ServerSentEvent } from "@vertesia/api-fetch-client";
 
 interface LLamaMessage {
     role: string;
@@ -239,7 +240,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         const region = this.getLlamaModelRegion(modelName);
         const client = driver.getLLamaClient(region);
         const openaiEndpoint = `endpoints/openapi/chat/completions`;
-        const stream = await client.post(openaiEndpoint, {
+        const stream = await client.post<ReadableStream<ServerSentEvent>>(openaiEndpoint, {
             payload,
             reader: 'sse'
         });

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -6,13 +6,14 @@ import {
 import { VertexAIDriver } from "../index.js";
 import { ModelDefinition } from "../models.js";
 import { transformSSEStream } from "@llumiverse/core/async";
+import type { ServerSentEvent } from "@vertesia/api-fetch-client";
 
 interface LLamaMessage {
     role: string;
     content: string;
 }
 
-interface LLamaPrompt {
+export interface LLamaPrompt {
     messages: LLamaMessage[];
 }
 
@@ -61,7 +62,7 @@ interface LLamaStreamResponse {
 /**
  * Convert a stream to a string
  */
-async function streamToString(stream: any): Promise<string> {
+async function streamToString(stream: AsyncIterable<Uint8Array | Buffer | string>): Promise<string> {
     const chunks: Buffer[] = [];
     for await (const chunk of stream) {
         chunks.push(Buffer.from(chunk));
@@ -155,7 +156,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
 
         const modelOptions = options.model_options as TextFallbackOptions;
 
-        const payload: Record<string, any> = {
+        const payload: Record<string, unknown> = {
             model: `meta/${modelName}`,
             messages: conversation.messages,
             stream: false,
@@ -214,7 +215,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
 
         const modelOptions = options.model_options as TextFallbackOptions;
 
-        const payload: Record<string, any> = {
+        const payload: Record<string, unknown> = {
             model: `meta/${modelName}`,
             messages: conversation.messages,
             stream: true,
@@ -239,7 +240,7 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         const region = this.getLlamaModelRegion(modelName);
         const client = driver.getLLamaClient(region);
         const openaiEndpoint = `endpoints/openapi/chat/completions`;
-        const stream = await client.post(openaiEndpoint, {
+        const stream = await client.post<ReadableStream<ServerSentEvent>>(openaiEndpoint, {
             payload,
             reader: 'sse'
         });

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -240,10 +240,10 @@ export class LLamaModelDefinition implements ModelDefinition<LLamaPrompt> {
         const region = this.getLlamaModelRegion(modelName);
         const client = driver.getLLamaClient(region);
         const openaiEndpoint = `endpoints/openapi/chat/completions`;
-        const stream = await client.post<ReadableStream<ServerSentEvent>>(openaiEndpoint, {
+        const stream = await client.post(openaiEndpoint, {
             payload,
             reader: 'sse'
-        });
+        }) as ReadableStream<ServerSentEvent>;
 
         return transformSSEStream(stream, (data: string): CompletionChunkObject => {
             const json = JSON.parse(data) as LLamaStreamResponse;

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, normalizeEmbeddingsOptions, type TextFallbackOptions, WATSONX_DEFAULT_EMBEDDING_MODEL } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import type { GenerateEmbeddingPayload, GenerateEmbeddingResponse, WatsonAuthToken, WatsonxListModelResponse, WatsonxModelSpec, WatsonxTextGenerationPayload, WatsonxTextGenerationResponse } from "./interfaces.js";
 
 interface WatsonxDriverOptions extends DriverOptions {
@@ -82,7 +82,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             project_id: this.projectId,
         }
 
-        const stream = await this.fetchClient.post(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
+        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
             payload: payload,
             reader: 'sse'
         })
@@ -183,7 +183,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             };
         } catch (error) {
             if (LlumiverseError.isLlumiverseError(error)) throw error;
-            if (error instanceof Error && typeof (error as any).status !== 'number') throw error;
+            if (error instanceof Error && typeof (error as { status?: unknown }).status !== 'number') throw error;
             throw this.formatLlumiverseError(error, {
                 provider: this.provider,
                 model,

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, normalizeEmbeddingsOptions, type TextFallbackOptions, WATSONX_DEFAULT_EMBEDDING_MODEL } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
+import { FetchClient } from "@vertesia/api-fetch-client";
 import type { GenerateEmbeddingPayload, GenerateEmbeddingResponse, WatsonAuthToken, WatsonxListModelResponse, WatsonxModelSpec, WatsonxTextGenerationPayload, WatsonxTextGenerationResponse } from "./interfaces.js";
 
 interface WatsonxDriverOptions extends DriverOptions {
@@ -82,7 +82,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             project_id: this.projectId,
         }
 
-        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
+        const stream = await this.fetchClient.post(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
             payload: payload,
             reader: 'sse'
         })

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -1,6 +1,6 @@
 import { AbstractDriver, type AIModel, type Completion, type CompletionChunkObject, type DriverOptions, type EmbeddingsOptions, type EmbeddingsResult, type ExecutionOptions, LlumiverseError, normalizeEmbeddingsOptions, type TextFallbackOptions, WATSONX_DEFAULT_EMBEDDING_MODEL } from "@llumiverse/core";
 import { transformSSEStream } from "@llumiverse/core/async";
-import { FetchClient } from "@vertesia/api-fetch-client";
+import { FetchClient, type ServerSentEvent } from "@vertesia/api-fetch-client";
 import type { GenerateEmbeddingPayload, GenerateEmbeddingResponse, WatsonAuthToken, WatsonxListModelResponse, WatsonxModelSpec, WatsonxTextGenerationPayload, WatsonxTextGenerationResponse } from "./interfaces.js";
 
 interface WatsonxDriverOptions extends DriverOptions {
@@ -82,7 +82,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             project_id: this.projectId,
         }
 
-        const stream = await this.fetchClient.post(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
+        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
             payload: payload,
             reader: 'sse'
         })

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -82,10 +82,10 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
             project_id: this.projectId,
         }
 
-        const stream = await this.fetchClient.post<ReadableStream<ServerSentEvent>>(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
+        const stream = await this.fetchClient.post(`/ml/v1/text/generation_stream?version=${API_VERSION}`, {
             payload: payload,
             reader: 'sse'
-        })
+        }) as ReadableStream<ServerSentEvent>;
 
         return transformSSEStream(stream, (data: string) => {
             const json = JSON.parse(data) as WatsonxTextGenerationResponse;

--- a/drivers/test/__helpers__/test-utils.ts
+++ b/drivers/test/__helpers__/test-utils.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared helpers for tests in @llumiverse/drivers. These avoid repeated `as unknown` casts
+ * and centralize the patterns we need when asserting on untyped/dynamic values in tests.
+ */
+
+/**
+ * Create an Error with extra typed properties (e.g. `status`, `code`).
+ * Replaces the `(err as unknown).status = 429` pattern.
+ *
+ * @example
+ *   const err = errorWith('Rate limit exceeded', { status: 429 });
+ *   err.status; // typed as number
+ */
+export function errorWith<T extends object>(message: string, extra: T): Error & T {
+    return Object.assign(new Error(message), extra);
+}
+
+/**
+ * Safely read a property from an unknown value. Returns `undefined` if `obj` is null/undefined,
+ * not an object, or doesn't have the key. The return type can be narrowed via the generic.
+ *
+ * @example
+ *   const status = getProp<number>(error, 'status');
+ */
+export function getProp<T = unknown>(obj: unknown, key: string): T | undefined {
+    if (obj != null && typeof obj === 'object' && key in obj) {
+        return (obj as Record<string, unknown>)[key] as T;
+    }
+    return undefined;
+}
+
+/**
+ * Cast an object to expose its private members for testing. The caller defines the shape
+ * (typically a `type DriverInternals = { privateMethod: (...) => ReturnT; ... }`).
+ *
+ * @example
+ *   type Internals = { isErrorRetryable: (err: unknown) => boolean };
+ *   exposePrivate<Internals>(driver).isErrorRetryable(err);
+ */
+export function exposePrivate<T>(obj: object): T {
+    return obj as unknown as T;
+}
+
+/**
+ * Recursive "navigable" type for asserting on results of structure-preserving
+ * transformations (e.g. stripping/serialization). Each property access returns the same
+ * type, letting tests navigate deeply without per-test interfaces. For sites that call
+ * string/array methods on a leaf (e.g. `.substring`), add a targeted `as string` cast.
+ */
+export type Tree = { readonly [key: string]: Tree };

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -1,4 +1,4 @@
-import { AbstractDriver, AIModel, ExecutionOptions, getMaxOutputTokens, getMaxTokensLimitBedrock, getMaxTokensLimitVertexAi, Modalities, PromptSegment } from '@llumiverse/core';
+import { AbstractDriver, AIModel, ExecutionOptions, getMaxOutputTokens, getMaxTokensLimitBedrock, getMaxTokensLimitVertexAi, Modalities, PromptRole, PromptSegment } from '@llumiverse/core';
 import 'dotenv/config';
 import { GoogleAuth } from 'google-auth-library';
 import { describe, expect, test } from "vitest";
@@ -18,8 +18,7 @@ const drivers: TestDriver[] = [];
 
 
 if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
-    const auth = new GoogleAuth();
-    const client = auth.getClient();
+    new GoogleAuth();
     drivers.push({
         name: "google-vertex",
         driver: new VertexAIDriver({
@@ -293,7 +292,7 @@ describe.concurrent.each(drivers)("Driver $name", ({ name, driver, models }) => 
             limit = getMaxOutputTokens(model);
         }
 
-        const shortPrompt: PromptSegment[] = [{ role: 'user', content: 'Say "ok".' }];
+        const shortPrompt: PromptSegment[] = [{ role: PromptRole.user, content: 'Say "ok".' }];
         const r = await driver.execute(shortPrompt, {
             model,
             model_options: {

--- a/drivers/test/bedrock-toolconfig-checkpoint.test.ts
+++ b/drivers/test/bedrock-toolconfig-checkpoint.test.ts
@@ -22,6 +22,7 @@ import { convertOpenAIFunctionItemsToText } from '../src/openai/index.js';
 import { claudeMessagesContainToolBlocks, convertClaudeToolBlocksToText } from '../src/shared/claude-messages.js';
 // VertexAI Gemini
 import { convertGeminiFunctionPartsToText } from '../src/vertexai/models/gemini.js';
+import type { Tree } from './__helpers__/test-utils.js';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 
@@ -64,16 +65,16 @@ describe('Bedrock - convertToolBlocksToText', () => {
         const result = convertToolBlocksToText(messages);
 
         // Plain message unchanged
-        expect((result[0].content![0] as any).text).toBe('Search');
+        expect((result[0].content![0] as unknown as Tree).text).toBe('Search');
         // Text block preserved, toolUse converted
-        expect((result[1].content![0] as any).text).toBe('Searching...');
-        expect((result[1].content![1] as any).text).toContain('[Tool call: search_docs');
-        expect((result[1].content![1] as any).text).toContain('query');
-        expect((result[1].content![1] as any).toolUse).toBeUndefined();
+        expect((result[1].content![0] as unknown as Tree).text).toBe('Searching...');
+        expect((result[1].content![1] as unknown as Tree).text).toContain('[Tool call: search_docs');
+        expect((result[1].content![1] as unknown as Tree).text).toContain('query');
+        expect((result[1].content![1] as unknown as Tree).toolUse).toBeUndefined();
         // toolResult converted
-        expect((result[2].content![0] as any).text).toContain('[Tool result:');
-        expect((result[2].content![0] as any).text).toContain('Found 3 docs');
-        expect((result[2].content![0] as any).toolResult).toBeUndefined();
+        expect((result[2].content![0] as unknown as Tree).text).toContain('[Tool result:');
+        expect((result[2].content![0] as unknown as Tree).text).toContain('Found 3 docs');
+        expect((result[2].content![0] as unknown as Tree).toolResult).toBeUndefined();
     });
 
     test('truncates large inputs and results', () => {
@@ -82,10 +83,10 @@ describe('Bedrock - convertToolBlocksToText', () => {
             { role: 'user', content: [{ toolResult: { toolUseId: 't1', content: [{ text: 'y'.repeat(1000) }] } }] },
         ];
         const result = convertToolBlocksToText(messages);
-        expect((result[0].content![0] as any).text.length).toBeLessThan(700);
-        expect((result[0].content![0] as any).text).toContain('...');
-        expect((result[1].content![0] as any).text.length).toBeLessThan(700);
-        expect((result[1].content![0] as any).text).toContain('...');
+        expect((result[0].content![0] as unknown as Tree).text.length).toBeLessThan(700);
+        expect((result[0].content![0] as unknown as Tree).text).toContain('...');
+        expect((result[1].content![0] as unknown as Tree).text.length).toBeLessThan(700);
+        expect((result[1].content![0] as unknown as Tree).text).toContain('...');
     });
 
     test('preparePayload converts when tools=[] but preserves when tools provided', () => {
@@ -101,8 +102,8 @@ describe('Bedrock - convertToolBlocksToText', () => {
         // tools=[] → conversion, no toolConfig
         const emptyTools = driver.preparePayload(prompt, { model: 'anthropic.claude-sonnet-4-20250514', tools: [] } as ExecutionOptions);
         expect(emptyTools.toolConfig).toBeUndefined();
-        expect((emptyTools.messages![1].content![0] as any).toolUse).toBeUndefined();
-        expect((emptyTools.messages![1].content![0] as any).text).toContain('[Tool call: think');
+        expect((emptyTools.messages![1].content![0] as unknown as Tree).toolUse).toBeUndefined();
+        expect((emptyTools.messages![1].content![0] as unknown as Tree).text).toContain('[Tool call: think');
 
         // tools provided → no conversion, toolConfig set
         const withTools = driver.preparePayload(
@@ -110,7 +111,7 @@ describe('Bedrock - convertToolBlocksToText', () => {
             { model: 'anthropic.claude-sonnet-4-20250514', tools: [{ name: 'x', description: 'x', input_schema: { type: 'object' } }] } as ExecutionOptions,
         );
         expect(withTools.toolConfig).toBeDefined();
-        expect((withTools.messages![1].content![0] as any).toolUse).toBeDefined();
+        expect((withTools.messages![1].content![0] as unknown as Tree).toolUse).toBeDefined();
     });
 
     test('no conversion when conversation has no tool blocks', () => {
@@ -311,14 +312,14 @@ describe('OpenAI - convertOpenAIFunctionItemsToText', () => {
         expect(result[4]).toEqual(items[4]);
 
         // function_call converted to assistant text
-        const callItem = result[2] as any;
+        const callItem = result[2] as unknown as Tree;
         expect(callItem.role).toBe('assistant');
         expect(callItem.content).toContain('[Tool call: get_weather');
         expect(callItem.content).toContain('Paris');
         expect(callItem.type).toBeUndefined();
 
         // function_call_output converted to user text
-        const outputItem = result[3] as any;
+        const outputItem = result[3] as unknown as Tree;
         expect(outputItem.role).toBe('user');
         expect(outputItem.content).toContain('[Tool result:');
         expect(outputItem.content).toContain('15 degrees');
@@ -331,10 +332,10 @@ describe('OpenAI - convertOpenAIFunctionItemsToText', () => {
             { type: 'function_call_output', call_id: 'fc1', output: 'y'.repeat(1000) } as ResponseInputItem,
         ];
         const result = convertOpenAIFunctionItemsToText(items);
-        expect((result[0] as any).content.length).toBeLessThan(700);
-        expect((result[0] as any).content).toContain('...');
-        expect((result[1] as any).content.length).toBeLessThan(700);
-        expect((result[1] as any).content).toContain('...');
+        expect((result[0] as unknown as Tree).content.length).toBeLessThan(700);
+        expect((result[0] as unknown as Tree).content).toContain('...');
+        expect((result[1] as unknown as Tree).content.length).toBeLessThan(700);
+        expect((result[1] as unknown as Tree).content).toContain('...');
     });
 
     test('no conversion when no function items', () => {
@@ -355,10 +356,10 @@ describe('OpenAI - convertOpenAIFunctionItemsToText', () => {
             { role: 'user', content: 'Summarize' },
         ];
         const result = convertOpenAIFunctionItemsToText(items);
-        expect((result[0] as any).content).toContain('[Tool call: search');
-        expect((result[1] as any).content).toContain('[Tool call: fetch');
-        expect((result[2] as any).content).toContain('[Tool result:');
-        expect((result[3] as any).content).toContain('[Tool result:');
+        expect((result[0] as unknown as Tree).content).toContain('[Tool call: search');
+        expect((result[1] as unknown as Tree).content).toContain('[Tool call: fetch');
+        expect((result[2] as unknown as Tree).content).toContain('[Tool result:');
+        expect((result[3] as unknown as Tree).content).toContain('[Tool result:');
         expect(result[4]).toEqual(items[4]); // user message unchanged
     });
 });

--- a/drivers/test/checkpoint-tool-conversion.test.ts
+++ b/drivers/test/checkpoint-tool-conversion.test.ts
@@ -30,7 +30,7 @@ interface TestDriver {
 const drivers: TestDriver[] = [];
 
 if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
-    const _auth = new GoogleAuth();
+    new GoogleAuth();
     drivers.push({
         name: 'google-vertex',
         driver: new VertexAIDriver({
@@ -151,8 +151,7 @@ describe.concurrent.each(drivers)('Driver $name - checkpoint tool conversion', (
         // 2. finish_reason should NOT be tool_use (no tools were provided)
         expect(checkpointResult.finish_reason).not.toBe('tool_use');
         // 3. Should have text content back
-        const hasContent = checkpointResult.result_text ||
-            (checkpointResult.result && checkpointResult.result.length > 0);
+        const hasContent = Array.isArray(checkpointResult.result) && checkpointResult.result.length > 0;
         expect(hasContent).toBeTruthy();
     });
 });

--- a/drivers/test/conversation.test.ts
+++ b/drivers/test/conversation.test.ts
@@ -114,37 +114,6 @@ if (process.env.ANTHROPIC_API_KEY) {
 const hasClaudeDrivers = drivers.some(driver => driver.name.includes("claude"));
 
 /**
- * DataSource implementation that fetches image from URL and provides it as a stream.
- * This simulates how Studio sends images - fetched and converted to base64/bytes.
- */
-class ImageUrlSource implements DataSource {
-    private cachedBuffer: ArrayBuffer | null = null;
-
-    constructor(public url: string, public mime_type: string = "image/jpeg") { }
-
-    get name() {
-        return this.url.split('/').pop() || 'image';
-    }
-
-    async getURL(): Promise<string> {
-        // Return the original URL - driver will fetch it
-        return this.url;
-    }
-
-    async getStream(): Promise<ReadableStream<string | Uint8Array>> {
-        // Fetch the image and return as stream (this is what Studio does)
-        const response = await fetch(this.url);
-        if (!response.ok) {
-            throw new Error(`Failed to fetch image from url: ${this.url}`);
-        }
-        if (!response.body) {
-            throw new Error(`No content from url: ${this.url}`);
-        }
-        return response.body;
-    }
-}
-
-/**
  * DataSource implementation that provides pre-fetched image data as base64.
  * This more closely simulates how Studio sends images through the conversation.
  */
@@ -227,7 +196,7 @@ function getClaudeOptionsWithCache(model: string, driverName: string): Execution
             _option_id: optionId,
             max_tokens: 256,
             cache_enabled: true,
-        } as any,
+        },
         output_modality: Modalities.text,
     };
 }
@@ -291,7 +260,7 @@ describe.skipIf(hasClaudeDrivers)("Claude prompt caching (no Claude drivers conf
     });
 });
 
-describe.concurrent.skipIf(!hasDrivers).each(drivers)("Driver $name - Multi-turn Conversations", ({ name, driver, textModel, visionModel }) => {
+describe.skipIf(!hasDrivers).concurrent.each(drivers)("Driver $name - Multi-turn Conversations", ({ name, driver, textModel, visionModel }) => {
 
     test(`${name}: multi-turn text conversation (3 turns)`, { timeout: TIMEOUT }, async () => {
         const options = getTextOptions(textModel);

--- a/drivers/test/image-gen.test.ts
+++ b/drivers/test/image-gen.test.ts
@@ -6,9 +6,6 @@ import { BedrockDriver } from "../src";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "../src/bedrock/nova-image-payload";
 import { testPrompt_imageVariations, testPrompt_textToImage, testPrompt_textToImageGuidance } from "./samples";
 
-const TIMEOUT = 120 * 1000;
-
-
 interface TestDriver {
     driver: AbstractDriver;
     models: string[];

--- a/drivers/test/openai-streaming-tool-id.test.ts
+++ b/drivers/test/openai-streaming-tool-id.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import type OpenAI from 'openai';
 import { mapResponseStream } from '../src/openai/index.js';
+import type { Tree } from './__helpers__/test-utils.js';
 
 type ResponseStreamEvent = OpenAI.Responses.ResponseStreamEvent;
 
@@ -52,7 +53,7 @@ describe('OpenAI Responses streaming tool ids', () => {
         const tools = chunks.flatMap(chunk => chunk.tool_use ?? []);
         expect(tools).toHaveLength(3);
         expect(tools[0]).toMatchObject({ id: 'tool_0', tool_name: 'plan' });
-        expect(tools.map(tool => (tool as any)._actual_id)).toEqual([
+        expect(tools.map(tool => (tool as unknown as Tree as Tree)._actual_id)).toEqual([
             'call_plan_tool',
             'call_plan_tool',
             'call_plan_tool',
@@ -85,7 +86,7 @@ describe('OpenAI Responses streaming tool ids', () => {
         }
 
         const tools = chunks.flatMap(chunk => chunk.tool_use ?? []);
-        expect((tools[0] as any)._actual_id).toBe('fc_response_item');
-        expect((tools[1] as any)._actual_id).toBe('fc_response_item');
+        expect((tools[0] as unknown as Tree)._actual_id).toBe('fc_response_item');
+        expect((tools[1] as unknown as Tree)._actual_id).toBe('fc_response_item');
     });
 });

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, test } from 'vitest';
 import { fixOrphanedToolUse as fixOrphanedToolUseBedrock } from '../src/bedrock/index.js';
 import { fixOrphanedToolUse as fixOrphanedToolUseOpenAI } from '../src/openai/index.js';
 import { fixOrphanedToolUse as fixOrphanedToolUseClaude } from '../src/shared/claude-messages.js';
+import type { Tree } from './__helpers__/test-utils.js';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 
@@ -425,19 +426,19 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         // 3 function_calls + 3 synthetic outputs + 1 user message
         expect(result).toHaveLength(7);
 
-        expect((result[0] as any).type).toBe('function_call');
-        expect((result[1] as any).type).toBe('function_call');
-        expect((result[2] as any).type).toBe('function_call');
+        expect((result[0] as unknown as Tree).type).toBe('function_call');
+        expect((result[1] as unknown as Tree).type).toBe('function_call');
+        expect((result[2] as unknown as Tree).type).toBe('function_call');
 
         // 3 synthetic outputs
-        expect((result[3] as any).type).toBe('function_call_output');
-        expect((result[3] as any).call_id).toBe('fc_1');
-        expect((result[4] as any).type).toBe('function_call_output');
-        expect((result[4] as any).call_id).toBe('fc_2');
-        expect((result[5] as any).type).toBe('function_call_output');
-        expect((result[5] as any).call_id).toBe('fc_3');
+        expect((result[3] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[3] as unknown as Tree).call_id).toBe('fc_1');
+        expect((result[4] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[4] as unknown as Tree).call_id).toBe('fc_2');
+        expect((result[5] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[5] as unknown as Tree).call_id).toBe('fc_3');
 
-        expect((result[6] as any).role).toBe('user');
+        expect((result[6] as unknown as Tree).role).toBe('user');
     });
 
     test('handles partial outputs - only injects for missing ones', () => {
@@ -453,17 +454,17 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         // fc_1 has output, fc_2 is orphaned
         expect(result).toHaveLength(5);
 
-        expect((result[0] as any).type).toBe('function_call');
-        expect((result[1] as any).type).toBe('function_call');
-        expect((result[2] as any).type).toBe('function_call_output');
-        expect((result[2] as any).call_id).toBe('fc_1');
+        expect((result[0] as unknown as Tree).type).toBe('function_call');
+        expect((result[1] as unknown as Tree).type).toBe('function_call');
+        expect((result[2] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[2] as unknown as Tree).call_id).toBe('fc_1');
 
         // Synthetic output for fc_2 injected before user message
-        expect((result[3] as any).type).toBe('function_call_output');
-        expect((result[3] as any).call_id).toBe('fc_2');
-        expect((result[3] as any).output).toContain('Tool interrupted');
+        expect((result[3] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[3] as unknown as Tree).call_id).toBe('fc_2');
+        expect((result[3] as unknown as Tree).output).toContain('Tool interrupted');
 
-        expect((result[4] as any).role).toBe('user');
+        expect((result[4] as unknown as Tree).role).toBe('user');
     });
 
     test('handles trailing orphan at end of conversation', () => {
@@ -477,9 +478,9 @@ describe('fixOrphanedToolUse - OpenAI', () => {
 
         // Trailing orphan should get a synthetic output appended
         expect(result).toHaveLength(4);
-        expect((result[2] as any).type).toBe('function_call');
-        expect((result[3] as any).type).toBe('function_call_output');
-        expect((result[3] as any).call_id).toBe('fc_1');
+        expect((result[2] as unknown as Tree).type).toBe('function_call');
+        expect((result[3] as unknown as Tree).type).toBe('function_call_output');
+        expect((result[3] as unknown as Tree).call_id).toBe('fc_1');
     });
 
     test('real-world scenario: user stops agent mid-execution (ask_user)', () => {
@@ -507,7 +508,7 @@ describe('fixOrphanedToolUse - OpenAI', () => {
         expect(synthetic.output).toContain('ask_user');
 
         // Last user message is preserved
-        expect((result[5] as any).role).toBe('user');
+        expect((result[5] as unknown as Tree).role).toBe('user');
     });
 
     test('does not inject when function_call_output exists later in the array', () => {

--- a/drivers/test/samples.ts
+++ b/drivers/test/samples.ts
@@ -27,24 +27,6 @@ export const testSchema_color: JSONSchema = {
     }
 }
 
-class ImageSource implements DataSource {
-    file: string;
-    mime_type: "image/jpeg" = "image/jpeg";
-    constructor(file: string) {
-        this.file = resolve(file);
-    }
-    get name() {
-        return basename(this.file);
-    }
-    async getURL(): Promise<string> {
-        return `file://${this.file}`;
-    }
-    async getStream(): Promise<ReadableStream<string | Uint8Array>> {
-        const stream = createReadStream(this.file);
-        return createReadableStreamFromReadable(stream);
-    }
-}
-
 class ImageUrlSource implements DataSource {
     constructor(public url: string, public mime_type: string = "image/jpeg") {
     }
@@ -60,7 +42,7 @@ class ImageUrlSource implements DataSource {
 }
 
 /** Fetch with timeout and fallback to a local test image */
-async function fetchWithFallback(url: string): Promise<ReadableStream<Uint8Array>> {
+async function fetchWithFallback(url: string): Promise<ReadableStream<string | Uint8Array>> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), 10_000);
     try {

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -17,8 +17,7 @@ const drivers: TestDriver[] = [];
 
 
 if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
-    const auth = new GoogleAuth();
-    const client = auth.getClient();
+    new GoogleAuth();
     drivers.push({
         name: "google-vertex",
         driver: new VertexAIDriver({
@@ -178,18 +177,6 @@ const PROMPT_WITH_GET_NAME_TOOL = [
         content: "What is the weather in Paris?",
     },
 ] satisfies PromptSegment[];
-
-function addToolResponse(prompt: PromptSegment[], tool_use_id: string, response: string): PromptSegment[] {
-    return [
-        ...prompt,
-        {
-            role: PromptRole.tool,
-            tool_use_id: tool_use_id,
-            content: response
-        }
-    ];
-
-}
 
 function getTestOptions(model: string): ExecutionOptions {
     return {

--- a/drivers/test/utils.ts
+++ b/drivers/test/utils.ts
@@ -30,7 +30,7 @@ export function completionResultToString(result: CompletionResult): string {
  * Expects the text to be pure JSON if no JSON result is found
  * Throws if no JSON result is found or if parsing fails
  */
-export function parseCompletionResultsToJson(results: CompletionResult[]): any {
+export function parseCompletionResultsToJson(results: CompletionResult[]): unknown {
     const jsonResults = results.filter(r => r.type === "json");
     if (jsonResults.length >= 1) {
         return jsonResults[0].value;
@@ -54,7 +54,7 @@ export function parseCompletionResultsToJson(results: CompletionResult[]): any {
  * Joins text results with the specified separator, default is empty string
  * If multiple JSON results are found only the first one is returned
  */
-export function parseCompletionResults(result: CompletionResult[], separator: string = ""): any {
+export function parseCompletionResults(result: CompletionResult[], separator: string = ""): unknown {
     try {
         return parseCompletionResultsToJson(result);
     } catch {

--- a/drivers/test/vertexai-streaming-conversation.test.ts
+++ b/drivers/test/vertexai-streaming-conversation.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "vitest";
 import { Content } from "@google/genai";
 import { ExecutionOptions, unwrapConversationArray } from "@llumiverse/core";
-import { VertexAIDriver } from "../src";
+import { VertexAIDriver, VertexAIPrompt } from "../src";
+import type { Tree } from "./__helpers__/test-utils.js";
 
 function extractTextParts(message: { parts?: Array<{ text?: string }> }): string[] {
     if (!message.parts) return [];
@@ -27,11 +28,11 @@ describe("VertexAI streaming conversation rebuild", () => {
         const result = [{ type: "text", value: "response" }];
 
         const conversation = driver.buildStreamingConversation(
-            prompt as any,
-            result as any,
+            prompt as unknown as VertexAIPrompt,
+            result,
             undefined,
             options
-        ) as unknown;
+        );
 
         const unwrapped = unwrapConversationArray<Content>(conversation) ?? (conversation as Content[]);
 
@@ -68,11 +69,11 @@ describe("VertexAI streaming conversation rebuild", () => {
         const result = [{ type: "text", value: "response" }];
 
         const conversation = driver.buildStreamingConversation(
-            prompt as any,
-            result as any,
+            prompt as unknown as VertexAIPrompt,
+            result,
             undefined,
             options
-        ) as any;
+        ) as unknown as Tree;
 
         expect(conversation.system).toEqual(existing.system);
         expect(conversation.messages.length).toBe(3);

--- a/drivers/tsconfig.json
+++ b/drivers/tsconfig.json
@@ -32,6 +32,7 @@
     "noFallthroughCasesInSwitch": true,
     "useUnknownInCatchVariables": true,
     "noPropertyAccessFromIndexSignature": false,
+    "noImplicitAny": true,
   },
   "include": [
     "src"

--- a/drivers/tsconfig.test.json
+++ b/drivers/tsconfig.test.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "declaration": true,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": [
+    "src",
+    "test"
+  ],
+  "exclude": [
+    "node_modules",
+    "lib"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "format:check": "pnpm exec biome format .",
         "release": "pnpm -r publish --access public",
         "prepare": "cp ./README.md ./core/ && cp ./README.md ./drivers/ && git config core.hooksPath .githooks 2>/dev/null || true",
-        "build": "pnpm -r build"
+        "build": "pnpm -r build",
+        "typecheck": "pnpm -r typecheck"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "release": "pnpm -r publish --access public",
         "prepare": "cp ./README.md ./core/ && cp ./README.md ./drivers/ && git config core.hooksPath .githooks 2>/dev/null || true",
         "build": "pnpm -r build",
-        "typecheck": "pnpm -r typecheck"
+        "typecheck:test": "pnpm -r typecheck:test"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,6 +1000,7 @@ packages:
   '@smithy/core@3.24.0':
     resolution: {integrity: sha512-rZ5YfycIXX6puoGjthnDiMpUgtKNOq3c7CndQYkCNYQTv26AiCrZQOJPy7ANSfZ6Okk3UvCRnmO1OYWlLnYZgg==}
     engines: {node: '>=18.0.0'}
+    deprecated: Deprecated due to incompatibility with Node.js 18 in some environments https://github.com/smithy-lang/smithy-typescript/issues/2022
 
   '@smithy/credential-provider-imds@4.2.14':
     resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}


### PR DESCRIPTION
## Summary
- Remove all `any` types in favour of `unknown` with proper narrowing
- Clean up lint warnings (catch narrowing, unused vars/imports)
- Add `tsconfig.test.json` + `typecheck:test` script (covers test files)
- Wire `typecheck:test` into CI alongside the existing build pipeline
- Update TypeScript build config and rollup config for stricter type-checking

## Verification
- `pnpm lint` — 0 errors, 0 warnings (was 26 warnings)
- `pnpm typecheck` (main src) — 0 errors
- `pnpm typecheck:test` (src + tests) — 0 errors
- `pnpm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>