### PR TITLE
fix: invalid_grant is non-retryable

### DIFF
--- a/core/src/Driver.error.test.ts
+++ b/core/src/Driver.error.test.ts
@@ -143,6 +143,15 @@ describe('AbstractDriver Error Formatting', () => {
                 expect(driver.isRetryableError(undefined, 'HTTP 529 error')).toBe(true);
             });
 
+            it('should classify invalid_grant credential issuer failures as non-retryable', () => {
+                expect(
+                    driver.isRetryableError(
+                        undefined,
+                        "Error code invalid_grant: Error connecting to the given credential's issuer.",
+                    ),
+                ).toBe(false);
+            });
+
             it('should mark unknown messages as undefined (let consumer decide)', () => {
                 expect(driver.isRetryableError(undefined, 'Invalid API key')).toBeUndefined();
                 expect(driver.isRetryableError(undefined, 'Bad request')).toBeUndefined();

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -399,6 +399,11 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
         if (lowerMessage.includes('429')) return true;
         if (lowerMessage.includes('529')) return true;
 
+        // Explicit auth failures should never be retried even when they arrive without
+        // a numeric status code (for example, google-auth-library invalid_grant errors).
+        if (lowerMessage.includes('invalid_grant')) return false;
+        if (lowerMessage.includes("credential's issuer")) return false;
+
         // Numeric status codes
         if (statusCode !== undefined) {
             if (statusCode === 429 || statusCode === 408) return true; // Rate limit, timeout

--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -291,6 +291,36 @@ describe('GeminiModelDefinition Error Handling', () => {
             expect(error.name).toBe('LlumiverseError');
             expect(error.code).toBe(500);
         });
+
+        it('should treat invalid_grant credential issuer failures as non-retryable', () => {
+            const authError = new Error("Error code invalid_grant: Error connecting to the given credential's issuer.");
+
+            const error = driver.formatLlumiverseError(authError, {
+                provider: 'vertexai',
+                model: 'gemini-2.5-flash',
+                operation: 'execute',
+            });
+
+            expect(error.retryable).toBe(false);
+            expect(error.code).toBeUndefined();
+        });
+
+        it('should preserve invalid_grant from Google API errors', () => {
+            const googleError = {
+                status: 400,
+                message: "Error code invalid_grant: Error connecting to the given credential's issuer.",
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'locations/global/publishers/google/models/gemini-2.5-flash',
+                operation: 'execute',
+            });
+
+            expect(error.retryable).toBe(false);
+            expect(error.code).toBe(400);
+            expect(error.name).toBe('invalid_grant');
+        });
     });
 
     describe('isGeminiErrorRetryable', () => {
@@ -343,6 +373,15 @@ describe('GeminiModelDefinition Error Handling', () => {
                 exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(
                     400,
                     'INVALID_ARGUMENT: bad input',
+                ),
+            ).toBe(false);
+        });
+
+        it('should treat invalid_grant as non-retryable before status-based retry rules', () => {
+            expect(
+                exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(
+                    503,
+                    "Error code invalid_grant: Error connecting to the given credential's issuer.",
                 ),
             ).toBe(false);
         });

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -50,6 +50,8 @@ import { truncateBinaryForDebug } from '../../shared/debug-prompt.js';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 import type { ModelDefinition } from '../models.js';
 
+type GoogleApiErrorLike = Pick<ApiError, 'status' | 'message'>;
+
 function supportsStructuredOutput(options: PromptOptions): boolean {
     // Gemini 1.0 Ultra does not support JSON output, 1.0 Pro does.
     return !!options.result_schema && !options.model.includes('ultra');
@@ -841,11 +843,11 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             throw error;
         }
 
-        const apiError = error as ApiError;
+        const apiError = error;
         const httpStatusCode = apiError.status;
 
         // Extract error message
-        const message = apiError.message || String(error);
+        const message = apiError.message;
 
         // Build user-facing message with status code
         let userMessage = message;
@@ -874,13 +876,14 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
     /**
      * Type guard to check if error is a Google API error.
      */
-    private isGoogleApiError(error: unknown): error is ApiError {
+    private isGoogleApiError(error: unknown): error is GoogleApiErrorLike {
         return (
             error !== null &&
             typeof error === 'object' &&
             'status' in error &&
             typeof (error as { status?: unknown }).status === 'number' &&
-            'message' in error
+            'message' in error &&
+            typeof (error as { message?: unknown }).message === 'string'
         );
     }
 
@@ -914,6 +917,8 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
      * @returns True if retryable, false if not retryable, undefined if unknown
      */
     private isGeminiErrorRetryable(httpStatusCode: number, message?: string): boolean | undefined {
+        if (message && this.isNonRetryableAuthError(message)) return false;
+
         // Retryable status codes
         if (httpStatusCode === 408) return true; // Request timeout
         if (httpStatusCode === 429) return true; // Rate limit/quota
@@ -940,6 +945,11 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         return undefined;
     }
 
+    private isNonRetryableAuthError(message: string): boolean {
+        const lowerMessage = message.toLowerCase();
+        return lowerMessage.includes('invalid_grant') || lowerMessage.includes("credential's issuer");
+    }
+
     /**
      * Extract error type name from error message.
      * Google errors often include the error type in the message.
@@ -948,6 +958,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
     private extractErrorName(message: string): string | undefined {
         // Common Google error patterns
         const patterns = [
+            /^Error code ([a-zA-Z0-9_-]+):/, // "Error code invalid_grant: message"
             /^([A-Z_]+):/, // "ERROR_NAME: message"
             /\[([A-Z_]+)\]/, // "[ERROR_NAME] message"
             /^(\w+Error):/, // "ErrorTypeError: message"


### PR DESCRIPTION
## Summary
- Mark `invalid_grant` credential issuer failures as non-retryable in the shared driver error classifier.
- Strengthen VertexAI Gemini API error handling with a typed error guard, auth-failure precedence, and `invalid_grant` error-name extraction.
- Add regression coverage for generic fallback handling and VertexAI Gemini 400 `invalid_grant` errors.

## Test Plan
- `cd core && pnpm exec vitest run src/Driver.error.test.ts`
- `cd drivers && pnpm exec vitest run src/vertexai/models/gemini-error-handling.test.ts`
- `cd core && pnpm run lint`
- `cd core && pnpm run build`
- `cd drivers && pnpm run lint`
- `cd drivers && pnpm run build`