### PR TITLE
fix(release): use `npm pkg get` instead of `pnpm pkg get` in publish script

### DIFF
--- a/.github/bin/publish-all-packages.sh
+++ b/.github/bin/publish-all-packages.sh
@@ -30,7 +30,7 @@ update_package_versions() {
   fi
 
   # Get current version and strip any existing -dev* suffix to get base version
-  current_version=$(pnpm pkg get version | tr -d '"')
+  current_version=$(npm pkg get version | tr -d '"')
   base_version=$(echo "$current_version" | sed 's/-dev.*//')
 
   # Apply bump if needed (for both snapshot and release)
@@ -72,7 +72,7 @@ publish_packages() {
     if [ -d "$pkg" ] && [ -f "$pkg/package.json" ]; then
       cd "$pkg"
 
-      pkg_version=$(pnpm pkg get version | tr -d '"')
+      pkg_version=$(npm pkg get version | tr -d '"')
 
       # Fail if npm_tag is not set (safety check to prevent publishing without explicit tag)
       if [ -z "$npm_tag" ]; then
@@ -101,7 +101,7 @@ verify_published_packages() {
   failed_packages=()
 
   # Get the expected version from root package.json
-  expected_version=$(pnpm pkg get version | tr -d '"')
+  expected_version=$(npm pkg get version | tr -d '"')
 
   for pkg in "${PACKAGES[@]}"; do
     if [ -d "$pkg" ]; then
@@ -188,7 +188,7 @@ commit_and_push() {
   echo "=== Committing version changes ==="
 
   # Get the version from root package.json
-  version=$(pnpm pkg get version | tr -d '"')
+  version=$(npm pkg get version | tr -d '"')
 
   git config user.email "github-actions[bot]@users.noreply.github.com"
   git config user.name "github-actions[bot]"
@@ -215,7 +215,7 @@ write_github_summary() {
   echo "=== Writing GitHub Summary ==="
 
   # Get the version from root package.json
-  version=$(pnpm pkg get version | tr -d '"')
+  version=$(npm pkg get version | tr -d '"')
 
   # Determine title based on dry run mode
   if [ "$DRY_RUN" = "true" ]; then


### PR DESCRIPTION
## Summary

The `publish-npm-packages` workflow has been failing since the pnpm 10 → 11 upgrade (#393). pnpm 11 [removed the `pkg` passthrough command](https://github.com/pnpm/pnpm/releases/tag/v11.0.0), so `pnpm pkg get version` now errors with `ERR_PNPM_NOT_IMPLEMENTED`. That error string was being captured into version variables, producing garbage versions in publish and verification mismatches.

Failing run: https://github.com/vertesia/llumiverse/actions/runs/26213492174/job/77129900662

Symptoms in the log:
- `line 40: ... syntax error in expression` (the error string fed into the arithmetic in `IFS='.' read ...`)
- `Publishing @llumiverse/common@[ERR_PNPM_NOT_IMPLEMENTED] ...`
- `Version mismatch (expected: [ERR_PNPM_NOT_IMPLEMENTED] ..., got: 1.2.0)`

## Fix

Replace the 5 `pnpm pkg get version` calls in `.github/bin/publish-all-packages.sh` with `npm pkg get version`. `npm pkg get` is supported (the workflow already installs npm via `npm install -g npm@latest`).

## Test plan

- [ ] Re-trigger the workflow against `preview` with `dry_run: true`
- [ ] Confirm `=== Updating package versions ===` shows a clean version (no `ERR_PNPM_NOT_IMPLEMENTED`)
- [ ] Confirm `Publishing @llumiverse/<pkg>@<clean-version>` lines look correct
- [ ] Confirm verification summary shows `✓ All packages passed verification`

## Follow-ups (not in this PR)

Two other pnpm 11 changes worth tracking separately:
- Filter `./*` now includes the root workspace (pnpm/pnpm#10465) — line 65 may now re-bump root. Idempotent in practice (same target version) but worth tightening to `--filter "./{common,core,drivers}"`.
- `minimumReleaseAge` default is now 1440 min (24h). Downstream consumers on pnpm 11 will not be able to install `@llumiverse/*` for 24h after a release unless they override the setting.
