### PR TITLE
fix: use Actions context for ref_name in submodule dispatch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -74,6 +74,6 @@ jobs:
               "event_type": "update-git-submodule-request",
               "client_payload": {
                 "llumiverse_sha": "${{ github.sha }}",
-                "branch": "${GITHUB_REF_NAME}"
+                "branch": "${{ github.ref_name }}"
               }
             }'


### PR DESCRIPTION
## Summary

Fixes the broken cross-repo submodule update dispatch from llumiverse → composableai.

The `repository_dispatch` POST body in [.github/workflows/build-and-test.yml](.github/workflows/build-and-test.yml) is a single-quoted bash string. Bash does not expand `${VAR}` inside single quotes, so the literal string `"${GITHUB_REF_NAME}"` was being posted as the branch value.

The downstream composableai workflow's "Validate branch" step then rejects it with:

> `Error: Invalid branch '${GITHUB_REF_NAME}'. Only 'main' and 'preview' branches are supported.`

Switch to `${{ github.ref_name }}`. GitHub Actions substitutes that at workflow-render time — before bash sees the line — which is why the adjacent `${{ github.sha }}` was already working correctly.

A companion PR in composableai fixes the same shape of bug in its own dispatch to studio.

## Test Plan

- [ ] Push a commit to `main` or `preview` on llumiverse and confirm the `notify-repo-composableai` job dispatches with the correct branch value (visible in the composableai workflow's run logs as the `TARGET_COMPOSABLEAI_BRANCH` env)
- [ ] Confirm composableai's `update-git-submodule` workflow run on the resulting dispatch passes the "Validate branch" step and opens a sync PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>