### PR TITLE
fix: retry transport aborts and deadline-exceeded errors

### DIFF
--- a/core/src/Driver.error.test.ts
+++ b/core/src/Driver.error.test.ts
@@ -98,6 +98,15 @@ describe('AbstractDriver Error Formatting', () => {
                 expect(driver.isRetryableError(400, 'Please retry with a valid model id')).toBe(false);
             });
 
+            it('should mark transport aborts and deadline-exceeded as retryable even under a 4xx status', () => {
+                expect(driver.isRetryableError(undefined, 'This operation was aborted')).toBe(true);
+                expect(driver.isRetryableError(499, 'This operation was aborted')).toBe(true);
+                expect(driver.isRetryableError(400, 'Deadline expired before operation could complete')).toBe(true);
+                expect(driver.isRetryableError(504, '[504] DEADLINE_EXCEEDED')).toBe(true);
+                // a genuine non-transient 4xx without an abort/deadline signal stays non-retryable
+                expect(driver.isRetryableError(400, 'Invalid argument')).toBe(false);
+            });
+
             it('should mark 2xx and 3xx as not retryable', () => {
                 expect(driver.isRetryableError(200, 'OK')).toBe(false);
                 expect(driver.isRetryableError(301, 'Moved permanently')).toBe(false);

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -398,6 +398,12 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         if (lowerMessage.includes('throttl')) return true;
         if (lowerMessage.includes('429')) return true;
         if (lowerMessage.includes('529')) return true;
+        // A transport-level abort (request-timeout / dropped connection) or a
+        // deadline-exceeded is transient and should be retried — even when the provider
+        // surfaces it under a misleading 4xx status. A deliberate cancellation is raised
+        // as a Temporal CancelledFailure (not an LLM error), so it never reaches here.
+        if (lowerMessage.includes('aborted')) return true;
+        if (lowerMessage.includes('deadline')) return true;
 
         // Numeric status codes
         if (statusCode !== undefined) {

--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -93,6 +93,24 @@ describe('GeminiModelDefinition Error Handling', () => {
             expect(error.name).toBe('NOT_FOUND');
         });
 
+        it('should mark a client-closed/aborted request (499) as retryable despite the 4xx status', () => {
+            const error = modelDef.formatLlumiverseError(
+                driver,
+                { status: 499, message: 'This operation was aborted' },
+                { provider: 'vertexai', model: 'gemini-2.0-flash', operation: 'execute' },
+            );
+            expect(error.retryable).toBe(true);
+        });
+
+        it('should mark DEADLINE_EXCEEDED as retryable even under a 4xx status', () => {
+            const error = modelDef.formatLlumiverseError(
+                driver,
+                { status: 400, message: 'DEADLINE_EXCEEDED: Deadline expired before operation could complete' },
+                { provider: 'vertexai', model: 'gemini-2.0-flash', operation: 'execute' },
+            );
+            expect(error.retryable).toBe(true);
+        });
+
         it('should handle RESOURCE_EXHAUSTED error (429) as retryable', () => {
             const googleError = {
                 status: 429,

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -933,6 +933,14 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             }
         }
 
+        // A transport-level abort (request-timeout / dropped connection, sometimes reported
+        // as 499 client-closed) or a deadline-exceeded is transient and should be retried,
+        // even though it carries a 4xx status. Honor it before the 4xx → non-retryable rule.
+        if (message) {
+            const lower = message.toLowerCase();
+            if (lower.includes('aborted') || lower.includes('deadline')) return true;
+        }
+
         // Non-retryable 4xx client errors
         if (httpStatusCode >= 400 && httpStatusCode < 500) return false;
 


### PR DESCRIPTION
## Summary
- Classify request-timeout / dropped-connection **aborts** and **deadline-exceeded** as retryable in the base driver classifier (`Driver.isRetryableError`) and the Gemini override (`isGeminiErrorRetryable`).
- The transient message signal is now honored **before** the generic `4xx → non-retryable` rule, so an abort/deadline reported under a misleading 4xx status (e.g. `499` client-closed) is no longer marked non-retryable.
- A deliberate cancellation surfaces as a separate error type and is unaffected; genuine 4xx client errors (400/401/403/404) remain non-retryable.

## Why
A transient streaming abort (e.g. a slow Gemini call hitting a request timeout) was being classified non-retryable, so the call failed on its first attempt instead of being retried.

## Test Plan
- [x] `core` — `vitest run src/Driver.error.test.ts` → 25 passed (adds abort/deadline/499 cases; existing 4xx cases unchanged)
- [x] `drivers` — `vitest run src/vertexai/models/gemini-error-handling.test.ts` → 28 passed (adds 499-abort and 400-deadline cases)
- [x] `turbo build` for `@llumiverse/core` and `@llumiverse/drivers` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>