### PR TITLE
feat: Debug prompt, binary truncation

### DIFF
--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -217,7 +217,7 @@ export class DefaultCompletionStream<PromptT = any> implements CompletionStream<
 
         this.completion = {
             result: accumulatedResults, // Return the accumulated CompletionResult[] instead of text
-            prompt: this.prompt,
+            prompt: this.driver.formatDebugPrompt(this.prompt),
             execution_time: Date.now() - start,
             token_usage: tokens,
             finish_reason: finish_reason,

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -196,20 +196,24 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
             }
 
             const execution_time = Date.now() - start;
-            return { ...result, prompt, execution_time };
+            return { ...result, prompt: this.formatDebugPrompt(prompt), execution_time };
         } catch (error) {
             // Don't wrap if already a LlumiverseError
             if (LlumiverseError.isLlumiverseError(error)) {
                 throw error;
             }
             // Log the original error for debugging
-            this.logger.error({ err: error, data: { provider: this.provider, model: options.model, operation: 'execute', prompt } }, `Error during execution in provider ${this.provider}:`);
+            this.logger.error({ err: error, data: { provider: this.provider, model: options.model, operation: 'execute', prompt: this.formatDebugPrompt(prompt) } }, `Error during execution in provider ${this.provider}:`);
             throw this.formatLlumiverseError(error, {
                 provider: this.provider,
                 model: options.model,
                 operation: 'execute',
             });
         }
