### PR TITLE
fix(build): clean lib + tsbuildinfo before building core/common/drivers

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -59,7 +59,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./lib tsconfig.tsbuildinfo"
     },
     "author": "Llumiverse",

--- a/core/package.json
+++ b/core/package.json
@@ -75,7 +75,7 @@
         "lint": "biome lint src",
         "test": "vitest run",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./lib tsconfig.tsbuildinfo"
     },
     "author": "Llumiverse",

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -19,7 +19,7 @@
         "lint": "biome lint src",
         "test": "vitest run --retry 3 --passWithNoTests",
         "typecheck:test": "tsc -p tsconfig.test.json --noEmit",
-        "build": "pnpm exec tsmod build",
+        "build": "pnpm exec rimraf ./lib ./tsconfig.tsbuildinfo && pnpm exec tsmod build",
         "clean": "rimraf ./lib tsconfig.tsbuildinfo"
     },
     "author": "Llumiverse",


### PR DESCRIPTION
## Summary

`@llumiverse/core`, `@llumiverse/common`, and `@llumiverse/drivers` compile with TypeScript project references (`composite: true`), keeping an incremental cache in `tsconfig.tsbuildinfo`. When a CI/build cache restores a **stale** `lib/` + `tsbuildinfo`, the incremental build can skip re-emitting newly-added declarations — producing a package that's missing recent exports and breaking downstream typechecks.

## Fix

Prepend `rimraf ./lib ./tsconfig.tsbuildinfo` to each `build` script so every rebuild starts from a clean slate and stale incremental state can't survive a cache restore.

## Why this doesn't hurt caching
The task runner caches at the **task** level (keyed on inputs, restoring outputs). On a cache **hit** the build script never runs, so the `rimraf` + recompile don't happen. It only runs on a cache **miss** — an actual rebuild, where a clean compile is exactly what's wanted. Removing `tsbuildinfo` only disables TypeScript's intra-build incremental (sub-second here); it does not affect task/remote caching.

## Verification
- `pnpm build` → core / common / drivers all build clean with the new step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>