### PR TITLE
chore(ci): clear zizmor security findings and standardize workflow names

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,34 +1,48 @@
-name: Build+Test
+name: (test) Build and test
 
 on:
   push:
   workflow_dispatch:
+
+# Cancel superseded runs on the same branch (latest push wins).
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   build-and-test:
+    name: Build and test
     runs-on: ubuntu-latest
+    # Scopes provider API keys (OPENAI, MISTRAL, GROQ, TOGETHER, etc.) to a
+    # dedicated environment (zizmor: secrets-outside-env).
+    environment: build
     permissions:
-      id-token: write
+      id-token: write # required for OIDC federation with GCP and AWS
       contents: read
     strategy:
       matrix:
         node-version: [24.x]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
-      - run: pnpm install
-      - run: pnpm build
+      - name: Install workspace dependencies
+        run: pnpm install
+      - name: Build workspace
+        run: pnpm build
 
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
@@ -37,7 +51,8 @@ jobs:
           project_id: "dengenlabs"
           workload_identity_provider: "projects/265888598630/locations/global/workloadIdentityPools/composable-cloud/providers/github"
 
-      - uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@d979d5b3a71173a29b74b5b88418bfda9437d885 # v6.1.1
         with:
           audience: sts.amazonaws.com
           role-to-assume: arn:aws:iam::716085231028:role/ComposablePromptExecutor
@@ -56,24 +71,28 @@ jobs:
         run: pnpm typecheck:test && npx vitest
 
   notify-repo-composableai:
+    name: Notify vertesia/composableai of new commit
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/preview' || startsWith(github.ref, 'refs/heads/repo-dispatch')
     needs:
       - build-and-test
+    # Scopes the cross-repo dispatch token to a dedicated environment.
+    environment: build
     steps:
       - name: Notify repository vertesia/composableai
+        env:
+          REPO_COMPOSABLEAI_ACCESS_TOKEN: ${{ secrets.REPO_COMPOSABLEAI_ACCESS_TOKEN }}
+          LLUMIVERSE_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.ref_name }}
         run: |
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.REPO_COMPOSABLEAI_ACCESS_TOKEN }}" \
+            -H "Authorization: Bearer ${REPO_COMPOSABLEAI_ACCESS_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --fail-with-body \
             https://api.github.com/repos/vertesia/composableai/dispatches \
-            -d '{
-              "event_type": "update-git-submodule-request",
-              "client_payload": {
-                "llumiverse_sha": "${{ github.sha }}",
-                "branch": "${{ github.ref_name }}"
-              }
-            }'
+            -d "$(jq -nc \
+              --arg sha "${LLUMIVERSE_SHA}" \
+              --arg branch "${BRANCH}" \
+              '{event_type: "update-git-submodule-request", client_payload: {llumiverse_sha: $sha, branch: $branch}}')"

--- a/.github/workflows/code-sync.yaml
+++ b/.github/workflows/code-sync.yaml
@@ -1,4 +1,4 @@
-name: code-sync
+name: (sync) preview -> main
 
 on:
   push:
@@ -15,6 +15,12 @@ on:
         required: false
         default: ""
 
+# Serialize concurrent runs so two simultaneous pushes don't race on the
+# shared temporary branch or step on each other's PR creation.
+concurrency:
+  group: code-sync-${{ inputs.from_branch || github.ref_name }}
+  cancel-in-progress: false
+
 env:
   FROM_BRANCH: ${{ inputs.from_branch || github.ref_name }}
 
@@ -23,10 +29,11 @@ permissions:
 
 jobs:
   sync:
+    name: Sync code from preview to main
     runs-on: ubuntu-latest
     permissions:
-      contents: write # required for pushing changes to the repository
-      pull-requests: write # required for creating pull requests
+      contents: write # required for pushing the temporary sync branch
+      pull-requests: write # required for creating the conflict-resolution PR
     outputs:
       is_merged: ${{ steps.sync.outputs.IS_MERGED }}
       pr_number: ${{ steps.sync.outputs.PR_NUMBER }}
@@ -45,6 +52,7 @@ jobs:
         id: sync
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           export SOURCE_REF="${FROM_BRANCH}"
           export SOURCE_SHA="$(git rev-parse "origin/${FROM_BRANCH}")"
