### PR TITLE
ci(renovate): add scoped automerge for eligible Renovate PRs

### DIFF
--- a/.github/workflows/renovate-automerge.yaml
+++ b/.github/workflows/renovate-automerge.yaml
@@ -1,0 +1,232 @@
+name: (renovate) automerge eligible dependency updates
+
+on:
+  # zizmor: ignore[dangerous-triggers] This intentionally chains after successful Renovate branch workflows, then re-checks the exact head SHA before merging.
+  workflow_run:
+    workflows:
+      - "(test) Build and test"
+      - "(lint) Lint codebase"
+    types:
+      - completed
+    branches:
+      - "renovate/**"
+
+permissions:
+  actions: read # required to inspect workflow run status for the exact Renovate head SHA
+  contents: read # required for repository metadata access through gh
+  pull-requests: read # required to inspect PR metadata, labels, and changed files
+
+jobs:
+  approve-and-merge:
+    name: Approve and merge eligible Renovate PR
+    if: |
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'renovate/')
+    runs-on: ubuntu-latest
+    environment: renovate-automerge
+    timeout-minutes: 5
+    concurrency:
+      group: renovate-automerge-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Check automerge eligibility
+        id: eligibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "should_merge=false"
+            echo "pr_url="
+          } >> "$GITHUB_OUTPUT"
+
+          prs_json="$(gh pr list \
+            --repo "$REPO" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --json number,url,author,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,labels,mergeStateStatus,files,commits \
+            --limit 10)"
+
+          pr_count="$(jq 'length' <<< "$prs_json")"
+          if [[ "$pr_count" == "0" ]]; then
+            echo "No open PR found for $HEAD_BRANCH."
+            exit 0
+          fi
+          if [[ "$pr_count" != "1" ]]; then
+            echo "Expected exactly one open PR for $HEAD_BRANCH, found $pr_count." >&2
+            exit 1
+          fi
+
+          pr_number="$(jq -r '.[0].number' <<< "$prs_json")"
+          pr_url="$(jq -r '.[0].url' <<< "$prs_json")"
+          author_login="$(jq -r '.[0].author.login // ""' <<< "$prs_json")"
+          base_ref="$(jq -r '.[0].baseRefName' <<< "$prs_json")"
+          head_ref="$(jq -r '.[0].headRefName' <<< "$prs_json")"
+          head_sha="$(jq -r '.[0].headRefOid' <<< "$prs_json")"
+          head_repo="$(jq -r '.[0].headRepository.nameWithOwner // ""' <<< "$prs_json")"
+          head_owner="$(jq -r '.[0].headRepositoryOwner.login // ""' <<< "$prs_json")"
+          is_cross_repo="$(jq -r '.[0].isCrossRepository' <<< "$prs_json")"
+          is_draft="$(jq -r '.[0].isDraft' <<< "$prs_json")"
+          merge_state="$(jq -r '.[0].mergeStateStatus // ""' <<< "$prs_json")"
+          repo_owner="${REPO%%/*}"
+
+          if [[ "$author_login" != "loopingz" ]]; then
+            echo "Skipping PR #$pr_number: author is $author_login, not loopingz."
+            exit 0
+          fi
+          if [[ "$head_ref" != "$HEAD_BRANCH" ]]; then
+            echo "Skipping PR #$pr_number: PR head branch $head_ref does not match workflow branch $HEAD_BRANCH."
+            exit 0
+          fi
+          if [[ "$is_cross_repo" != "false" ]]; then
+            echo "Skipping PR #$pr_number: PR is from a fork."
+            exit 0
+          fi
+          if [[ "$head_repo" != "$REPO" ]]; then
+            echo "Skipping PR #$pr_number: head repository is $head_repo, not $REPO."
+            exit 0
+          fi
+          if [[ "$head_owner" != "$repo_owner" ]]; then
+            echo "Skipping PR #$pr_number: head repository owner is $head_owner, not $repo_owner."
+            exit 0
+          fi
+          if [[ "$base_ref" != "main" ]]; then
+            echo "Skipping PR #$pr_number: base branch is $base_ref, not main."
+            exit 0
+          fi
+          if [[ "$is_draft" != "false" ]]; then
+            echo "Skipping PR #$pr_number: PR is draft."
+            exit 0
+          fi
+          if [[ "$head_sha" != "$HEAD_SHA" ]]; then
+            echo "Skipping PR #$pr_number: workflow SHA $HEAD_SHA does not match current PR head $head_sha."
+            exit 0
+          fi
+          if ! jq -e '.[0].labels | any(.name == "renovate-automerge")' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: missing renovate-automerge label."
+            exit 0
+          fi
+          if ! jq -e '.[0].labels | any(.name == "dependencies")' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: missing dependencies label."
+            exit 0
+          fi
+          if [[ "$merge_state" == "DIRTY" ]]; then
+            echo "Skipping PR #$pr_number: PR has merge conflicts."
+            exit 0
+          fi
+
+          if ! jq -e '.[0].files | all(.changeType == "MODIFIED")' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: PR includes non-modified file changes."
+            jq -r '.[0].files[] | select(.changeType != "MODIFIED") | "- \(.changeType) \(.path)"' <<< "$prs_json"
+            exit 0
+          fi
+
+          disallowed_files="$(gh pr diff "$pr_url" --repo "$REPO" --name-only | grep -vE '(^|/)(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$' || true)"
+          if [[ -n "$disallowed_files" ]]; then
+            echo "Skipping PR #$pr_number: PR changes files outside supported dependency manifests/lockfiles."
+            echo "$disallowed_files"
+            exit 0
+          fi
+
+          if ! jq -e '
+            .[0].commits as $commits
+            | ($commits | length) > 0
+            and ($commits | all(
+              (
+                .authors | any(
+                  .login == "renovate-bot"
+                  or .email == "renovate@whitesourcesoftware.com"
+                )
+              )
+              or (
+                (.messageHeadline == "chore: update lockfile" or (.messageHeadline | startswith("Merge ")))
+                and (
+                  .authors | any(
+                    .login == "github-actions[bot]"
+                    or .email == "github-actions[bot]@users.noreply.github.com"
+                    or .name == "github-actions[bot]"
+                  )
+                )
+              )
+            ))
+          ' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: PR contains commits not authored by Renovate or the lockfile repair workflow."
+            exit 0
+          fi
+
+          echo "PR #$pr_number by $author_login is eligible for automerge after workflow checks pass."
+
+          required_workflows=(
+            "build-and-test.yml"
+            "lint.yml"
+          )
+
+          for workflow in "${required_workflows[@]}"; do
+            runs_json="$(gh run list \
+              --repo "$REPO" \
+              --workflow "$workflow" \
+              --branch "$HEAD_BRANCH" \
+              --commit "$HEAD_SHA" \
+              --json databaseId,status,conclusion,event,headSha,url \
+              --limit 20)"
+            run_json="$(jq -c --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha and .event == "push")] | sort_by(.databaseId) | last // empty' <<< "$runs_json")"
+
+            if [[ -z "$run_json" ]]; then
+              echo "Waiting for $workflow to run for $HEAD_SHA."
+              exit 0
+            fi
+
+            status="$(jq -r '.status' <<< "$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+            url="$(jq -r '.url' <<< "$run_json")"
+
+            if [[ "$status" != "completed" ]]; then
+              echo "Waiting for $workflow to complete for $HEAD_SHA: $url"
+              exit 0
+            fi
+            if [[ "$conclusion" != "success" ]]; then
+              echo "Not merging PR #$pr_number: $workflow concluded '$conclusion': $url"
+              exit 0
+            fi
+
+            echo "$workflow passed for $HEAD_SHA: $url"
+          done
+
+          {
+            echo "should_merge=true"
+            echo "pr_url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate automerge token
+        if: steps.eligibility.outputs.should_merge == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_VERTESIA_RENOVATE_AUTOMERGE_ID }}
+          private-key: ${{ secrets.APP_VERTESIA_RENOVATE_AUTOMERGE_PEM }}
+          permission-actions: read
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Approve and merge eligible Renovate PR
+        if: steps.eligibility.outputs.should_merge == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_URL: ${{ steps.eligibility.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Auto-approved eligible Renovate dependency update after build/test and lint passed for ${HEAD_SHA}."
+          gh pr merge "$PR_URL" \
+            --repo "$REPO" \
+            --squash \
+            --delete-branch \
+            --match-head-commit "$HEAD_SHA"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Default label applied to every Renovate PR (matches studio/composableai).
+  // The automerge workflow's eligibility gate requires this label.
+  "labels": ["dependencies"],
   // Bypass the 7-day minimum release age for security fixes.
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days"
@@ -12,6 +15,15 @@
         "*"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      // Mark npm patch/minor updates eligible for scoped bot automerge
+      // (the renovate-automerge.yaml workflow merges them once CI passes).
+      // node/npm/pnpm are excluded so runtime/package-manager bumps stay manual.
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "addLabels": ["renovate-automerge"],
+      "matchPackageNames": ["!npm", "!pnpm", "!node"]
     },
     {
       "groupName": "gh-actions deps",


### PR DESCRIPTION
## Why

Renovate PRs in llumiverse (e.g. #437) never auto-merge because llumiverse has **no auto-merge mechanism at all**

## What

**`.github/workflows/renovate-automerge.yaml`** — ported from studio, adapted to llumiverse:
- Triggers after `(test) Build and test` + `(lint) Lint codebase` complete on `renovate/**` branches.
- Re-checks the exact head SHA, then enforces the same eligibility gates: author `loopingz`, same-repo (no forks), base `main`, not draft, `renovate-automerge` **and** `dependencies` labels present, no merge conflicts, all files `MODIFIED`, every commit Renovate/lockfile-bot authored.
- **File allowlist limited to npm** manifests/lockfiles (`package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`) — llumiverse has no maven/go/terraform/python.
- Requires `build-and-test.yml` + `lint.yml` to have concluded `success` for the head SHA, then approves + squash-merges via the GitHub App token.

**`.renovaterc.json5`**:
- Adds the default `labels: ["dependencies"]` (the gate requires it).
- Adds the `renovate-automerge` label to **npm patch/minor** updates (`node`/`npm`/`pnpm` excluded). **Majors stay unlabeled → manual merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)