### PR TITLE
chore: switch Biome checks to the check command and apply fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Pre-commit hook:
-# - Runs biome format checks, then biome lint, on staged files only.
-# - These checks never write fixes and never mutate the git index.
+# - Runs biome check --write on staged files only.
+# - Re-stages Biome fixes so the commit contains the checked content.
 # - Standalone clone or local `pnpm install`: biome is reachable via pnpm exec.
 # - Submodule mode (no local node_modules): walks up to the first parent
 #   workspace with a biome binary while still using this repo as the working directory.
@@ -43,6 +43,7 @@ fi
 staged_files=()
 while IFS= read -r -d '' file; do
     case "$file" in
+        package.json | */package.json | \
         *.js | *.cjs | *.mjs | *.jsx | *.ts | *.tsx)
             staged_files+=("$file")
             ;;
@@ -53,23 +54,11 @@ if (( ${#staged_files[@]} == 0 )); then
     exit 0
 fi
 
-run_biome() {
-    local command="$1"
-    shift
+if ! git diff --quiet -- "${staged_files[@]}"; then
+    echo "Error: cannot run biome --write with partially staged files."
+    echo "Stage or stash unstaged changes in the files being committed, then try again."
+    exit 1
+fi
 
-    local chunk=()
-    for file in "${staged_files[@]}"; do
-        chunk+=("$file")
-        if (( ${#chunk[@]} >= 100 )); then
-            "${BIOME_CMD[@]}" "$command" --no-errors-on-unmatched --files-ignore-unknown=true "$@" "${chunk[@]}"
-            chunk=()
-        fi
-    done
-
-    if (( ${#chunk[@]} > 0 )); then
-        "${BIOME_CMD[@]}" "$command" --no-errors-on-unmatched --files-ignore-unknown=true "$@" "${chunk[@]}"
-    fi
-}
-
-run_biome format
-run_biome lint --diagnostic-level=error
+"${BIOME_CMD[@]}" check --write --staged --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error
+git add -- "${staged_files[@]}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   lint:
-    name: Lint codebase
+    name: Check codebase
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,5 +32,5 @@ jobs:
           cache: pnpm
       - name: Install workspace dependencies
         run: pnpm install --frozen-lockfile
-      - name: Lint codebase
-        run: pnpm lint
+      - name: Check codebase
+        run: pnpm check

--- a/biome.json
+++ b/biome.json
@@ -8,6 +8,7 @@
     "files": {
         "ignoreUnknown": true,
         "includes": [
+            "**/package.json",
             "**/*.{js,cjs,mjs,jsx,ts,tsx}",
             "!**/dist/**",
             "!**/lib/**",

--- a/common/package.json
+++ b/common/package.json
@@ -1,82 +1,82 @@
 {
-  "name": "@llumiverse/common",
-  "version": "1.3.0",
-  "type": "module",
-  "description": "Public types, enums and options used by Llumiverse API.",
-  "files": [
-    "lib",
-    "src"
-  ],
-  "keywords": [
-    "llm",
-    "ai",
-    "prompt",
-    "prompt engineering",
-    "ml",
-    "machine learning",
-    "embeddings",
-    "training",
-    "model",
-    "universal",
-    "api",
-    "chatgpt",
-    "openai",
-    "vertexai",
-    "bedrock",
-    "replicate",
-    "huggingface",
-    "togetherai"
-  ],
-  "types": "./lib/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "async": [
-        "./lib/types/async.d.ts"
-      ],
-      "formatters": [
-        "./lib/types/formatters/index.d.ts"
-      ]
-    }
-  },
-  "exports": {
-    ".": {
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
+    "name": "@llumiverse/common",
+    "version": "1.3.0",
+    "type": "module",
+    "description": "Public types, enums and options used by Llumiverse API.",
+    "files": [
+        "lib",
+        "src"
+    ],
+    "keywords": [
+        "llm",
+        "ai",
+        "prompt",
+        "prompt engineering",
+        "ml",
+        "machine learning",
+        "embeddings",
+        "training",
+        "model",
+        "universal",
+        "api",
+        "chatgpt",
+        "openai",
+        "vertexai",
+        "bedrock",
+        "replicate",
+        "huggingface",
+        "togetherai"
+    ],
+    "types": "./lib/types/index.d.ts",
+    "typesVersions": {
+        "*": {
+            "async": [
+                "./lib/types/async.d.ts"
+            ],
+            "formatters": [
+                "./lib/types/formatters/index.d.ts"
+            ]
+        }
     },
-    "./async": {
-      "types": "./lib/types/async.d.ts",
-      "import": "./lib/esm/async.js",
-      "require": "./lib/cjs/async.js"
+    "exports": {
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "./async": {
+            "types": "./lib/types/async.d.ts",
+            "import": "./lib/esm/async.js",
+            "require": "./lib/cjs/async.js"
+        },
+        "./formatters": {
+            "types": "./lib/types/formatters/index.d.ts",
+            "import": "./lib/esm/formatters/index.js",
+            "require": "./lib/cjs/formatters/index.js"
+        }
     },
-    "./formatters": {
-      "types": "./lib/types/formatters/index.d.ts",
-      "import": "./lib/esm/formatters/index.js",
-      "require": "./lib/cjs/formatters/index.js"
+    "scripts": {
+        "lint": "biome lint src",
+        "test": "vitest run",
+        "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
+        "build": "pnpm exec tsmod build",
+        "clean": "rimraf ./lib tsconfig.tsbuildinfo"
+    },
+    "author": "Llumiverse",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/vertesia/llumiverse",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
+    },
+    "devDependencies": {
+        "@types/node": "^24.12.4",
+        "rimraf": "^6.1.3",
+        "ts-dual-module": "^0.6.3",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
+    },
+    "ts_dual_module": {
+        "outDir": "lib"
     }
-  },
-  "scripts": {
-    "lint": "biome lint src",
-    "test": "vitest run",
-    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-    "build": "pnpm exec tsmod build",
-    "clean": "rimraf ./lib tsconfig.tsbuildinfo"
-  },
-  "author": "Llumiverse",
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/vertesia/llumiverse",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
-  },
-  "devDependencies": {
-    "@types/node": "^24.12.4",
-    "rimraf": "^6.1.3",
-    "ts-dual-module": "^0.6.3",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
-  },
-  "ts_dual_module": {
-    "outDir": "lib"
-  }
 }

--- a/common/src/LlumiverseError.test.ts
+++ b/common/src/LlumiverseError.test.ts
@@ -1,4 +1,4 @@
-import { type LlumiverseErrorContext, LlumiverseError } from '@llumiverse/common';
+import { LlumiverseError, type LlumiverseErrorContext } from '@llumiverse/common';
 import { describe, expect, it } from 'vitest';
 
 describe('LlumiverseError', () => {

--- a/common/src/capability/azure_foundry.ts
+++ b/common/src/capability/azure_foundry.ts
@@ -1,4 +1,4 @@
-import type { ModelModalities, ModelCapabilities } from '../types.js';
+import type { ModelCapabilities, ModelModalities } from '../types.js';
 
 // Global feature flags - temporarily disable tool support for non-OpenAI models
 const ENABLE_TOOL_SUPPORT_NON_OPENAI = false;

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -1,5 +1,4 @@
 export * from './capability.js';
-export * from './options.js';
 export * from './options/anthropic.js';
 export * from './options/bedrock.js';
 export * from './options/context-windows.js';
@@ -10,4 +9,5 @@ export * from './options/openai.js';
 export * from './options/shared-parsing.js';
 export * from './options/version-parsing.js';
 export * from './options/vertexai.js';
+export * from './options.js';
 export * from './types.js';

--- a/common/src/options/azure_foundry.ts
+++ b/common/src/options/azure_foundry.ts
@@ -1,7 +1,7 @@
 import {
-    type ModelOptionsInfo,
     type ModelOptionInfoItem,
     type ModelOptions,
+    type ModelOptionsInfo,
     OptionType,
     SharedOptions,
 } from '../types.js';

--- a/common/src/options/groq.ts
+++ b/common/src/options/groq.ts
@@ -1,7 +1,7 @@
 import {
-    type ModelOptionsInfo,
     type ModelOptionInfoItem,
     type ModelOptions,
+    type ModelOptionsInfo,
     OptionType,
     SharedOptions,
 } from '../types.js';

--- a/core/package.json
+++ b/core/package.json
@@ -1,112 +1,112 @@
 {
-  "name": "@llumiverse/core",
-  "version": "1.3.0",
-  "type": "module",
-  "description": "Provide an universal API to LLMs. Support for existing LLMs can be added by writing a driver.",
-  "files": [
-    "lib",
-    "src"
-  ],
-  "keywords": [
-    "llm",
-    "ai",
-    "prompt",
-    "prompt engineering",
-    "ml",
-    "machine learning",
-    "embeddings",
-    "training",
-    "model",
-    "universal",
-    "api",
-    "chatgpt",
-    "openai",
-    "vertexai",
-    "bedrock",
-    "replicate",
-    "huggingface",
-    "togetherai"
-  ],
-  "types": "./lib/types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "async": [
-        "./lib/types/async.d.ts"
-      ],
-      "driver": [
-        "./lib/types/Driver.d.ts"
-      ],
-      "formatters": [
-        "./lib/types/formatters/index.d.ts"
-      ],
-      "http-agent": [
-        "./lib/types/http-agent.d.ts"
-      ]
-    }
-  },
-  "exports": {
-    ".": {
-      "types": "./lib/types/index.d.ts",
-      "import": "./lib/esm/index.js",
-      "require": "./lib/cjs/index.js"
+    "name": "@llumiverse/core",
+    "version": "1.3.0",
+    "type": "module",
+    "description": "Provide an universal API to LLMs. Support for existing LLMs can be added by writing a driver.",
+    "files": [
+        "lib",
+        "src"
+    ],
+    "keywords": [
+        "llm",
+        "ai",
+        "prompt",
+        "prompt engineering",
+        "ml",
+        "machine learning",
+        "embeddings",
+        "training",
+        "model",
+        "universal",
+        "api",
+        "chatgpt",
+        "openai",
+        "vertexai",
+        "bedrock",
+        "replicate",
+        "huggingface",
+        "togetherai"
+    ],
+    "types": "./lib/types/index.d.ts",
+    "typesVersions": {
+        "*": {
+            "async": [
+                "./lib/types/async.d.ts"
+            ],
+            "driver": [
+                "./lib/types/Driver.d.ts"
+            ],
+            "formatters": [
+                "./lib/types/formatters/index.d.ts"
+            ],
+            "http-agent": [
+                "./lib/types/http-agent.d.ts"
+            ]
+        }
     },
-    "./async": {
-      "types": "./lib/types/async.d.ts",
-      "import": "./lib/esm/async.js",
-      "require": "./lib/cjs/async.js"
-    },
-    "./driver": {
-      "types": "./lib/types/Driver.d.ts",
-      "import": "./lib/esm/Driver.js",
-      "require": "./lib/cjs/Driver.js"
-    },
-    "./formatters": {
-      "types": "./lib/types/formatters/index.d.ts",
-      "import": "./lib/esm/formatters/index.js",
-      "require": "./lib/cjs/formatters/index.js"
-    },
-    "./http-agent": {
-      "types": "./lib/types/http-agent.d.ts",
-      "import": "./lib/esm/http-agent.js",
-      "require": "./lib/cjs/http-agent.js"
-    }
-  },
-  "scripts": {
-    "lint": "biome lint src",
-    "test": "vitest run",
-    "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-    "build": "pnpm exec tsmod build",
-    "clean": "rimraf ./lib tsconfig.tsbuildinfo"
-  },
-  "author": "Llumiverse",
-  "license": "Apache-2.0",
-  "homepage": "https://github.com/vertesia/llumiverse",
-  "repository": {
-    "type": "git",
-    "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
-  },
-  "devDependencies": {
-    "@vertesia/api-fetch-client": "^1.3.0",
-    "rimraf": "^6.1.3",
-    "ts-dual-module": "^0.6.3",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
-  },
-  "dependencies": {
-    "@llumiverse/common": "workspace:*",
-    "@types/node": "^24.12.4",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
-    "jsonrepair": "^3.14.0",
-    "undici": "^7.20.0"
-  },
-  "ts_dual_module": {
-    "outDir": "lib",
     "exports": {
-      "async": "async.js",
-      "driver": "Driver.js",
-      "formatters": "formatters/index.js",
-      "http-agent": "http-agent.js"
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "./async": {
+            "types": "./lib/types/async.d.ts",
+            "import": "./lib/esm/async.js",
+            "require": "./lib/cjs/async.js"
+        },
+        "./driver": {
+            "types": "./lib/types/Driver.d.ts",
+            "import": "./lib/esm/Driver.js",
+            "require": "./lib/cjs/Driver.js"
+        },
+        "./formatters": {
+            "types": "./lib/types/formatters/index.d.ts",
+            "import": "./lib/esm/formatters/index.js",
+            "require": "./lib/cjs/formatters/index.js"
+        },
+        "./http-agent": {
+            "types": "./lib/types/http-agent.d.ts",
+            "import": "./lib/esm/http-agent.js",
+            "require": "./lib/cjs/http-agent.js"
+        }
+    },
+    "scripts": {
+        "lint": "biome lint src",
+        "test": "vitest run",
+        "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
+        "build": "pnpm exec tsmod build",
+        "clean": "rimraf ./lib tsconfig.tsbuildinfo"
+    },
+    "author": "Llumiverse",
+    "license": "Apache-2.0",
+    "homepage": "https://github.com/vertesia/llumiverse",
+    "repository": {
+        "type": "git",
+        "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
+    },
+    "devDependencies": {
+        "@vertesia/api-fetch-client": "^1.3.0",
+        "rimraf": "^6.1.3",
+        "ts-dual-module": "^0.6.3",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
+    },
+    "dependencies": {
+        "@llumiverse/common": "workspace:*",
+        "@types/node": "^24.12.4",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "jsonrepair": "^3.14.0",
+        "undici": "^7.20.0"
+    },
+    "ts_dual_module": {
+        "outDir": "lib",
+        "exports": {
+            "async": "async.js",
+            "driver": "Driver.js",
+            "formatters": "formatters/index.js",
+            "http-agent": "http-agent.js"
+        }
     }
-  }
 }

--- a/core/src/async.ts
+++ b/core/src/async.ts
@@ -1,5 +1,5 @@
-import type { ServerSentEvent } from '@vertesia/api-fetch-client';
 import type { CompletionChunkObject } from '@llumiverse/common';
+import type { ServerSentEvent } from '@vertesia/api-fetch-client';
 
 export async function* asyncMap<T, R>(asyncIterable: AsyncIterable<T>, callback: (value: T, index: number) => R) {
     let i = 0;

--- a/core/test/conversation-strip.test.ts
+++ b/core/test/conversation-strip.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'vitest';
 import {
-    stripBinaryFromConversation,
+    deserializeBinaryFromStorage,
+    getConversationMeta,
+    incrementConversationTurn,
+    setConversationMeta,
     stripBase64ImagesFromConversation,
+    stripBinaryFromConversation,
     stripHeartbeatsFromConversation,
     truncateLargeTextInConversation,
-    getConversationMeta,
-    setConversationMeta,
-    incrementConversationTurn,
-    deserializeBinaryFromStorage,
 } from '../src/conversation-utils';
 
 import type { Tree } from './__helpers__/test-utils';

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -1,8 +1,8 @@
 import fs, { readFileSync } from 'node:fs';
+import type { JSONArray, JSONObject, JsonResult } from '@llumiverse/common';
 import { describe, expect, test } from 'vitest';
 import { extractAndParseJSON, parseJSON } from '../src/json';
-import type { JSONArray, JSONObject, JsonResult } from '@llumiverse/common';
-import { validateResult, ValidationError } from '../src/validation';
+import { ValidationError, validateResult } from '../src/validation';
 import { readDataFile } from './utils';
 
 describe('Core Utilities', () => {

--- a/core/test/utils.ts
+++ b/core/test/utils.ts
@@ -1,5 +1,5 @@
-import { dirname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 const dataDir = join(dirname(new URL(import.meta.url).pathname), 'data');
 const dataFile = (file: string) => join(dataDir, file);

--- a/drivers/src/bedrock/error-handling.test.ts
+++ b/drivers/src/bedrock/error-handling.test.ts
@@ -1,7 +1,7 @@
 import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
-import { BedrockDriver } from './index.js';
 import { exposePrivate } from '../../test/__helpers__/test-utils.js';
+import { BedrockDriver } from './index.js';
 
 type BedrockDriverInternals = {
     isBedrockErrorRetryable: (

--- a/drivers/src/bedrock/twelvelabs.ts
+++ b/drivers/src/bedrock/twelvelabs.ts
@@ -2,10 +2,11 @@ import {
     type DataSource,
     type ExecutionOptions,
     type JSONSchema,
+    PromptRole,
+    type PromptSegment,
     readStreamAsBase64,
     type TextFallbackOptions,
 } from '@llumiverse/core';
-import { type PromptSegment, PromptRole } from '@llumiverse/core';
 import { isAmazonS3Hostname, parseS3UrlToUri } from './s3.js';
 
 // TwelveLabs Pegasus Request/Response Types

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -1,23 +1,23 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { BaseOpenAIDriver } from './index.js';
 import { LlumiverseError, Providers } from '@llumiverse/core';
 import OpenAI from 'openai';
 import {
-    APIError,
-    BadRequestError,
-    AuthenticationError,
-    PermissionDeniedError,
-    NotFoundError,
-    ConflictError,
-    UnprocessableEntityError,
-    RateLimitError,
-    InternalServerError,
     APIConnectionError,
     APIConnectionTimeoutError,
-    LengthFinishReasonError,
+    APIError,
+    AuthenticationError,
+    BadRequestError,
+    ConflictError,
     ContentFilterFinishReasonError,
+    InternalServerError,
+    LengthFinishReasonError,
+    NotFoundError,
+    PermissionDeniedError,
+    RateLimitError,
+    UnprocessableEntityError,
 } from 'openai/error';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { exposePrivate, getProp } from '../../test/__helpers__/test-utils.js';
+import { BaseOpenAIDriver } from './index.js';
 
 type BaseOpenAIDriverInternals = {
     isOpenAIErrorRetryable: (

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -1,7 +1,7 @@
 // This file is used by multiple drivers
 // to format prompts in a way that is compatible with OpenAI's API.
 
-import { PromptRole, type PromptOptions, type PromptSegment } from '@llumiverse/common';
+import { type PromptOptions, PromptRole, type PromptSegment } from '@llumiverse/common';
 import { readStreamAsBase64 } from '@llumiverse/core';
 import type OpenAI from 'openai';
 

--- a/drivers/src/vertexai/embeddings/embeddings.test.ts
+++ b/drivers/src/vertexai/embeddings/embeddings.test.ts
@@ -12,8 +12,8 @@ import { helpers } from '@google-cloud/aiplatform';
 import { Base64DataSource, URLDataSource } from '@llumiverse/core';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { VertexAIDriver } from '../index.js';
-import { generateLegacyMultimodalEmbeddings } from './embed-legacy-multimodal.js';
 import { generateVertexAiEmbeddings } from './embed.js';
+import { generateLegacyMultimodalEmbeddings } from './embed-legacy-multimodal.js';
 
 // ── Live-mode toggle ──────────────────────────────────────────────────────────
 /** Set to true to run tests against the real Vertex AI API instead of mocks. */

--- a/drivers/src/vertexai/models/claude-error-handling.test.ts
+++ b/drivers/src/vertexai/models/claude-error-handling.test.ts
@@ -13,9 +13,9 @@ import {
 } from '@anthropic-ai/sdk/error';
 import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { exposePrivate } from '../../../test/__helpers__/test-utils.js';
 import type { VertexAIDriver } from '../index.js';
 import { ClaudeModelDefinition } from './claude.js';
-import { exposePrivate } from '../../../test/__helpers__/test-utils.js';
 
 type ClaudeModelInternals = {
     isClaudeErrorRetryable: (

--- a/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
+++ b/drivers/src/vertexai/models/claude-streaming-spacing.test.ts
@@ -1,8 +1,8 @@
 import type { CompletionChunkObject, ExecutionOptions } from '@llumiverse/core';
 import { describe, expect, it } from 'vitest';
+import type { ClaudePrompt } from '../../shared/claude-messages.js';
 import type { VertexAIDriver } from '../index.js';
 import { ClaudeModelDefinition } from './claude.js';
-import type { ClaudePrompt } from '../../shared/claude-messages.js';
 
 function createAsyncStream(events: unknown[]): AsyncIterable<unknown> {
     return (async function* () {

--- a/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
+++ b/drivers/src/vertexai/models/gemini-conversation-mutation.test.ts
@@ -13,8 +13,8 @@
  * Fix: use a local `payloadContents` variable so the caller's conversation is never mutated.
  */
 
-import type { ExecutionOptions } from '@llumiverse/core';
 import { FinishReason } from '@google/genai';
+import type { ExecutionOptions } from '@llumiverse/core';
 import { describe, expect, it } from 'vitest';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 import { convertGeminiFunctionPartsToText, GeminiModelDefinition } from './gemini.js';

--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -1,8 +1,8 @@
 import { LlumiverseError } from '@llumiverse/core';
 import { beforeEach, describe, expect, it } from 'vitest';
+import { exposePrivate, getProp } from '../../../test/__helpers__/test-utils.js';
 import { VertexAIDriver } from '../index.js';
 import { GeminiModelDefinition } from './gemini.js';
-import { exposePrivate, getProp } from '../../../test/__helpers__/test-utils.js';
 
 type GeminiModelInternals = {
     isGeminiErrorRetryable: (httpStatusCode: number, message?: string) => boolean | undefined;

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -1,17 +1,16 @@
+// Import the helper module for converting arbitrary protobuf.Value objects
+import { helpers, type protos } from '@google-cloud/aiplatform';
 import {
     type AIModel,
     type Completion,
     type ExecutionOptions,
+    type ImagenOptions,
     ModelType,
     PromptRole,
     type PromptSegment,
     readStreamAsBase64,
-    type ImagenOptions,
 } from '@llumiverse/core';
 import type { VertexAIDriver } from '../index.js';
-
-// Import the helper module for converting arbitrary protobuf.Value objects
-import { type protos, helpers } from '@google-cloud/aiplatform';
 
 interface ImagenBaseReference {
     referenceType:

--- a/drivers/src/vertexai/models/llama.ts
+++ b/drivers/src/vertexai/models/llama.ts
@@ -9,10 +9,10 @@ import {
     type PromptSegment,
     type TextFallbackOptions,
 } from '@llumiverse/core';
-import type { VertexAIDriver } from '../index.js';
-import type { ModelDefinition } from '../models.js';
 import { transformSSEStream } from '@llumiverse/core/async';
 import type { ServerSentEvent } from '@vertesia/api-fetch-client';
+import type { VertexAIDriver } from '../index.js';
+import type { ModelDefinition } from '../models.js';
 
 interface LLamaMessage {
     role: string;

--- a/drivers/test/openai-streaming-tool-id.test.ts
+++ b/drivers/test/openai-streaming-tool-id.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from 'vitest';
 import type OpenAI from 'openai';
+import { describe, expect, test } from 'vitest';
 import { mapResponseStream } from '../src/openai/index.js';
 import type { Tree } from './__helpers__/test-utils.js';
 

--- a/drivers/test/samples.ts
+++ b/drivers/test/samples.ts
@@ -1,10 +1,10 @@
-import { type DataSource, PromptRole, type PromptSegment, readStreamAsBase64 } from '@llumiverse/core';
-import type { NovaMessagesPrompt } from '@llumiverse/core/formatters';
 import { createReadStream } from 'node:fs';
-import type { JSONSchema } from '@llumiverse/core';
-import { createReadableStreamFromReadable } from 'node-web-stream-adapters';
 import { basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { JSONSchema } from '@llumiverse/core';
+import { type DataSource, PromptRole, type PromptSegment, readStreamAsBase64 } from '@llumiverse/core';
+import type { NovaMessagesPrompt } from '@llumiverse/core/formatters';
+import { createReadableStreamFromReadable } from 'node-web-stream-adapters';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // 512x512 JPEG fallback — within Bedrock's [320, 4096] range

--- a/drivers/test/utils.ts
+++ b/drivers/test/utils.ts
@@ -1,5 +1,5 @@
-import { dirname, join } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type { CompletionResult } from '@llumiverse/common';
 
 const dataDir = join(dirname(new URL(import.meta.url).pathname), 'data');

--- a/drivers/test/vertexai-streaming-conversation.test.ts
+++ b/drivers/test/vertexai-streaming-conversation.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, test } from 'vitest';
 import type { Content } from '@google/genai';
 import { type ExecutionOptions, unwrapConversationArray } from '@llumiverse/core';
+import { describe, expect, test } from 'vitest';
 import { VertexAIDriver, type VertexAIPrompt } from '../src';
 import type { Tree } from './__helpers__/test-utils.js';
 

--- a/examples/src/bedrock.ts
+++ b/examples/src/bedrock.ts
@@ -1,6 +1,7 @@
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
 import { type AIModel, PromptRole, type PromptSegment } from '@llumiverse/core';
 import { BedrockDriver } from '@llumiverse/drivers';
+
 const credentials = defaultProvider({
     profile: 'default',
 });

--- a/package.json
+++ b/package.json
@@ -1,35 +1,30 @@
 {
-  "name": "@llumiverse/parent",
-  "version": "1.3.0",
-  "private": true,
-  "type": "module",
-  "scripts": {
-    "build": "pnpm -r build",
-    "bump": "pnpm exec wst bump minor",
-    "ci:local": "pnpm run format:check && pnpm run lint && pnpm run build && pnpm run typecheck:test && pnpm run test",
-    "format": "pnpm exec biome format --write .",
-    "format:check": "pnpm exec biome format .",
-    "lint": "pnpm exec biome lint",
-    "lint:fix": "pnpm exec biome lint --write",
-    "prepare": "cp ./README.md ./core/ && cp ./README.md ./drivers/ && git config core.hooksPath .githooks 2>/dev/null || true",
-    "release": "pnpm -r publish --access public",
-    "test": "pnpm -r test",
-    "typecheck:test": "pnpm -r typecheck:test"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.4.4",
-    "cross-spawn": "^7.0.6",
-    "lint-staged": "^17.0.5",
-    "npm-ws-tools": "^0.3.0",
-    "rollup": "^4.60.4",
-    "typescript": "^6.0.3",
-    "vitest": "^4.1.7"
-  },
-  "lint-staged": {
-    "*.{js,cjs,mjs,jsx,ts,tsx,css,html}": [
-      "pnpm exec biome format --write --no-errors-on-unmatched --files-ignore-unknown=true",
-      "pnpm exec biome lint --no-errors-on-unmatched --files-ignore-unknown=true --diagnostic-level=error"
-    ]
-  },
-  "packageManager": "pnpm@11.3.0"
+    "name": "@llumiverse/parent",
+    "version": "1.3.0",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "build": "pnpm -r build",
+        "bump": "pnpm exec wst bump minor",
+        "check": "pnpm exec biome check .",
+        "check:write": "pnpm exec biome check --write .",
+        "ci:local": "pnpm run check && pnpm run build && pnpm run typecheck:test && pnpm run test",
+        "format": "pnpm exec biome format --write .",
+        "format:check": "pnpm exec biome format .",
+        "lint": "pnpm exec biome lint",
+        "lint:fix": "pnpm exec biome lint --write",
+        "prepare": "cp ./README.md ./core/ && cp ./README.md ./drivers/ && git config core.hooksPath .githooks 2>/dev/null || true",
+        "release": "pnpm -r publish --access public",
+        "test": "pnpm -r test",
+        "typecheck:test": "pnpm -r typecheck:test"
+    },
+    "devDependencies": {
+        "@biomejs/biome": "2.4.4",
+        "cross-spawn": "^7.0.6",
+        "npm-ws-tools": "^0.3.0",
+        "rollup": "^4.60.4",
+        "typescript": "^6.0.3",
+        "vitest": "^4.1.7"
+    },
+    "packageManager": "pnpm@11.3.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,9 +48,6 @@ importers:
       cross-spawn:
         specifier: ^7.0.6
         version: 7.0.6
-      lint-staged:
-        specifier: ^17.0.5
-        version: 17.0.5
       npm-ws-tools:
         specifier: ^0.3.0
         version: 0.3.0
@@ -62,7 +59,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))
+        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4))
 
   common:
     devDependencies:
@@ -80,7 +77,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))
+        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4))
 
   core:
     dependencies:
@@ -117,7 +114,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))
+        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4))
 
   drivers:
     dependencies:
@@ -217,7 +214,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))
+        version: 4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4))
 
   examples:
     dependencies:
@@ -1031,25 +1028,13 @@ packages:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
     engines: {node: '>=6'}
 
-  ansi-escapes@7.3.0:
-    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
-    engines: {node: '>=18'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
-    engines: {node: '>=12'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
-
-  ansi-styles@6.2.3:
-    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
-    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1087,14 +1072,6 @@ packages:
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
-
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
-    engines: {node: '>=20'}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1153,9 +1130,6 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
-  emoji-regex@10.6.0:
-    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
-
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1165,10 +1139,6 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
-
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
 
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
@@ -1188,9 +1158,6 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -1269,10 +1236,6 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
-  get-east-asian-width@1.6.0:
-    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
-    engines: {node: '>=18'}
-
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
     engines: {node: 18 || 20 || >=22}
@@ -1324,10 +1287,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@5.1.0:
-    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
-    engines: {node: '>=18'}
-
   is-inside-container@1.0.0:
     resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
     engines: {node: '>=14.16'}
@@ -1368,15 +1327,6 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
-  lint-staged@17.0.5:
-    resolution: {integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==}
-    engines: {node: '>=22.22.1'}
-    hasBin: true
-
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
-    engines: {node: '>=22.13.0'}
-
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
 
@@ -1401,10 +1351,6 @@ packages:
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -1414,10 +1360,6 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1466,10 +1408,6 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   open@10.1.0:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
@@ -1552,10 +1490,6 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   retry-request@8.0.2:
     resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
     engines: {node: '>=18'}
@@ -1563,9 +1497,6 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
-
-  rfdc@1.4.1:
-    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rimraf@6.1.3:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
@@ -1600,18 +1531,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
-
-  slice-ansi@7.1.2:
-    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
-    engines: {node: '>=18'}
-
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1634,21 +1553,9 @@ packages:
   stream-shift@1.0.3:
     resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
-  string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
-
-  string-width@7.2.0:
-    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
-    engines: {node: '>=18'}
-
-  string-width@8.2.1:
-    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
-    engines: {node: '>=20'}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1656,10 +1563,6 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
-    engines: {node: '>=12'}
 
   strnum@2.3.0:
     resolution: {integrity: sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==}
@@ -1806,17 +1709,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  wrap-ansi@10.0.0:
-    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
-    engines: {node: '>=20'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  wrap-ansi@9.0.2:
-    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
-    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -1840,11 +1735,6 @@ packages:
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-
-  yaml@2.9.0:
-    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
-    engines: {node: '>= 14.6'}
-    hasBin: true
 
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -2775,13 +2665,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@6.4.2(@types/node@24.12.4))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@24.12.4)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@24.12.4)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -2833,19 +2723,11 @@ snapshots:
 
   ansi-colors@4.1.3: {}
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
-
-  ansi-styles@6.2.3: {}
 
   argparse@2.0.1: {}
 
@@ -2879,15 +2761,6 @@ snapshots:
       run-applescript: 7.0.0
 
   chai@6.2.2: {}
-
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.1
 
   cliui@8.0.1:
     dependencies:
@@ -2939,8 +2812,6 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
 
   end-of-stream@1.4.4:
@@ -2951,8 +2822,6 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
-
-  environment@1.1.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -2993,8 +2862,6 @@ snapshots:
 
   event-target-shim@5.0.1:
     optional: true
-
-  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -3070,8 +2937,6 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.6.0: {}
-
   glob@13.0.6:
     dependencies:
       minimatch: 10.2.5
@@ -3145,10 +3010,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
-
   is-inside-container@1.0.0:
     dependencies:
       is-docker: 3.0.0
@@ -3200,23 +3061,6 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
-  lint-staged@17.0.5:
-    dependencies:
-      listr2: 10.2.1
-      picomatch: 4.0.4
-      string-argv: 0.3.2
-      tinyexec: 1.1.2
-    optionalDependencies:
-      yaml: 2.9.0
-
-  listr2@10.2.1:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
-
   lodash.camelcase@4.3.0: {}
 
   lodash.includes@4.3.0: {}
@@ -3233,14 +3077,6 @@ snapshots:
 
   lodash.once@4.1.1: {}
 
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   long@5.3.2: {}
 
   lru-cache@11.1.0: {}
@@ -3248,8 +3084,6 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-
-  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -3290,10 +3124,6 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   open@10.1.0:
     dependencies:
@@ -3368,11 +3198,6 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   retry-request@8.0.2:
     dependencies:
       extend: 3.0.2
@@ -3381,8 +3206,6 @@ snapshots:
       - supports-color
 
   retry@0.13.1: {}
-
-  rfdc@1.4.1: {}
 
   rimraf@6.1.3:
     dependencies:
@@ -3434,18 +3257,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  signal-exit@4.1.0: {}
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
@@ -3468,24 +3279,11 @@ snapshots:
 
   stream-shift@1.0.3: {}
 
-  string-argv@0.3.2: {}
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.1:
-    dependencies:
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
 
   string_decoder@1.3.0:
     dependencies:
@@ -3494,10 +3292,6 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
-
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
 
   strnum@2.3.0: {}
 
@@ -3539,7 +3333,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0):
+  vite@6.4.2(@types/node@24.12.4):
     dependencies:
       esbuild: 0.25.6
       fdir: 6.5.0(picomatch@4.0.4)
@@ -3550,12 +3344,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       fsevents: 2.3.3
-      yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@24.12.4)(vite@6.4.2(@types/node@24.12.4)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@6.4.2(@types/node@24.12.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.7(vite@6.4.2(@types/node@24.12.4))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -3572,7 +3365,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 6.4.2(@types/node@24.12.4)(yaml@2.9.0)
+      vite: 6.4.2(@types/node@24.12.4)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.4
@@ -3590,23 +3383,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.1
-      strip-ansi: 7.2.0
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 
@@ -3615,9 +3396,6 @@ snapshots:
   xml-naming@0.1.0: {}
 
   y18n@5.0.8: {}
-
-  yaml@2.9.0:
-    optional: true
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary
- Switch the lint/format pipeline to Biome's `check` command.
- Apply the resulting Biome auto-fixes across the codebase (formatting / import ordering / quote style).

## Test Plan
- [ ] Biome check / `pnpm lint` passes in CI
- [ ] Build passes in CI

Note: this is a mechanical Biome `check` migration; verification is via CI (full local build/lint across the repo not run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>