@@ -60,9 +68,9 @@ jobs:
           Type   | Item      | Value
           :----- | :-------- | :---------------
           Source | commit    | ${SOURCE_MSG}
-          Source | ref       | \`${SOURCE_REF}\` ([\`${SOURCE_SHA}\`](https://github.com/${{ github.repository }}/commit/${SOURCE_SHA}))
+          Source | ref       | \`${SOURCE_REF}\` ([\`${SOURCE_SHA}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${SOURCE_SHA}))
           Target | commit    | ${TARGET_MSG}
-          Target | ref       | \`${TARGET_REF}\` ([\`${TARGET_SHA}\`](https://github.com/${{ github.repository }}/commit/${TARGET_SHA}))
+          Target | ref       | \`${TARGET_REF}\` ([\`${TARGET_SHA}\`](https://github.com/${GITHUB_REPOSITORY}/commit/${TARGET_SHA}))
           Other  | branch    | \`${TEMP_BRANCH}\`
           EOF
 
@@ -142,12 +150,15 @@ jobs:
   # TODO: Add tests for the synced code
 
   push:
+    name: Fast-forward main with the synced branch
     needs:
       - sync
     if: ${{ needs.sync.outputs.is_merged == 'true' }}
     runs-on: ubuntu-latest
+    # Scopes DEPLOY_KEY to a dedicated environment (zizmor: secrets-outside-env).
+    environment: build
     permissions:
-      contents: write # required for pushing changes to the repository
+      contents: write # required for fast-forwarding main with the synced branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -159,6 +170,8 @@ jobs:
           persist-credentials: false
 
       - name: Push changes to main branch
+        env:
+          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}
         run: |
           set -x
 
@@ -170,60 +183,63 @@ jobs:
           # note: --ff-only ensures that the merge will only succeed if it can be fast-forwarded. This avoids creating
           # a merge commit and keeps the history clean. If failed, user should trigger the workflow again, or resolving
           # conflicts and then sync manually.
-          git merge --ff-only --no-edit ${NEEDS_SYNC_OUTPUTS_SYNC_REF}
+          git merge --ff-only --no-edit "${NEEDS_SYNC_OUTPUTS_SYNC_REF}"
 
           git push origin main
-        env:
-          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}
 
   notify:
+    name: Notify developer of successful sync
     runs-on: ubuntu-latest
     needs:
       - push
     if: ${{ needs.push.result == 'success' && github.actor != 'github-actions[bot]' }}
+    # Scopes the cross-repo dispatch token to a dedicated environment.
+    environment: build
     steps:
       - name: Notify studio
+        env:
+          STUDIO_DISPATCH_TOKEN: ${{ secrets.STUDIO_DISPATCH_TOKEN }}
+          ACTION_RUN_URL: https://github.com/vertesia/llumiverse/actions/runs/${{ github.run_id }}
         run: |
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.STUDIO_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer ${STUDIO_DISPATCH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --fail-with-body \
             https://api.github.com/repos/vertesia/studio/dispatches \
-            -d '{
-              "event_type": "developer-notification",
-              "client_payload": {
-                "github_login": "${GITHUB_ACTOR}",
-                "message": "Your changes from `preview` have been synced to `main` in vertesia/llumiverse. See the <https://github.com/vertesia/llumiverse/actions/runs/${{ github.run_id }}|Action run>."
-              }
-            }'
+            -d "$(jq -nc \
+              --arg actor "${GITHUB_ACTOR}" \
+              --arg url "${ACTION_RUN_URL}" \
+              '{event_type: "developer-notification", client_payload: {github_login: $actor, message: ("Your changes from `preview` have been synced to `main` in vertesia/llumiverse. See the <" + $url + "|Action run>.")}}')"
 
   notify_conflict:
+    name: Notify developer of conflict PR
     needs: sync
     if: ${{ needs.sync.outputs.pr_number != '0' }}
     runs-on: ubuntu-latest
+    # Scopes the cross-repo dispatch token to a dedicated environment.
+    environment: build
     steps:
       - name: Notify studio for Slack notification
+        env:
+          STUDIO_DISPATCH_TOKEN: ${{ secrets.STUDIO_DISPATCH_TOKEN }}
+          NEEDS_SYNC_OUTPUTS_PR_URL: ${{ needs.sync.outputs.pr_url }}
         run: |
           curl -L \
             -X POST \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${{ secrets.STUDIO_DISPATCH_TOKEN }}" \
+            -H "Authorization: Bearer ${STUDIO_DISPATCH_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             --fail-with-body \
             https://api.github.com/repos/vertesia/studio/dispatches \
-            -d '{
-              "event_type": "developer-notification",
-              "client_payload": {
-                "github_login": "${GITHUB_ACTOR}",
-                "message": "Your changes from `preview` failed to sync to `main` in vertesia/llumiverse due to merge conflicts. Please resolve this PR: ${NEEDS_SYNC_OUTPUTS_PR_URL}"
-              }
-            }'
-        env:
-          NEEDS_SYNC_OUTPUTS_PR_URL: ${{ needs.sync.outputs.pr_url }}
+            -d "$(jq -nc \
+              --arg actor "${GITHUB_ACTOR}" \
+              --arg url "${NEEDS_SYNC_OUTPUTS_PR_URL}" \
+              '{event_type: "developer-notification", client_payload: {github_login: $actor, message: ("Your changes from `preview` failed to sync to `main` in vertesia/llumiverse due to merge conflicts. Please resolve this PR: " + $url)}}')"
 
   cleanup:
+    name: Cleanup temporary sync branch
     runs-on: ubuntu-latest
     needs:
       - sync
@@ -231,7 +247,7 @@ jobs:
     # Always run cleanup except when there is a conflict PR that needs the branch to stay alive.
     if: ${{ always() && needs.sync.outputs.should_cleanup != 'false' }}
     permissions:
-      contents: write # required for deleting the temporary branch
+      contents: write # required for deleting the temporary sync branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -241,11 +257,11 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup temporary branch
+        env:
+          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}
         run: |
           set -x
 
           TEMP_BRANCH="${NEEDS_SYNC_OUTPUTS_SYNC_REF}"
           git branch -D "$TEMP_BRANCH" || true # Ignore if branch does not exist
           git push origin --delete "$TEMP_BRANCH" || true # Ignore if branch does not exist
-        env:
-          NEEDS_SYNC_OUTPUTS_SYNC_REF: ${{ needs.sync.outputs.sync_ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,13 @@
-name: (lint) lint codebase
+name: (lint) Lint codebase
 
 on:
   push:
   workflow_dispatch:
+
+# Cancel superseded runs on the same branch (latest push wins).
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -12,15 +17,20 @@ jobs:
     name: Lint codebase
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           run_install: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.x
           cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm lint
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Lint codebase
+        run: pnpm lint

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,4 +1,4 @@
-name: publish-npm-packages
+name: (publish) NPM packages
 
 on:
   workflow_dispatch:
@@ -26,6 +26,12 @@ on:
         type: boolean
         default: true
 
+# Serialize publish runs so two concurrent dispatches don't race on the
+# shared npm registry or push competing version bumps.
+concurrency:
+  group: publish-npm-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -33,9 +39,12 @@ jobs:
   publish:
     name: Publish NPM packages ${{ inputs.dry_run && '[dry-run]' || '' }}[${{ inputs.release_type }}/${{ inputs.bump_type }}]
     runs-on: ubuntu-latest
+    # Scopes DEPLOY_KEY (used to push version bumps past branch protection)
+    # to a dedicated environment.
+    environment: build
     permissions:
-      id-token: write  # Required for OIDC between GitHub and NPM
-      contents: write  # Required to push version changes
+      id-token: write  # required for OIDC between GitHub and NPM
+      contents: write  # required to push version-bump commits
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -43,8 +52,10 @@ jobs:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
           persist-credentials: false
 
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Install pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -53,14 +64,20 @@ jobs:
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm
         run: npm install -g npm@latest
-      - run: npm --version
+      - name: Verify npm version
+        run: npm --version
 
-      - run: pnpm install
+      - name: Install workspace dependencies
+        run: pnpm install
 
       - name: Publish all packages
+        env:
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          BUMP_TYPE: ${{ inputs.bump_type }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           ./.github/bin/publish-all-packages.sh \
               --ref "${GITHUB_REF_NAME}" \
-              --release-type "${{ inputs.release_type }}" \
-              --bump-type "${{ inputs.bump_type }}" \
-              --dry-run "${{ inputs.dry_run }}"
+              --release-type "${RELEASE_TYPE}" \
+              --bump-type "${BUMP_TYPE}" \
+              --dry-run "${DRY_RUN}"

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,4 +1,4 @@
-name: zizmor
+name: (security) Zizmor
 
 on:
   push:
@@ -7,27 +7,34 @@ on:
     branches: ["**"]
   workflow_dispatch:
 
+# Cancel superseded runs on the same branch (latest push wins).
+concurrency:
+  group: zizmor-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
   zizmor:
-    name: zizmor
+    name: Run zizmor security audit
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
-      contents: read
-      actions: read
+      security-events: write # required to upload SARIF results to Code Scanning
+      contents: read         # required for actions/checkout to read the repo tree
+      actions: read          # required by upload-sarif to enrich findings with workflow context
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
 
       - name: Run zizmor
-        run: uvx zizmor@1.24.1 --no-exit-codes --persona=auditor --format=sarif .github > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: uvx zizmor@1.24.1 --no-exit-codes --persona=auditor --format=sarif .github > results.sarif
 
       - name: Upload SARIF
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## Summary

Closes all **34 open zizmor security findings** for this repo (visible in [Security → Code scanning](https://github.com/vertesia/llumiverse/security/code-scanning)) and standardizes workflow display names along the way.

## Findings closed (by rule)

| Rule | Severity | Count |
|---|---|---|
| `template-injection` | error | 11 |
| `secrets-outside-env` | warning | 9 |
| `anonymous-definition` | note | 7 |
| `concurrency-limits` | note | 5 |
| `undocumented-permissions` | note | 2 |

## How each rule is addressed

- **`template-injection`** — hoist every `${{ ... }}` interpolation out of `run:` scripts into a `env:` block on the step, then reference `$VAR` from the shell. For workflows that pose a JSON payload to the GitHub API, switch from string-concatenated `-d '{ ... }'` to `jq -nc --arg` so untrusted values can never be interpreted as JSON.
- **`secrets-outside-env`** — assign jobs that reference repository secrets to the `build` GitHub environment created in repo settings. Scoped jobs: `build-and-test` (provider API keys), `notify-repo-composableai` (cross-repo dispatch token), `code-sync` push/notify/notify_conflict (DEPLOY_KEY, STUDIO_DISPATCH_TOKEN), `publish-npm publish` (DEPLOY_KEY).
- **`anonymous-definition`** — every job and every step now has an explicit `name:`.
- **`concurrency-limits`** — workflow-level `concurrency:` blocks added. Cancel-in-progress on PR-scoped workflows (build-and-test, lint, zizmor); serialize on shared-resource workflows (publish-npm, code-sync) where racing runs would step on each other.
- **`undocumented-permissions`** — one-line rationale comment next to each permission scope.

## Naming standardization

Adopts the `(category) Title` convention used by `vertesia/studio` (`(lint) lint codebase`, `(publish) NPM packages`, etc.) for a consistent Actions sidebar:

| File | Before | After |
|---|---|---|
| `build-and-test.yml` | `Build+Test` | `(test) Build and test` |
| `publish-npm.yaml` | `publish-npm-packages` | `(publish) NPM packages` |
| `lint.yml` | `(lint) lint codebase` | `(lint) Lint codebase` |
| `code-sync.yaml` | `code-sync` | `(sync) preview -> main` |
| `zizmor.yaml` | `zizmor` | `(security) Zizmor` |

## Verification

```sh
uvx zizmor@1.24.1 --persona=auditor .github/workflows/
# 34 findings → 0
```

## Test plan

- [ ] PR's `(security) Zizmor` check is green (0 findings)
- [ ] PR's `(test) Build and test` job runs (note: secrets now require the `build` environment; the environment must allow this branch or the job will skip)
- [ ] After merge, open GitHub code-scanning alerts auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)