### PR TITLE
chore: add zizmor CI workflow

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
-        run: uvx zizmor --format=sarif . > results.sarif
+        run: uvx zizmor@1.24.1 --format=sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,37 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
+      - name: Run zizmor
+        run: uvx zizmor --format=sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
## Summary

Add a `.github/workflows/zizmor.yaml` workflow that runs [zizmor](https://docs.zizmor.sh/) on every push to `main` and every PR, then uploads the findings as SARIF to GitHub code scanning.

**What this enforces:** zizmor catches the supply-chain pitfalls that the recent SHA-pinning PR cleaned up — most importantly `unpinned-uses`, but also `template-injection`, `excessive-permissions`, `dangerous-triggers`, `artipacked` (credentials leaked into uploaded artifacts), and more. With this workflow in place, regressions show up in the **Security → Code scanning** tab and as inline annotations on PRs, instead of slipping through review.

**On first run** there may be findings beyond `unpinned-uses` (template injection, default-permissions, etc.). They show up in code scanning, but `if: ${{ !cancelled() }}` on the SARIF upload step ensures results upload even when zizmor exits non-zero, so the visibility loop closes from day one.

## Action SHAs used

All pinned and ≥7 days old at PR creation (policy from the pinning PR):

- `actions/checkout` `de0fac2e...` (v6.0.2, 2026-01-09)
- `astral-sh/setup-uv` `08807647...` (v8.1.0, 2026-04-16)
- `github/codeql-action/upload-sarif` `68bde559...` (v4.35.4, 2026-05-07)

## Test plan

- [ ] After merge, confirm the `zizmor` workflow runs on the merge commit to `main` and findings (if any) appear in **Security → Code scanning**.
- [ ] Open a test PR that intentionally adds `actions/checkout@v6` (no SHA) and confirm zizmor flags it as `unpinned-uses`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)