### PR TITLE
fix(core): don't split surrogate pairs when truncating conversation text

### DIFF
--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -598,7 +598,18 @@ function truncateLargeTextInternal(obj: unknown, maxChars: number): unknown {
             return obj;
         }
         if (obj.length > maxChars) {
-            return obj.substring(0, maxChars) + TEXT_TRUNCATED_MARKER;
+            // Don't cut through a surrogate pair: substring() slices at a UTF-16
+            // code-unit index, so a boundary that lands between the two halves of
+            // a non-BMP character (emoji, CJK-ext, …) leaves a lone high surrogate.
+            // That is invalid Unicode — it can't be UTF-8 encoded losslessly and
+            // strict JSON parsers (e.g. Vertex/Gemini) reject the request body as
+            // "The input data is not valid json". Step back one unit in that case.
+            let end = maxChars;
+            const lastUnit = obj.charCodeAt(end - 1);
+            if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) {
+                end -= 1;
+            }
+            return obj.substring(0, end) + TEXT_TRUNCATED_MARKER;
         }
         return obj;
     }

--- a/core/test/conversation-truncate-surrogate.test.ts
+++ b/core/test/conversation-truncate-surrogate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'vitest';
+import { truncateLargeTextInConversation } from '../src/conversation-utils.js';
+
+// Matches a lone (unpaired) UTF-16 surrogate: a high surrogate not followed by a
+// low surrogate, or a low surrogate not preceded by a high one. A string with a
+// lone surrogate is not valid Unicode and cannot be encoded to UTF-8 losslessly,
+// so strict JSON parsers (e.g. Vertex/Gemini) reject the request body as
+// "The input data is not valid json".
+const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+
+// truncateLargeTextInConversation uses maxChars = textMaxTokens * CHARS_PER_TOKEN
+// (CHARS_PER_TOKEN = 4).
+const CHARS_PER_TOKEN = 4;
+
+describe('truncateLargeTextInConversation — surrogate safety', () => {
+    test('does not leave a lone surrogate when the boundary splits a surrogate pair', () => {
+        const maxTokens = 10;
+        const maxChars = maxTokens * CHARS_PER_TOKEN; // 40
+
+        // Put a non-BMP emoji (🎉 = U+1F389 = '🎉', a surrogate pair)
+        // so its HIGH surrogate sits at index maxChars-1 and its LOW surrogate at
+        // index maxChars. substring(0, maxChars) keeps the high, drops the low.
+        const input = `${'a'.repeat(maxChars - 1)}🎉${'b'.repeat(50)}`;
+        expect(input.isWellFormed()).toBe(true); // sanity: the source is valid
+        expect(input.length).toBeGreaterThan(maxChars);
+
+        const out = truncateLargeTextInConversation(input, { textMaxTokens: maxTokens }) as string;
+
+        // The truncated text must remain valid UTF-16 — no lone surrogate.
+        expect(LONE_SURROGATE.test(out)).toBe(false);
+        expect(out.isWellFormed()).toBe(true);
+
+        // And it must survive a UTF-8 round-trip unchanged (an HTTP/JSON body is
+        // UTF-8). A lone surrogate becomes U+FFFD on round-trip, so this would
+        // differ — exactly the corruption Vertex rejects.
+        expect(Buffer.from(out, 'utf8').toString('utf8')).toBe(out);
+    });
+
+    test('control: truncating between BMP characters stays well-formed', () => {
+        const out = truncateLargeTextInConversation('a'.repeat(200), { textMaxTokens: 10 }) as string;
+        expect(LONE_SURROGATE.test(out)).toBe(false);
+        expect(out.isWellFormed()).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

`truncateLargeTextInConversation` truncates with `obj.substring(0, maxChars)`, which slices at a **UTF-16 code-unit index**. When the boundary falls inside a non-BMP character's surrogate pair (emoji like 🎉/🪑, CJK extensions, etc.), it keeps the high surrogate and drops the low one, leaving a **lone surrogate**. A lone surrogate is invalid Unicode — it can't be UTF-8 encoded losslessly, so strict JSON parsers (e.g. Vertex/Gemini) reject the entire request body with `400 FAILED_PRECONDITION: The input data is not valid json`.

This is a real, observed failure: it terminated a long agent run when a conversation checkpoint force-truncated a large block that happened to have an emoji on the 8K-token boundary.

## Fix

Step back one code unit when the truncation boundary is a high surrogate, so the pair is never split.

```ts
let end = maxChars;
const lastUnit = obj.charCodeAt(end - 1);
if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) end -= 1;
return obj.substring(0, end) + TEXT_TRUNCATED_MARKER;
```

## Test

`core/test/conversation-truncate-surrogate.test.ts` places `🎉` exactly on the truncation boundary and asserts the output:
- contains no lone surrogate (`isWellFormed()`),
- survives a UTF-8 round-trip unchanged.

Plus a BMP-boundary control. The test **fails on the previous `substring` implementation** (proving the bug) and passes with this fix. Existing strip suite (72 tests) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>