### PR TITLE
chore(renovate): batch dependency PRs by weekday

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -83,7 +83,8 @@
         "npm",
         "pnpm"
       ],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": "* * * * 2" // Tuesday
     },
     {
       "description": "Keep Node.js-related updates on v24 until the runtime is upgraded deliberately.",

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -28,7 +28,8 @@
     {
       "groupName": "gh-actions deps",
       "matchManagers": ["github-actions"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": "* * * * 2" // Tuesday
     },
     {
       // Mark gh-actions patch/minor/digest updates eligible for scoped bot
@@ -43,7 +44,8 @@
     {
       "groupName": "node deps",
       "matchManagers": ["npm", "nvm", "nodenv"],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": "* * * * 3" // Wednesday
     },
     {
       "groupName": "Model Provider Client libraries",
@@ -61,7 +63,8 @@
         "@aws-sdk/**",
         "@anthropic-ai/**"
       ],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": "* * * * 4" // Thursday
     },
     {
       "groupName": "Vertesia libraries",
@@ -72,7 +75,8 @@
         "@vertesia/**",
         "ts-dual-module"
       ],
-      "rangeStrategy": "bump"
+      "rangeStrategy": "bump",
+      "schedule": "* * * * 1" // Monday
     },
     {
       "groupName": "package manager dependencies",


### PR DESCRIPTION
## Summary
Most Renovate package-rule groups had no `schedule`, so PRs were opened on any day of the week. This pins each group to a weekday so non-security updates batch to a predictable single day per group (matching the convention in the related repos):

| Day | Groups |
|-----|--------|
| Mon | Vertesia libraries |
| Tue | gh-actions deps, package manager dependencies |
| Wed | node deps |
| Thu | Model Provider Client libraries, Package Overrides |

## Security fixes unaffected
`vulnerabilityAlerts` (`minimumReleaseAge: "0 days"`) is unchanged, so security remediation PRs continue to be raised immediately regardless of these schedules.

## Test Plan
- [ ] Config-only change to `.renovaterc.json5` (JSON5); no build/test impact.
- [ ] Each group's next non-security update PR should only open on its assigned weekday.
- [ ] Security alerts still open any day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>