+    }
+
+    public formatDebugPrompt(prompt: PromptT): PromptT {
+        return prompt;
     }
 
     protected isImageModel(_model: string): boolean {

--- a/drivers/src/anthropic/index.ts
+++ b/drivers/src/anthropic/index.ts
@@ -21,6 +21,7 @@ import {
     type ClaudePrompt,
     executeClaudeCompletion,
     formatAnthropicLlumiverseError,
+    formatClaudeDebugPrompt,
     formatClaudePrompt,
     streamClaudeCompletion,
 } from "../shared/claude-messages.js";
@@ -42,6 +43,10 @@ export class AnthropicDriver extends AbstractDriver<AnthropicDriverOptions, Clau
 
     protected formatPrompt(segments: PromptSegment[], opts: ExecutionOptions): Promise<ClaudePrompt> {
         return formatClaudePrompt(segments, opts);
+    }
+
+    public formatDebugPrompt(prompt: ClaudePrompt): ClaudePrompt {
+        return formatClaudeDebugPrompt(prompt);
     }
 
     async requestTextCompletion(prompt: ClaudePrompt, options: ExecutionOptions): Promise<Completion> {

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -10,7 +10,7 @@ import type {
 } from "@azure-rest/ai-inference";
 import { AzureOpenAIDriver } from "../openai/azure_openai.js";
 import { createSseStream, NodeJSReadableStream } from "@azure/core-sse";
-import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
+import { formatOpenAIDebugPrompt, formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
@@ -100,6 +100,10 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
 
     protected canStream(_options: ExecutionOptions): Promise<boolean> {
         return Promise.resolve(true);
+    }
+
+    public formatDebugPrompt(prompt: ResponseInputItem[]): ResponseInputItem[] {
+        return formatOpenAIDebugPrompt(prompt);
     }
 
     async requestTextCompletion(prompt: ResponseInputItem[], options: ExecutionOptions): Promise<Completion> {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -2,7 +2,7 @@ import {
     Bedrock, CreateModelCustomizationJobCommand, type FoundationModelSummary, GetModelCustomizationJobCommand,
     type GetModelCustomizationJobCommandOutput, ModelCustomizationJobStatus, ModelModality, StopModelCustomizationJobCommand
 } from "@aws-sdk/client-bedrock";
-import { BedrockRuntime, type ContentBlock, type ConverseRequest, type ConverseResponse, type ConverseStreamOutput, type InferenceConfiguration, type Message, type Tool } from "@aws-sdk/client-bedrock-runtime";
+import { BedrockRuntime, type ContentBlock, type ConverseRequest, type ConverseResponse, type ConverseStreamOutput, type InferenceConfiguration, type Message, type Tool, type ToolResultContentBlock } from "@aws-sdk/client-bedrock-runtime";
 import { S3Client } from "@aws-sdk/client-s3";
 import type { AwsCredentialIdentity, Provider } from "@aws-sdk/types";
 import {
@@ -37,6 +37,7 @@ import { transformAsyncIterator } from "@llumiverse/core/async";
 import { formatNovaPrompt, type NovaMessagesPrompt } from "@llumiverse/core/formatters";
 import { LRUCache } from "mnemonist";
 import { resolveClaudeThinking } from "../shared/claude-thinking.js";
+import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from "../shared/debug-prompt.js";
 import { converseConcatMessages, converseJSONprefill, converseSystemToMessages, formatConversePrompt } from "./converse.js";
 import { formatNovaImageGenerationPayload, NovaImageGenerationTaskType } from "./nova-image-payload.js";
 import { forceUploadFile } from "./s3.js";
@@ -115,6 +116,165 @@ export type BedrockPrompt = NovaMessagesPrompt | ConverseRequest | TwelvelabsPeg
 type BedrockSystemBlock = NonNullable<ConverseRequest['system']>[number];
 type BedrockToolEntry = NonNullable<NonNullable<ConverseRequest['toolConfig']>['tools']>[number];
 
+function formatBedrockBytes(bytes: Uint8Array | string | undefined): string | undefined {
+    if (bytes instanceof Uint8Array) {
+        return truncateBinaryForDebug(uint8ArrayToBase64ForDebug(bytes));
+    }
+    if (typeof bytes === 'string') {
+        return truncateBinaryForDebug(bytes);
+    }
+    return bytes;
+}
+
+function formatBedrockBytesForDebug(bytes: Uint8Array | string | undefined): Uint8Array {
+    // AWS SDK prompt types require Uint8Array here, but the debug prompt returned to
+    // Studio must be JSON-safe. Keep the mismatch contained to this conversion.
+    return formatBedrockBytes(bytes) as unknown as Uint8Array;
+}
+
+function formatBedrockContentBlockForDebug(block: ContentBlock): ContentBlock {
+    if (block.image?.source?.bytes) {
+        return {
+            ...block,
+            image: {
+                ...block.image,
+                source: {
+                    ...block.image.source,
+                    bytes: formatBedrockBytesForDebug(block.image.source.bytes),
+                },
+            },
+        };
+    }
+    if (block.document?.source?.bytes) {
+        return {
+            ...block,
+            document: {
+                ...block.document,
+                source: {
+                    ...block.document.source,
+                    bytes: formatBedrockBytesForDebug(block.document.source.bytes),
+                },
+            },
+        };
+    }
+    if (block.video?.source?.bytes) {
+        return {
+            ...block,
+            video: {
+                ...block.video,
+                source: {
+                    ...block.video.source,
+                    bytes: formatBedrockBytesForDebug(block.video.source.bytes),
+                },
+            },
+        };
+    }
+    if (block.toolResult?.content) {
+        return {
+            ...block,
+            toolResult: {
+                ...block.toolResult,
+                content: block.toolResult.content.map(formatBedrockToolResultContentBlockForDebug),
+            },
+        };
+    }
+    return block;
+}
+
+function formatBedrockToolResultContentBlockForDebug(block: ToolResultContentBlock): ToolResultContentBlock {
+    if (block.image?.source?.bytes) {
+        return {
+            ...block,
+            image: {
+                ...block.image,
+                source: {
+                    ...block.image.source,
+                    bytes: formatBedrockBytesForDebug(block.image.source.bytes),
+                },
+            },
+        };
+    }
+    if (block.document?.source?.bytes) {
+        return {
+            ...block,
+            document: {
+                ...block.document,
+                source: {
+                    ...block.document.source,
+                    bytes: formatBedrockBytesForDebug(block.document.source.bytes),
+                },
+            },
+        };
+    }
+    if (block.video?.source?.bytes) {
+        return {
+            ...block,
+            video: {
+                ...block.video,
+                source: {
+                    ...block.video.source,
+                    bytes: formatBedrockBytesForDebug(block.video.source.bytes),
+                },
+            },
+        };
+    }
+    return block;
+}
+
+function formatConversePromptForDebug(prompt: ConverseRequest): ConverseRequest {
+    return {
+        ...prompt,
+        messages: prompt.messages?.map(message => ({
+            ...message,
+            content: message.content?.map(formatBedrockContentBlockForDebug),
+        })),
+    };
+}
+
+function formatNovaPromptForDebug(prompt: NovaMessagesPrompt): NovaMessagesPrompt {
+    return {
+        ...prompt,
+        messages: prompt.messages.map(message => ({
+            ...message,
+            content: message.content.map(part => {
+                if (!part.image?.source.bytes && !part.video?.source.bytes) {
+                    return part;
+                }
+                return {
+                    ...part,
+                    image: part.image ? {
+                        ...part.image,
+                        source: {
+                            ...part.image.source,
+                            bytes: truncateBinaryForDebug(part.image.source.bytes),
+                        },
+                    } : undefined,
+                    video: part.video ? {
+                        ...part.video,
+                        source: {
+                            ...part.video.source,
+                            bytes: part.video.source.bytes ? truncateBinaryForDebug(part.video.source.bytes) : undefined,
+                        },
+                    } : undefined,
+                };
+            }),
+        })),
+    };
+}
+
+function formatTwelvelabsPromptForDebug(prompt: TwelvelabsPegasusRequest): TwelvelabsPegasusRequest {
+    if (!prompt.mediaSource.base64String) {
+        return prompt;
+    }
+    return {
+        ...prompt,
+        mediaSource: {
+            ...prompt.mediaSource,
+            base64String: truncateBinaryForDebug(prompt.mediaSource.base64String),
+        },
+    };
+}
+
 export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockPrompt> {
 
     static PROVIDER = "bedrock";
@@ -161,6 +321,16 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             return await formatTwelvelabsPegasusPrompt(segments, opts);
         }
         return await formatConversePrompt(segments, opts);
+    }
+
+    public formatDebugPrompt(prompt: BedrockPrompt): BedrockPrompt {
+        if ('mediaSource' in prompt) {
+            return formatTwelvelabsPromptForDebug(prompt);
+        }
+        if ('modelId' in prompt) {
+            return formatConversePromptForDebug(prompt);
+        }
+        return formatNovaPromptForDebug(prompt);
     }
 
     /**

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -5,6 +5,7 @@ import type { ChatCompletionMessageParam, ChatCompletionTool } from "groq-sdk/re
 import type { FunctionParameters } from "groq-sdk/resources/shared";
 import type OpenAI from "openai";
 import { formatOpenAILikeMultimodalPrompt } from "../openai/openai_format.js";
+import { truncateDataUrlForDebug } from "../shared/debug-prompt.js";
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
@@ -12,6 +13,30 @@ type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
 interface GroqDriverOptions extends DriverOptions {
     apiKey: string;
     endpoint_url?: string;
+}
+
+type GroqTextContentPart = { type: 'text', text: string };
+type GroqImageContentPart = { type: 'image_url', image_url: { url: string, detail?: 'auto' | 'low' | 'high' } };
+type GroqContentPart = GroqTextContentPart | GroqImageContentPart;
+type GroqUserMessageWithArrayContent = Extract<ChatCompletionMessageParam, { role: 'user' }> & {
+    content: GroqContentPart[];
+};
+
+function hasGroqArrayContent(message: ChatCompletionMessageParam): message is GroqUserMessageWithArrayContent {
+    return message.role === 'user' && Array.isArray(message.content);
+}
+
+function formatGroqContentPartForDebug(part: GroqContentPart): GroqContentPart {
+    if (part.type !== 'image_url') {
+        return part;
+    }
+    return {
+        ...part,
+        image_url: {
+            ...part.image_url,
+            url: truncateDataUrlForDebug(part.image_url.url),
+        },
+    };
 }
 
 export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletionMessageParam[]> {
@@ -59,6 +84,18 @@ export class GroqDriver extends AbstractDriver<GroqDriverOptions, ChatCompletion
 
         // Convert ResponseInputItem[] to Groq ChatCompletionMessageParam[]
         return convertResponseItemsToGroqMessages(responseItems);
+    }
+
+    public formatDebugPrompt(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
+        return messages.map(message => {
+            if (!hasGroqArrayContent(message)) {
+                return message;
+            }
+            return {
+                ...message,
+                content: message.content.map(formatGroqContentPartForDebug),
+            };
+        });
     }
 
     private getToolDefinitions(tools: ToolDefinition[] | undefined): ChatCompletionTool[] | undefined {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -50,7 +50,7 @@ import {
     RateLimitError,
     UnprocessableEntityError,
 } from 'openai/error';
-import { formatOpenAILikeMultimodalPrompt } from "./openai_format.js";
+import { formatOpenAIDebugPrompt, formatOpenAILikeMultimodalPrompt } from "./openai_format.js";
 
 // Response API types
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
@@ -106,6 +106,10 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<
     constructor(opts: BaseOpenAIDriverOptions) {
         super(opts);
         this.formatPrompt = formatOpenAILikeMultimodalPrompt;
+    }
+
+    public formatDebugPrompt(prompt: ResponseInputItem[]): ResponseInputItem[] {
+        return formatOpenAIDebugPrompt(prompt);
     }
 
     extractDataFromResponse(

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -4,11 +4,50 @@
 import { PromptRole, PromptOptions, PromptSegment } from "@llumiverse/common";
 import { readStreamAsBase64 } from "@llumiverse/core";
 import type OpenAI from "openai";
+import { truncateDataUrlForDebug } from "../shared/debug-prompt.js";
 
 // Types for Response API
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type ResponseInputContent = OpenAI.Responses.ResponseInputContent;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
+
+function isResponseInputContent(value: unknown): value is ResponseInputContent {
+    return typeof value === 'object' &&
+        value !== null &&
+        'type' in value &&
+        (value.type === 'input_text' || value.type === 'input_image' || value.type === 'input_file');
+}
+
+function isEasyInputMessageWithInputContent(item: ResponseInputItem): item is EasyInputMessage & { content: ResponseInputContent[] } {
+    return 'content' in item && Array.isArray(item.content) && item.content.every(isResponseInputContent);
+}
+
+export function formatOpenAIDebugPrompt(prompt: ResponseInputItem[]): ResponseInputItem[] {
+    return prompt.map(item => {
+        if (!isEasyInputMessageWithInputContent(item)) {
+            return item;
+        }
+        const content = item.content.map(content => {
+            if (content.type === 'input_image' && 'image_url' in content && typeof content.image_url === 'string') {
+                return {
+                    ...content,
+                    image_url: truncateDataUrlForDebug(content.image_url),
+                } satisfies ResponseInputContent;
+            }
+            if (content.type === 'input_file' && 'file_data' in content && typeof content.file_data === 'string') {
+                return {
+                    ...content,
+                    file_data: truncateDataUrlForDebug(content.file_data),
+                } satisfies ResponseInputContent;
+            }
+            return content;
+        });
+        return {
+            ...item,
+            content,
+        } satisfies EasyInputMessage;
+    });
+}
 
 export interface OpenAITextMessage {
     content: string;

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -63,6 +63,7 @@ import {
 } from '@llumiverse/core';
 import { asyncMap } from '@llumiverse/core/async';
 import { resolveClaudeThinking } from './claude-thinking.js';
+import { truncateBinaryForDebug } from './debug-prompt.js';
 
 // ============================================================================
 // Types
@@ -71,6 +72,40 @@ import { resolveClaudeThinking } from './claude-thinking.js';
 export interface ClaudePrompt {
     messages: MessageParam[];
     system?: TextBlockParam[];
+}
+
+function formatClaudeContentBlockForDebug(block: ContentBlockParam): ContentBlockParam {
+    if (block.type === 'image' && block.source.type === 'base64') {
+        return {
+            ...block,
+            source: {
+                ...block.source,
+                data: truncateBinaryForDebug(block.source.data),
+            },
+        };
+    }
+    if (block.type === 'document' && block.source.type === 'base64') {
+        return {
+            ...block,
+            source: {
+                ...block.source,
+                data: truncateBinaryForDebug(block.source.data),
+            },
+        };
+    }
+    return block;
+}
+
+export function formatClaudeDebugPrompt(prompt: ClaudePrompt): ClaudePrompt {
+    return {
+        ...prompt,
+        messages: prompt.messages.map(message => ({
+            ...message,
+            content: Array.isArray(message.content)
+                ? message.content.map(formatClaudeContentBlockForDebug)
+                : message.content,
+        })),
+    };
 }
 
 export interface AnthropicUsageLike {

--- a/drivers/src/shared/debug-prompt.ts
+++ b/drivers/src/shared/debug-prompt.ts
@@ -1,0 +1,28 @@
+export const BINARY_TRUNCATED_MARKER = '...[truncated binary]...';
+
+const BINARY_DEBUG_EDGE_CHARS = 10;
+
+export function truncateBinaryForDebug(value: string): string {
+    if (value.length <= BINARY_DEBUG_EDGE_CHARS * 2 + BINARY_TRUNCATED_MARKER.length) {
+        return value;
+    }
+    return `${value.slice(0, BINARY_DEBUG_EDGE_CHARS)}${BINARY_TRUNCATED_MARKER}${value.slice(-BINARY_DEBUG_EDGE_CHARS)}`;
+}
+
+export function truncateDataUrlForDebug(value: string): string {
+    const base64Marker = ';base64,';
+    const markerIndex = value.indexOf(base64Marker);
+    if (!value.startsWith('data:') || markerIndex === -1) {
+        return value;
+    }
+    const payloadStart = markerIndex + base64Marker.length;
+    return value.slice(0, payloadStart) + truncateBinaryForDebug(value.slice(payloadStart));
+}
+
+export function uint8ArrayToBase64ForDebug(bytes: Uint8Array): string {
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+}

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -25,11 +25,13 @@ import {
 } from "@llumiverse/core";
 import { FetchClient } from "@vertesia/api-fetch-client";
 import { type AuthClient, GoogleAuth, type GoogleAuthOptions } from "google-auth-library";
+import { type ClaudePrompt, formatClaudeDebugPrompt } from "../shared/claude-messages.js";
 import { getEmbeddingsForImages } from "./embeddings/embeddings-image.js";
 import { type TextEmbeddingsOptions, getEmbeddingsForText } from "./embeddings/embeddings-text.js";
 import { getModelDefinition } from "./models.js";
 import { ANTHROPIC_REGIONS, NON_GLOBAL_ANTHROPIC_MODELS } from "./models/claude.js";
-import { ImagenModelDefinition, type ImagenPrompt } from "./models/imagen.js";
+import { formatGeminiDebugPrompt } from "./models/gemini.js";
+import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } from "./models/imagen.js";
 
 export interface VertexAIDriverOptions extends DriverOptions {
     project: string;
@@ -43,7 +45,7 @@ export interface GenerateContentPrompt {
 }
 
 //General Prompt type for VertexAI
-export type VertexAIPrompt = ImagenPrompt | GenerateContentPrompt;
+export type VertexAIPrompt = ClaudePrompt | ImagenPrompt | GenerateContentPrompt;
 
 export function trimModelName(model: string) {
     const i = model.lastIndexOf("@");
@@ -256,6 +258,16 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
             return new ImagenModelDefinition(options.model).createPrompt(this, segments, options);
         }
         return getModelDefinition(options.model).createPrompt(this, segments, options);
+    }
+
+    public formatDebugPrompt(prompt: VertexAIPrompt): VertexAIPrompt {
+        if ('messages' in prompt) {
+            return formatClaudeDebugPrompt(prompt);
+        }
+        if ('contents' in prompt) {
+            return formatGeminiDebugPrompt(prompt);
+        }
+        return formatImagenDebugPrompt(prompt);
     }
 
     async requestTextCompletion(prompt: VertexAIPrompt, options: ExecutionOptions): Promise<Completion> {

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -25,6 +25,7 @@ import {
     type VertexAIGeminiOptions
 } from "@llumiverse/core";
 import { asyncMap } from "@llumiverse/core/async";
+import { truncateBinaryForDebug } from "../../shared/debug-prompt.js";
 import type { GenerateContentPrompt, VertexAIDriver } from "../index.js";
 import type { ModelDefinition } from "../models.js";
 
@@ -59,6 +60,32 @@ const geminiSafetySettings: SafetySetting[] = [
         threshold: HarmBlockThreshold.BLOCK_ONLY_HIGH
     }
 ];
+
+function formatGeminiContentForDebug(content: Content): Content {
+    return {
+        ...content,
+        parts: content.parts?.map(part => {
+            if (!part.inlineData?.data) {
+                return part;
+            }
+            return {
+                ...part,
+                inlineData: {
+                    ...part.inlineData,
+                    data: truncateBinaryForDebug(part.inlineData.data),
+                },
+            } satisfies Part;
+        }),
+    };
+}
+
+export function formatGeminiDebugPrompt(prompt: GenerateContentPrompt): GenerateContentPrompt {
+    return {
+        ...prompt,
+        contents: prompt.contents.map(formatGeminiContentForDebug),
+        system: prompt.system ? formatGeminiContentForDebug(prompt.system) : undefined,
+    };
+}
 
 // We do the mapping here rather than in common to avoid bringing the SDK into the common package.
 function getProminentPeopleOption(prominentPeople?: "PROMINENT_PEOPLE_UNSPECIFIED" | "ALLOW_PROMINENT_PEOPLE" | "BLOCK_PROMINENT_PEOPLE") {

--- a/drivers/src/vertexai/models/imagen.ts
+++ b/drivers/src/vertexai/models/imagen.ts
@@ -2,6 +2,7 @@ import {
     AIModel, Completion, ExecutionOptions,
     ModelType, PromptRole, PromptSegment, readStreamAsBase64, ImagenOptions
 } from "@llumiverse/core";
+import { truncateBinaryForDebug } from "../../shared/debug-prompt.js";
 import { VertexAIDriver } from "../index.js";
 
 // Import the helper module for converting arbitrary protobuf.Value objects
@@ -81,6 +82,24 @@ export interface ImagenPrompt {
     referenceImages?: ImagenMessage[];
     subjectDescription?: string; //Used for image customization to describe in the reference image
     negativePrompt?: string; //Used for negative prompts
+}
+
+export function formatImagenDebugPrompt(prompt: ImagenPrompt): ImagenPrompt {
+    return {
+        ...prompt,
+        referenceImages: prompt.referenceImages?.map(reference => {
+            if (!reference.referenceImage?.bytesBase64Encoded) {
+                return reference;
+            }
+            return {
+                ...reference,
+                referenceImage: {
+                    ...reference.referenceImage,
+                    bytesBase64Encoded: truncateBinaryForDebug(reference.referenceImage.bytesBase64Encoded),
+                },
+            };
+        }),
+    };
 }
 
 function getImagenParameters(taskType: string, options: ImagenOptions) {

--- a/drivers/test/debug-prompt.test.ts
+++ b/drivers/test/debug-prompt.test.ts
@@ -1,0 +1,187 @@
+import type { ConverseRequest } from "@aws-sdk/client-bedrock-runtime";
+import type { Content } from "@google/genai";
+import { describe, expect, test } from "vitest";
+import { BedrockDriver } from "../src/bedrock/index.js";
+import { GroqDriver } from "../src/groq/index.js";
+import { formatOpenAIDebugPrompt } from "../src/openai/openai_format.js";
+import { formatClaudeDebugPrompt, type ClaudePrompt } from "../src/shared/claude-messages.js";
+import { BINARY_TRUNCATED_MARKER } from "../src/shared/debug-prompt.js";
+import type { GenerateContentPrompt } from "../src/vertexai/index.js";
+import { formatGeminiDebugPrompt } from "../src/vertexai/models/gemini.js";
+import { formatImagenDebugPrompt } from "../src/vertexai/models/imagen.js";
+import type { ImagenPrompt } from "../src/vertexai/models/imagen.js";
+
+describe('debug prompt binary truncation', () => {
+    test('truncates Claude base64 content blocks', () => {
+        const prompt: ClaudePrompt = {
+            messages: [{
+                role: 'user',
+                content: [{
+                    type: 'image',
+                    source: {
+                        type: 'base64',
+                        media_type: 'image/png',
+                        data: 'a'.repeat(80),
+                    },
+                }],
+            }],
+        };
+
+        const result = formatClaudeDebugPrompt(prompt);
+        const content = result.messages[0].content;
+
+        expect(Array.isArray(content) && content[0].type === 'image' && content[0].source.type === 'base64'
+            ? content[0].source.data
+            : undefined).toBe(`aaaaaaaaaa${BINARY_TRUNCATED_MARKER}aaaaaaaaaa`);
+        expect(prompt.messages[0].content[0].type === 'image' && prompt.messages[0].content[0].source.type === 'base64'
+            ? prompt.messages[0].content[0].source.data
+            : undefined).toBe('a'.repeat(80));
+    });
+
+    test('truncates OpenAI response input image data URLs', () => {
+        const prompt: Parameters<typeof formatOpenAIDebugPrompt>[0] = [{
+            role: 'user',
+            content: [{
+                type: 'input_image',
+                image_url: `data:image/png;base64,${'b'.repeat(80)}`,
+                detail: 'auto',
+            }],
+        }];
+
+        const result = formatOpenAIDebugPrompt(prompt);
+        const item = result[0];
+
+        expect('content' in item && Array.isArray(item.content) && item.content[0].type === 'input_image'
+            ? item.content[0].image_url
+            : undefined).toBe(`data:image/png;base64,bbbbbbbbbb${BINARY_TRUNCATED_MARKER}bbbbbbbbbb`);
+    });
+
+    test('truncates OpenAI response input file data URLs', () => {
+        const prompt: Parameters<typeof formatOpenAIDebugPrompt>[0] = [{
+            role: 'user',
+            content: [{
+                type: 'input_file',
+                filename: 'document.pdf',
+                file_data: `data:application/pdf;base64,${'f'.repeat(80)}`,
+            }],
+        }];
+
+        const result = formatOpenAIDebugPrompt(prompt);
+        const item = result[0];
+
+        expect('content' in item && Array.isArray(item.content) && item.content[0].type === 'input_file'
+            ? item.content[0].file_data
+            : undefined).toBe(`data:application/pdf;base64,ffffffffff${BINARY_TRUNCATED_MARKER}ffffffffff`);
+    });
+
+    test('truncates Vertex Gemini inlineData payloads', () => {
+        const prompt: GenerateContentPrompt = {
+            contents: [{
+                role: 'user',
+                parts: [{
+                    inlineData: {
+                        mimeType: 'image/png',
+                        data: 'c'.repeat(80),
+                    },
+                }],
+            } satisfies Content],
+        };
+
+        const result = formatGeminiDebugPrompt(prompt);
+
+        expect(result.contents[0].parts?.[0].inlineData?.data).toBe(`cccccccccc${BINARY_TRUNCATED_MARKER}cccccccccc`);
+    });
+
+    test('truncates Vertex Imagen reference images', () => {
+        const prompt: ImagenPrompt = {
+            prompt: 'make an image',
+            referenceImages: [{
+                referenceType: 'REFERENCE_TYPE_RAW',
+                referenceId: 1,
+                referenceImage: {
+                    bytesBase64Encoded: 'd'.repeat(80),
+                },
+            }],
+        };
+
+        const result = formatImagenDebugPrompt(prompt);
+
+        expect(result.referenceImages?.[0].referenceImage?.bytesBase64Encoded).toBe(`dddddddddd${BINARY_TRUNCATED_MARKER}dddddddddd`);
+    });
+
+    test('truncates Bedrock Converse byte sources', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const prompt: ConverseRequest = {
+            modelId: 'anthropic.claude-3-sonnet',
+            messages: [{
+                role: 'user',
+                content: [{
+                    image: {
+                        format: 'png',
+                        source: {
+                            bytes: Uint8Array.from({ length: 120 }, (_, i) => i),
+                        },
+                    },
+                }],
+            }],
+        };
+
+        const result = driver.formatDebugPrompt(prompt);
+        const bytes: unknown = 'modelId' in result
+            ? result.messages?.[0].content?.[0].image?.source?.bytes
+            : undefined;
+
+        expect(typeof bytes).toBe('string');
+        expect(bytes).toContain(BINARY_TRUNCATED_MARKER);
+    });
+
+    test('truncates Bedrock Converse tool result byte sources', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const prompt: ConverseRequest = {
+            modelId: 'anthropic.claude-3-sonnet',
+            messages: [{
+                role: 'user',
+                content: [{
+                    toolResult: {
+                        toolUseId: 'tool-1',
+                        content: [{
+                            image: {
+                                format: 'png',
+                                source: {
+                                    bytes: Uint8Array.from({ length: 120 }, (_, i) => i),
+                                },
+                            },
+                        }],
+                    },
+                }],
+            }],
+        };
+
+        const result = driver.formatDebugPrompt(prompt);
+        const bytes: unknown = 'modelId' in result
+            ? result.messages?.[0].content?.[0].toolResult?.content?.[0].image?.source?.bytes
+            : undefined;
+
+        expect(typeof bytes).toBe('string');
+        expect(bytes).toContain(BINARY_TRUNCATED_MARKER);
+    });
+
+    test('truncates Groq chat image data URLs', () => {
+        const driver = new GroqDriver({ apiKey: 'test' });
+        const result = driver.formatDebugPrompt([{
+            role: 'user',
+            content: [{
+                type: 'image_url',
+                image_url: {
+                    url: `data:image/jpeg;base64,${'e'.repeat(80)}`,
+                },
+            }],
+        }]);
+
+        const content = result[0].content;
+
+        expect(Array.isArray(content) && content[0].type === 'image_url'
+            ? content[0].image_url.url
+            : undefined).toBe(`data:image/jpeg;base64,eeeeeeeeee${BINARY_TRUNCATED_MARKER}eeeeeeeeee`);
+    });
+});


### PR DESCRIPTION
## Summary
- add a debug prompt formatting hook so returned prompts can differ from execution prompts
- truncate inline binary/base64 debug payloads in typed driver-specific prompt formatters
- cover Claude, OpenAI/Azure/Groq, Vertex Gemini/Imagen, and Bedrock prompt shapes

## Validation
- pnpm build
- cd drivers && pnpm exec vitest run test/debug-prompt.test.ts