### PR TITLE
fix: correct package export form, use "."

### DIFF
--- a/drivers/package.json
+++ b/drivers/package.json
@@ -9,9 +9,11 @@
     ],
     "types": "./lib/types/index.d.ts",
     "exports": {
-        "types": "./lib/types/index.d.ts",
-        "import": "./lib/esm/index.js",
-        "require": "./lib/cjs/index.js"
+        ".": {
+            "types": "./lib/types/index.d.ts",
+            "import": "./lib/esm/index.js",
+            "require": "./lib/cjs/index.js"
+        }
     },
     "scripts": {
         "lint": "biome lint src",


### PR DESCRIPTION
Previously worked due to:
https://nodejs.org/api/packages.html#exports-sugar

More correct form uses "."