### PR TITLE
ci: fix stale-PR workflow permissions and raise operations budget

### DIFF
--- a/.github/workflows/dev-stale.yaml
+++ b/.github/workflows/dev-stale.yaml
@@ -22,12 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
+      actions: write # required to manage the stale action's state cache
       issues: write # required to label PRs because PR labels are issue labels
       contents: write # for delete-branch option
       pull-requests: write # required to mark and close stale PRs
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
+          # Raise the per-run budget (default 30) so all stale PRs are
+          # processed in a single run instead of spilling into the next one.
+          operations-per-run: 100
+
           # Only process pull requests, not issues
           days-before-issue-stale: -1
           days-before-issue-close: -1


### PR DESCRIPTION
## Summary
- Add `actions: write` to the `(dev) stale pull requests` workflow's job permissions. `actions/stale` needs this to manage its state cache across runs (per the action's [recommended permissions](https://github.com/actions/stale?tab=readme-ov-file#recommended-permissions)); without it the cache can't be written and the action restarts from scratch each run.
- Set `operations-per-run: 100` (was the default `30`). The previous budget caused `No more operations left! Exiting...` warnings and left stale PRs unprocessed until the next scheduled run.

## Test Plan
- [ ] Workflow-YAML-only change; no build/test applies. Verify via the next scheduled run (or a manual `workflow_dispatch`) that the "No more operations left" warning no longer appears and no permission errors are logged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>