### PR TITLE
fix(drivers): drop orphaned tool_result blocks before sending (Claude, Bedrock, OpenAI, Gemini)

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1920,8 +1920,11 @@ function updateConversation(conversation: ConverseRequest, prompt: ConverseReque
     const combinedMessages = [...(conversation?.messages || []), ...(prompt.messages || [])];
     const combinedSystem = prompt.system || conversation?.system;
 
-    // Fix orphaned toolUse blocks before returning
-    const fixedMessages = fixOrphanedToolUse(combinedMessages);
+    // Fix both orphan directions before returning: a toolUse with no result
+    // (interrupted run) gets a synthetic result; a toolResult with no matching
+    // toolUse in the previous message (e.g. compaction-trimmed) is dropped. Either
+    // would otherwise trip the Converse API's toolUse/toolResult pairing check.
+    const fixedMessages = fixOrphanedToolResults(fixOrphanedToolUse(combinedMessages));
 
     return {
         modelId: prompt?.modelId || conversation?.modelId,
@@ -2048,6 +2051,50 @@ export function fixOrphanedToolUse(messages: Message[]): Message[] {
         }
     }
 
+    return result;
+}
+
+/**
+ * Drop toolResult blocks whose toolUseId has no matching toolUse in the
+ * immediately-preceding assistant message. Mirror of {@link fixOrphanedToolUse}:
+ * that function synthesizes results for an unanswered toolUse (e.g. a cancelled
+ * run); this one removes results left dangling after their toolUse was dropped
+ * (e.g. by conversation compaction/trimming).
+ *
+ * Without this, the AWS Converse API rejects the request because every
+ * toolResult must correspond to a toolUse in the previous message. Bedrock
+ * conversations are already role-alternating, so a compaction that drops an
+ * assistant toolUse turn leaves an orphaned toolResult (and a user/user
+ * adjacency); dropping the orphan — and the now-empty message — repairs both.
+ */
+export function fixOrphanedToolResults(messages: Message[]): Message[] {
+    if (messages.length === 0) return messages;
+    const result: Message[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
+        if (message.role !== 'user' || !message.content) {
+            result.push(message);
+            continue;
+        }
+        const hasToolResult = message.content.some((block) => block.toolResult);
+        if (!hasToolResult) {
+            result.push(message);
+            continue;
+        }
+        const prev = messages[i - 1];
+        const allowedIds = new Set<string>();
+        if (prev && prev.role === 'assistant' && prev.content) {
+            for (const block of prev.content) {
+                if (block.toolUse?.toolUseId) allowedIds.add(block.toolUse.toolUseId);
+            }
+        }
+        const filtered = message.content.filter((block) =>
+            block.toolResult ? allowedIds.has(block.toolResult.toolUseId ?? '') : true,
+        );
+        // Drop the message if every block was an orphaned toolResult.
+        if (filtered.length === 0) continue;
+        result.push(filtered.length === message.content.length ? message : { ...message, content: filtered });
+    }
     return result;
 }
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -1399,12 +1399,12 @@ export function fixOrphanedToolResults(items: ResponseInputItem[]): ResponseInpu
     const callIds = new Set<string>();
     for (const item of items) {
         if ('type' in item && item.type === 'function_call') {
-            callIds.add((item as OpenAI.Responses.ResponseFunctionToolCall).call_id);
+            callIds.add(item.call_id);
         }
     }
     return items.filter((item) => {
         if ('type' in item && item.type === 'function_call_output') {
-            return callIds.has((item as OpenAI.Responses.ResponseInputItem.FunctionCallOutput).call_id);
+            return callIds.has(item.call_id);
         }
         return true;
     });

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -169,7 +169,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
 
         // Include conversation history (same as non-streaming)
         // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
-        let conversation = fixOrphanedToolUse(updateConversation(options.conversation, prompt));
+        let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
 
         const toolDefs = getToolDefinitions(options.tools);
         const useTools: boolean = toolDefs ? supportsToolUse(options.model, this.provider, true) : false;
@@ -243,7 +243,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         const useTools: boolean = toolDefs ? supportsToolUse(options.model, this.provider) : false;
 
         // Fix orphaned function_call items (can occur when agent is stopped mid-tool-execution)
-        let conversation = fixOrphanedToolUse(updateConversation(options.conversation, prompt));
+        let conversation = fixOrphanedToolResults(fixOrphanedToolUse(updateConversation(options.conversation, prompt)));
 
         // When no tools are provided but conversation contains function_call/function_call_output
         // items (e.g. checkpoint summary calls), convert them to text to avoid API errors
@@ -1384,6 +1384,30 @@ export function fixOrphanedToolUse(items: ResponseInputItem[]): ResponseInputIte
     }
 
     return result;
+}
+
+/**
+ * Drop function_call_output items whose call_id has no matching function_call
+ * item anywhere in the input. Mirror of {@link fixOrphanedToolUse}: that
+ * synthesizes outputs for calls left unanswered (e.g. a cancelled run); this
+ * removes outputs left dangling after their function_call was dropped (e.g. by
+ * conversation compaction/trimming). The OpenAI Responses API requires every
+ * function_call_output to reference a prior function_call's call_id.
+ */
+export function fixOrphanedToolResults(items: ResponseInputItem[]): ResponseInputItem[] {
+    if (items.length === 0) return items;
+    const callIds = new Set<string>();
+    for (const item of items) {
+        if ('type' in item && item.type === 'function_call') {
+            callIds.add((item as OpenAI.Responses.ResponseFunctionToolCall).call_id);
+        }
+    }
+    return items.filter((item) => {
+        if ('type' in item && item.type === 'function_call_output') {
+            return callIds.has((item as OpenAI.Responses.ResponseInputItem.FunctionCallOutput).call_id);
+        }
+        return true;
+    });
 }
 
 function safeJsonParse(value: unknown): unknown {

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -501,6 +501,58 @@ export function fixOrphanedToolUse(messages: MessageParam[]): MessageParam[] {
     return result;
 }
 
+/**
+ * Drop tool_result blocks whose tool_use_id has no matching tool_use in the
+ * immediately preceding assistant message. This is the mirror of
+ * {@link fixOrphanedToolUse}: that function synthesizes results for tool_uses
+ * left unanswered (e.g. a cancelled run); this one removes results left dangling
+ * after their tool_use was dropped (e.g. by conversation compaction/trimming, or
+ * a parallel tool batch whose results were split across messages that cannot be
+ * re-paired).
+ *
+ * Without this, the Anthropic / Vertex-Anthropic API rejects the request with a
+ * non-retryable 400: "unexpected `tool_use_id` found in `tool_result` blocks ...
+ * Each `tool_result` block must have a corresponding `tool_use` block in the
+ * previous message." — which terminates the conversation.
+ *
+ * Must run AFTER mergeConsecutiveUserMessages so that parallel tool results which
+ * were split across separate user messages are first combined into the single
+ * user turn that follows the assistant tool_use message (otherwise valid results
+ * whose "previous message" is another user message would be wrongly dropped).
+ */
+export function fixOrphanedToolResults(messages: MessageParam[]): MessageParam[] {
+    if (messages.length === 0) return messages;
+    const result: MessageParam[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
+        if (message.role !== 'user' || !Array.isArray(message.content)) {
+            result.push(message);
+            continue;
+        }
+        const hasToolResult = message.content.some((block) => block.type === 'tool_result');
+        if (!hasToolResult) {
+            result.push(message);
+            continue;
+        }
+        // Collect the tool_use ids declared by the immediately preceding assistant message.
+        const prev = messages[i - 1];
+        const allowedIds = new Set<string>();
+        if (prev && prev.role === 'assistant' && Array.isArray(prev.content)) {
+            for (const block of prev.content) {
+                if (block.type === 'tool_use') allowedIds.add(block.id);
+            }
+        }
+        const filtered = message.content.filter((block) =>
+            block.type === 'tool_result' ? allowedIds.has(block.tool_use_id) : true,
+        );
+        // If every block was an orphaned tool_result, drop the message rather than
+        // emit an empty (and invalid) content array.
+        if (filtered.length === 0) continue;
+        result.push(filtered.length === message.content.length ? message : { ...message, content: filtered });
+    }
+    return result;
+}
+
 export function updateClaudeConversation(
     conversation: ClaudePrompt | undefined | null,
     prompt: ClaudePrompt,
@@ -636,7 +688,12 @@ export function getClaudePayload(
         requestOptions = { headers: { 'anthropic-beta': 'output-128k-2025-02-19' } };
     }
 
-    const fixedMessages = fixOrphanedToolUse(prompt.messages);
+    // Merge first so parallel tool results split across user messages are recombined
+    // into the single user turn after their assistant tool_use message; then fix both
+    // orphan directions (tool_use without result, and result without tool_use) so the
+    // request can never trip Anthropic/Vertex's tool_use/tool_result pairing validation.
+    const mergedMessages = mergeConsecutiveUserMessages(prompt.messages);
+    const fixedMessages = fixOrphanedToolResults(fixOrphanedToolUse(mergedMessages));
     let sanitizedMessages = sanitizeMessages(fixedMessages);
 
     if (options.tools) {

--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for fixOrphanedToolResults (Gemini).
+ *
+ * Gemini pairs a `functionResponse` part to its `functionCall` part by name. A
+ * functionResponse left dangling after its functionCall was dropped — e.g. by
+ * conversation compaction trimming the model tool-call turn, or an unmergeable
+ * parallel batch — causes the Gemini/Vertex API to reject the request. This is
+ * the same class of bug fixed in the Claude, Bedrock, and OpenAI drivers.
+ */
+
+import type { Content } from '@google/genai';
+import { describe, expect, test } from 'vitest';
+import { fixOrphanedToolResults } from './gemini.js';
+
+describe('fixOrphanedToolResults - Gemini', () => {
+    test('returns empty array for empty input', () => {
+        expect(fixOrphanedToolResults([])).toEqual([]);
+    });
+
+    test('keeps a functionResponse that has a matching functionCall in the previous model content', () => {
+        const contents: Content[] = [
+            { role: 'model', parts: [{ functionCall: { name: 'search', args: {} } }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'search', response: { ok: true } } }] },
+        ];
+        expect(fixOrphanedToolResults(contents)).toEqual(contents);
+    });
+
+    test('keeps all responses of a parallel batch when both calls are present', () => {
+        const contents: Content[] = [
+            {
+                role: 'model',
+                parts: [{ functionCall: { name: 'a', args: {} } }, { functionCall: { name: 'b', args: {} } }],
+            },
+            {
+                role: 'user',
+                parts: [
+                    { functionResponse: { name: 'a', response: {} } },
+                    { functionResponse: { name: 'b', response: {} } },
+                ],
+            },
+        ];
+        expect(fixOrphanedToolResults(contents)).toEqual(contents);
+    });
+
+    test('drops a functionResponse whose functionCall is absent from the previous content', () => {
+        const contents: Content[] = [
+            { role: 'model', parts: [{ functionCall: { name: 'a', args: {} } }] },
+            {
+                role: 'user',
+                parts: [
+                    { functionResponse: { name: 'a', response: {} } },
+                    { functionResponse: { name: 'gone', response: {} } },
+                ],
+            },
+        ];
+
+        const result = fixOrphanedToolResults(contents);
+        expect(result[1].parts).toHaveLength(1);
+        expect(result[1].parts?.[0].functionResponse?.name).toBe('a');
+    });
+
+    test('drops a content that becomes empty after removing orphaned responses', () => {
+        const contents: Content[] = [
+            { role: 'user', parts: [{ text: '[summary of prior work]' }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'gone', response: {} } }] },
+        ];
+
+        const result = fixOrphanedToolResults(contents);
+        expect(result).toHaveLength(1);
+        expect(result[0].parts?.[0].text).toBe('[summary of prior work]');
+    });
+
+    test('preserves non-functionResponse parts while dropping the orphan', () => {
+        const contents: Content[] = [
+            { role: 'model', parts: [{ text: 'thinking' }] },
+            {
+                role: 'user',
+                parts: [{ functionResponse: { name: 'gone', response: {} } }, { text: 'continue please' }],
+            },
+        ];
+
+        const result = fixOrphanedToolResults(contents);
+        expect(result[1].parts).toHaveLength(1);
+        expect(result[1].parts?.[0].text).toBe('continue please');
+    });
+});

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -140,6 +140,11 @@ function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentProm
             payloadContents = convertGeminiFunctionPartsToText(payloadContents);
         }
     }
+    // Drop functionResponse parts whose functionCall was lost (e.g. compaction),
+    // which would otherwise trip Gemini's functionCall/functionResponse pairing.
+    if (payloadContents) {
+        payloadContents = fixOrphanedToolResults(payloadContents);
+    }
 
     const useStructuredOutput = supportsStructuredOutput(options) && !tools;
 
@@ -275,6 +280,49 @@ export function mergeConsecutiveRole(contents: Content[] | undefined): Content[]
     }
 
     result.push(currentContent);
+    return result;
+}
+
+/**
+ * Drop functionResponse parts whose name has no matching functionCall in the
+ * immediately-preceding `model` content. Gemini pairs a functionResponse to its
+ * functionCall by name; a response left dangling after its call was dropped
+ * (e.g. by conversation compaction/trimming, or an unmergeable parallel batch)
+ * causes the API to reject the request. Mirrors the same guard added to the
+ * Claude, Bedrock, and OpenAI drivers.
+ *
+ * Run after mergeConsecutiveRole so parallel responses that were split across
+ * user contents are first recombined under the model turn that issued the calls,
+ * and are therefore not mistaken for orphans.
+ */
+export function fixOrphanedToolResults(contents: Content[]): Content[] {
+    if (contents.length === 0) return contents;
+    const result: Content[] = [];
+    for (let i = 0; i < contents.length; i++) {
+        const content = contents[i];
+        if (content.role !== 'user' || !content.parts) {
+            result.push(content);
+            continue;
+        }
+        const hasFunctionResponse = content.parts.some((part) => part.functionResponse);
+        if (!hasFunctionResponse) {
+            result.push(content);
+            continue;
+        }
+        const prev = contents[i - 1];
+        const allowedNames = new Set<string>();
+        if (prev && prev.role === 'model' && prev.parts) {
+            for (const part of prev.parts) {
+                if (part.functionCall?.name) allowedNames.add(part.functionCall.name);
+            }
+        }
+        const filtered = content.parts.filter((part) =>
+            part.functionResponse ? allowedNames.has(part.functionResponse.name ?? '') : true,
+        );
+        // Drop the content if every part was an orphaned functionResponse.
+        if (filtered.length === 0) continue;
+        result.push(filtered.length === content.parts.length ? content : { ...content, parts: filtered });
+    }
     return result;
 }
 

--- a/drivers/test/orphaned-tool-result-payload.test.ts
+++ b/drivers/test/orphaned-tool-result-payload.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Reproduction test for the non-retryable Vertex/Anthropic 400 that terminates
+ * agent conversations:
+ *
+ *   messages.N.content.k: unexpected `tool_use_id` found in `tool_result` blocks: <id>.
+ *   Each `tool_result` block must have a corresponding `tool_use` block in the
+ *   previous message.
+ *
+ * Root cause: a `tool_result` survives in the conversation while its matching
+ * `tool_use` does not appear in the immediately-preceding assistant message —
+ * e.g. conversation compaction trims the `tool_use` turn but keeps its result,
+ * or a parallel tool batch's results land in a message that can't be re-paired.
+ *
+ * This drives the real send-prep (`getClaudePayload`) end-to-end and asserts the
+ * produced payload contains no orphaned `tool_result` (the exact condition the
+ * API validates). It fails against the unfixed pipeline and passes once
+ * `fixOrphanedToolResults` is wired in.
+ */
+
+import type { MessageParam } from '@anthropic-ai/sdk/resources/index.js';
+import type { ExecutionOptions } from '@llumiverse/core';
+import { describe, expect, test } from 'vitest';
+import { type ClaudePrompt, getClaudePayload } from '../src/shared/claude-messages.js';
+
+/**
+ * Returns the tool_use_ids of any `tool_result` blocks whose matching `tool_use`
+ * is not declared by the immediately-preceding assistant message — i.e. exactly
+ * what the Anthropic/Vertex API rejects with a 400.
+ */
+function findOrphanedToolResults(messages: MessageParam[]): string[] {
+    const orphans: string[] = [];
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i];
+        if (message.role !== 'user' || !Array.isArray(message.content)) continue;
+        const prev = messages[i - 1];
+        const allowed = new Set<string>();
+        if (prev && prev.role === 'assistant' && Array.isArray(prev.content)) {
+            for (const block of prev.content) {
+                if (block.type === 'tool_use') allowed.add(block.id);
+            }
+        }
+        for (const block of message.content) {
+            if (block.type === 'tool_result' && !allowed.has(block.tool_use_id)) {
+                orphans.push(block.tool_use_id);
+            }
+        }
+    }
+    return orphans;
+}
+
+// Tools must be present so getClaudePayload preserves tool blocks instead of
+// converting them to text (which would hide the bug).
+const OPTIONS = {
+    model: 'claude-sonnet-4-6',
+    tools: [{ name: 'launch_workstream', description: '', input_schema: { type: 'object', properties: {} } }],
+} as unknown as ExecutionOptions;
+
+describe('getClaudePayload — orphaned tool_result (Vertex 400 repro)', () => {
+    test('a tool_result whose tool_use was dropped does not reach the payload', () => {
+        // Mirrors the real failed conversation: a compaction summary, a valid
+        // tool turn, then a parallel-result message where one result's tool_use
+        // is absent (its assistant tool_use was compacted away).
+        const prompt: ClaudePrompt = {
+            system: undefined,
+            messages: [
+                { role: 'user', content: [{ type: 'text', text: '[checkpoint summary of 454 messages]' }] },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'think_1', name: 'think', input: {} }] },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'think_1', content: 'ok' }] },
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'text', text: 'Launching workstream.' },
+                        { type: 'tool_use', id: 'launch_1', name: 'launch_workstream', input: {} },
+                    ],
+                },
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'tool_result', tool_use_id: 'launch_1', content: 'started' },
+                        // Orphan: matching tool_use is gone (compacted away).
+                        { type: 'tool_result', tool_use_id: 'toolu_orphan_gone', content: 'dangling result' },
+                    ],
+                },
+            ],
+        };
+
+        const { payload } = getClaudePayload(OPTIONS, prompt);
+        const orphans = findOrphanedToolResults(payload.messages as MessageParam[]);
+        expect(orphans).toEqual([]);
+
+        // The valid result is retained.
+        expect(JSON.stringify(payload.messages)).toContain('launch_1');
+    });
+
+    test('parallel tool results split across user messages stay paired after prep', () => {
+        // Two parallel tool_uses whose results were stored as two separate user
+        // messages. Merge must recombine them under the assistant turn so neither
+        // is treated as an orphan.
+        const prompt: ClaudePrompt = {
+            system: undefined,
+            messages: [
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'tool_use', id: 'get_project', name: 'get_project', input: {} },
+                        { type: 'tool_use', id: 'learn_ops', name: 'learn_artifact_operations', input: {} },
+                    ],
+                },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'get_project', content: 'p' }] },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'learn_ops', content: 'o' }] },
+            ],
+        };
+
+        const { payload } = getClaudePayload(OPTIONS, prompt);
+        expect(findOrphanedToolResults(payload.messages as MessageParam[])).toEqual([]);
+        // Both legitimate results survive.
+        const json = JSON.stringify(payload.messages);
+        expect(json).toContain('get_project');
+        expect(json).toContain('learn_ops');
+    });
+});

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -583,8 +583,8 @@ describe('fixOrphanedToolUse - OpenAI', () => {
                 call_id: 'fc_1',
                 name: 'search',
                 arguments: '{"query":"test"}',
-            } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'Search result' } as ResponseInputItem,
+            } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'Search result' } satisfies ResponseInputItem,
             { role: 'assistant', content: 'Here are the results.' },
         ];
 
@@ -600,7 +600,7 @@ describe('fixOrphanedToolUse - OpenAI', () => {
                 call_id: 'fc_1',
                 name: 'ask_user',
                 arguments: '{"question":"What?"}',
-            } as ResponseInputItem,
+            } satisfies ResponseInputItem,
             { role: 'user', content: 'Actually, stop that' },
         ];
 
@@ -627,9 +627,9 @@ describe('fixOrphanedToolUse - OpenAI', () => {
 
     test('handles multiple orphaned function_calls', () => {
         const items: ResponseInputItem[] = [
-            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call', call_id: 'fc_2', name: 'fetch', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call', call_id: 'fc_3', name: 'process', arguments: '{}' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_2', name: 'fetch', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_3', name: 'process', arguments: '{}' } satisfies ResponseInputItem,
             { role: 'user', content: 'Stop!' },
         ];
 
@@ -655,9 +655,9 @@ describe('fixOrphanedToolUse - OpenAI', () => {
 
     test('handles partial outputs - only injects for missing ones', () => {
         const items: ResponseInputItem[] = [
-            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call', call_id: 'fc_2', name: 'fetch', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'Search completed' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_2', name: 'fetch', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'Search completed' } satisfies ResponseInputItem,
             { role: 'user', content: 'Continue' },
         ];
 
@@ -688,7 +688,7 @@ describe('fixOrphanedToolUse - OpenAI', () => {
                 call_id: 'fc_1',
                 name: 'ask_user',
                 arguments: '{"question":"What?"}',
-            } as ResponseInputItem,
+            } satisfies ResponseInputItem,
         ];
 
         const result = fixOrphanedToolUseOpenAI(items);
@@ -713,7 +713,7 @@ describe('fixOrphanedToolUse - OpenAI', () => {
                 call_id: 'fc_ask_user',
                 name: 'ask_user',
                 arguments: '{"questions":["What do you mean?"]}',
-            } as ResponseInputItem,
+            } satisfies ResponseInputItem,
             // User sends another message (agent was stopped, no function_call_output)
             { role: 'user', content: [{ type: 'input_text', text: 'launch 10 workstreams' }] },
         ];
@@ -736,11 +736,11 @@ describe('fixOrphanedToolUse - OpenAI', () => {
     test('does not inject when function_call_output exists later in the array', () => {
         const items: ResponseInputItem[] = [
             { role: 'user', content: 'Search for something' },
-            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'Results found' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'Results found' } satisfies ResponseInputItem,
             { role: 'assistant', content: 'Found results.' },
-            { type: 'function_call', call_id: 'fc_2', name: 'analyze', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_2', output: 'Analysis complete' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_2', name: 'analyze', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_2', output: 'Analysis complete' } satisfies ResponseInputItem,
         ];
 
         const result = fixOrphanedToolUseOpenAI(items);
@@ -757,18 +757,18 @@ describe('fixOrphanedToolResults - OpenAI', () => {
 
     test('keeps a function_call_output that has a matching function_call', () => {
         const items: ResponseInputItem[] = [
-            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'ok' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'ok' } satisfies ResponseInputItem,
         ];
         expect(fixOrphanedToolResultsOpenAI(items)).toEqual(items);
     });
 
     test('drops a function_call_output whose call_id has no function_call', () => {
         const items: ResponseInputItem[] = [
-            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } satisfies ResponseInputItem,
             // Orphan: its function_call was compacted away.
-            { type: 'function_call_output', call_id: 'fc_gone', output: 'orphan' } as ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_gone', output: 'orphan' } satisfies ResponseInputItem,
             { role: 'assistant', content: 'done' },
         ];
 
@@ -780,10 +780,10 @@ describe('fixOrphanedToolResults - OpenAI', () => {
 
     test('retains parallel outputs that all have matching calls', () => {
         const items: ResponseInputItem[] = [
-            { type: 'function_call', call_id: 'fc_1', name: 'a', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call', call_id: 'fc_2', name: 'b', arguments: '{}' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_2', output: 'r2' } as ResponseInputItem,
-            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_1', name: 'a', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_2', name: 'b', arguments: '{}' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_2', output: 'r2' } satisfies ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } satisfies ResponseInputItem,
         ];
         expect(fixOrphanedToolResultsOpenAI(items)).toEqual(items);
     });

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -16,8 +16,14 @@ import type { MessageParam } from '@anthropic-ai/sdk/resources/index.js';
 import type { Message } from '@aws-sdk/client-bedrock-runtime';
 import type OpenAI from 'openai';
 import { describe, expect, test } from 'vitest';
-import { fixOrphanedToolUse as fixOrphanedToolUseBedrock } from '../src/bedrock/index.js';
-import { fixOrphanedToolUse as fixOrphanedToolUseOpenAI } from '../src/openai/index.js';
+import {
+    fixOrphanedToolResults as fixOrphanedToolResultsBedrock,
+    fixOrphanedToolUse as fixOrphanedToolUseBedrock,
+} from '../src/bedrock/index.js';
+import {
+    fixOrphanedToolResults as fixOrphanedToolResultsOpenAI,
+    fixOrphanedToolUse as fixOrphanedToolUseOpenAI,
+} from '../src/openai/index.js';
 import {
     fixOrphanedToolResults,
     fixOrphanedToolUse as fixOrphanedToolUseClaude,
@@ -491,6 +497,71 @@ describe('fixOrphanedToolUse - Bedrock', () => {
     });
 });
 
+describe('fixOrphanedToolResults - Bedrock', () => {
+    test('returns empty array for empty input', () => {
+        expect(fixOrphanedToolResultsBedrock([])).toEqual([]);
+    });
+
+    test('keeps a toolResult that has a matching toolUse in the previous message', () => {
+        const messages: Message[] = [
+            { role: 'assistant', content: [{ toolUse: { toolUseId: 'tool_1', name: 'search', input: {} } }] },
+            { role: 'user', content: [{ toolResult: { toolUseId: 'tool_1', content: [{ text: 'ok' }] } }] },
+        ];
+        expect(fixOrphanedToolResultsBedrock(messages)).toEqual(messages);
+    });
+
+    test('drops a toolResult whose toolUse is absent from the previous message', () => {
+        const messages: Message[] = [
+            { role: 'assistant', content: [{ toolUse: { toolUseId: 'tool_1', name: 'search', input: {} } }] },
+            {
+                role: 'user',
+                content: [
+                    { toolResult: { toolUseId: 'tool_1', content: [{ text: 'r1' }] } },
+                    { toolResult: { toolUseId: 'tool_2', content: [{ text: 'orphan' }] } },
+                ],
+            },
+        ];
+
+        const result = fixOrphanedToolResultsBedrock(messages);
+        // biome-ignore lint/style/noNonNullAssertion: content is set above
+        const userContent = result[1].content!;
+        expect(userContent).toHaveLength(1);
+        expect(userContent[0].toolResult?.toolUseId).toBe('tool_1');
+    });
+
+    test('drops a user message that becomes empty after removing orphaned toolResults', () => {
+        // Compaction left a toolResult whose assistant toolUse turn was summarized away.
+        const messages: Message[] = [
+            { role: 'user', content: [{ text: '[summary of prior work]' }] },
+            { role: 'user', content: [{ toolResult: { toolUseId: 'gone', content: [{ text: 'orphan' }] } }] },
+        ];
+
+        const result = fixOrphanedToolResultsBedrock(messages);
+        expect(result).toHaveLength(1);
+        // biome-ignore lint/style/noNonNullAssertion: content is set above
+        expect(result[0].content![0].text).toBe('[summary of prior work]');
+    });
+
+    test('preserves non-toolResult blocks while dropping the orphan', () => {
+        const messages: Message[] = [
+            { role: 'assistant', content: [{ text: 'thinking' }] },
+            {
+                role: 'user',
+                content: [
+                    { toolResult: { toolUseId: 'orphan', content: [{ text: 'x' }] } },
+                    { text: 'continue please' },
+                ],
+            },
+        ];
+
+        const result = fixOrphanedToolResultsBedrock(messages);
+        // biome-ignore lint/style/noNonNullAssertion: content is set above
+        const userContent = result[1].content!;
+        expect(userContent).toHaveLength(1);
+        expect(userContent[0].text).toBe('continue please');
+    });
+});
+
 describe('fixOrphanedToolUse - OpenAI', () => {
     test('returns empty array for empty input', () => {
         const result = fixOrphanedToolUseOpenAI([]);
@@ -676,5 +747,52 @@ describe('fixOrphanedToolUse - OpenAI', () => {
 
         // No changes - all function_calls have matching outputs
         expect(result).toEqual(items);
+    });
+});
+
+describe('fixOrphanedToolResults - OpenAI', () => {
+    test('returns empty array for empty input', () => {
+        expect(fixOrphanedToolResultsOpenAI([])).toEqual([]);
+    });
+
+    test('keeps a function_call_output that has a matching function_call', () => {
+        const items: ResponseInputItem[] = [
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'ok' } as ResponseInputItem,
+        ];
+        expect(fixOrphanedToolResultsOpenAI(items)).toEqual(items);
+    });
+
+    test('drops a function_call_output whose call_id has no function_call', () => {
+        const items: ResponseInputItem[] = [
+            { type: 'function_call', call_id: 'fc_1', name: 'search', arguments: '{}' } as ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } as ResponseInputItem,
+            // Orphan: its function_call was compacted away.
+            { type: 'function_call_output', call_id: 'fc_gone', output: 'orphan' } as ResponseInputItem,
+            { role: 'assistant', content: 'done' },
+        ];
+
+        const result = fixOrphanedToolResultsOpenAI(items);
+        expect(result).toHaveLength(3);
+        expect(result.some((i) => 'call_id' in i && i.call_id === 'fc_gone')).toBe(false);
+        expect(result.some((i) => 'call_id' in i && i.call_id === 'fc_1')).toBe(true);
+    });
+
+    test('retains parallel outputs that all have matching calls', () => {
+        const items: ResponseInputItem[] = [
+            { type: 'function_call', call_id: 'fc_1', name: 'a', arguments: '{}' } as ResponseInputItem,
+            { type: 'function_call', call_id: 'fc_2', name: 'b', arguments: '{}' } as ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_2', output: 'r2' } as ResponseInputItem,
+            { type: 'function_call_output', call_id: 'fc_1', output: 'r1' } as ResponseInputItem,
+        ];
+        expect(fixOrphanedToolResultsOpenAI(items)).toEqual(items);
+    });
+
+    test('leaves non-function items untouched', () => {
+        const items: ResponseInputItem[] = [
+            { role: 'user', content: 'hello' },
+            { role: 'assistant', content: 'hi' },
+        ];
+        expect(fixOrphanedToolResultsOpenAI(items)).toEqual(items);
     });
 });

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -18,7 +18,10 @@ import type OpenAI from 'openai';
 import { describe, expect, test } from 'vitest';
 import { fixOrphanedToolUse as fixOrphanedToolUseBedrock } from '../src/bedrock/index.js';
 import { fixOrphanedToolUse as fixOrphanedToolUseOpenAI } from '../src/openai/index.js';
-import { fixOrphanedToolUse as fixOrphanedToolUseClaude } from '../src/shared/claude-messages.js';
+import {
+    fixOrphanedToolResults,
+    fixOrphanedToolUse as fixOrphanedToolUseClaude,
+} from '../src/shared/claude-messages.js';
 import type { Tree } from './__helpers__/test-utils.js';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
@@ -214,6 +217,116 @@ describe('fixOrphanedToolUse - Claude', () => {
         expect(lastUserContent[1].content).toContain('user stopped');
 
         expect(lastUserContent[2].type).toBe('text');
+    });
+});
+
+describe('fixOrphanedToolResults - Claude', () => {
+    test('returns empty array for empty input', () => {
+        expect(fixOrphanedToolResults([])).toEqual([]);
+    });
+
+    test('keeps tool_result that has a matching tool_use in the previous message', () => {
+        const messages: MessageParam[] = [
+            { role: 'assistant', content: [{ type: 'tool_use', id: 'tool_1', name: 'search', input: {} }] },
+            { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tool_1', content: 'ok' }] },
+        ];
+        expect(fixOrphanedToolResults(messages)).toEqual(messages);
+    });
+
+    test('keeps all results of a parallel batch when both tool_uses are present', () => {
+        const messages: MessageParam[] = [
+            {
+                role: 'assistant',
+                content: [
+                    { type: 'tool_use', id: 'tool_1', name: 'a', input: {} },
+                    { type: 'tool_use', id: 'tool_2', name: 'b', input: {} },
+                ],
+            },
+            {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'tool_1', content: 'r1' },
+                    { type: 'tool_result', tool_use_id: 'tool_2', content: 'r2' },
+                ],
+            },
+        ];
+        expect(fixOrphanedToolResults(messages)).toEqual(messages);
+    });
+
+    test('drops a tool_result whose tool_use is absent from the previous message', () => {
+        // Compaction kept the result for tool_2 but dropped the assistant tool_use for it.
+        const messages: MessageParam[] = [
+            { role: 'assistant', content: [{ type: 'tool_use', id: 'tool_1', name: 'a', input: {} }] },
+            {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'tool_1', content: 'r1' },
+                    { type: 'tool_result', tool_use_id: 'tool_2', content: 'orphan' },
+                ],
+            },
+        ];
+
+        const result = fixOrphanedToolResults(messages);
+        const userContent = result[1].content as Array<{ type: string; tool_use_id?: string }>;
+        expect(userContent).toHaveLength(1);
+        expect(userContent[0].tool_use_id).toBe('tool_1');
+    });
+
+    test('drops a tool_result whose previous message is not an assistant tool_use turn', () => {
+        // e.g. a compaction summary user message precedes a surviving tool_result.
+        const messages: MessageParam[] = [
+            { role: 'user', content: [{ type: 'text', text: 'Here is the summary of prior work...' }] },
+            { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'gone', content: 'orphan' }] },
+        ];
+
+        const result = fixOrphanedToolResults(messages);
+        // The orphaned tool_result message is dropped entirely; the summary text remains.
+        expect(result).toHaveLength(1);
+        expect(result[0].role).toBe('user');
+        const remaining = result[0].content as Array<{ type: string }>;
+        expect(remaining[0].type).toBe('text');
+    });
+
+    test('preserves non-tool_result blocks while dropping the orphan', () => {
+        const messages: MessageParam[] = [
+            { role: 'assistant', content: [{ type: 'text', text: 'thinking out loud' }] },
+            {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'orphan', content: 'x' },
+                    { type: 'text', text: 'continue please' },
+                ],
+            },
+        ];
+
+        const result = fixOrphanedToolResults(messages);
+        const userContent = result[1].content as Array<{ type: string; text?: string }>;
+        expect(userContent).toHaveLength(1);
+        expect(userContent[0].type).toBe('text');
+        expect(userContent[0].text).toBe('continue please');
+    });
+
+    test('regression: split parallel results recombined by merge are all retained', () => {
+        // After mergeConsecutiveUserMessages, both results sit in one user message
+        // whose previous assistant turn declared both tool_uses — none are orphans.
+        const messages: MessageParam[] = [
+            {
+                role: 'assistant',
+                content: [
+                    { type: 'tool_use', id: 'get_project', name: 'get_project', input: {} },
+                    { type: 'tool_use', id: 'learn_ops', name: 'learn_artifact_operations', input: {} },
+                ],
+            },
+            {
+                role: 'user',
+                content: [
+                    { type: 'tool_result', tool_use_id: 'get_project', content: 'p' },
+                    { type: 'tool_result', tool_use_id: 'learn_ops', content: 'o' },
+                ],
+            },
+        ];
+        const result = fixOrphanedToolResults(messages);
+        expect((result[1].content as unknown[]).length).toBe(2);
     });
 });
 


### PR DESCRIPTION
## Summary
A conversation can carry a tool **result** whose matching tool **call** is absent from the conversation — left behind when context compaction trims the assistant tool-call turn but keeps its result, or when a parallel tool batch's results are split/unmergeable. Every major provider validates tool-call/result pairing and rejects this with a **non-retryable error that terminates the run** (observed in production as a Vertex/Anthropic 400: `unexpected tool_use_id found in tool_result blocks ... Each tool_result block must have a corresponding tool_use block in the previous message`).

Each driver already had a `fixOrphanedToolUse` (the *missing-result* direction, e.g. a cancelled run) but **no mirror to drop an orphaned result**. This adds that mirror across all four major drivers.

- **Claude** (`shared/claude-messages.ts`): add `fixOrphanedToolResults`; `getClaudePayload` now runs `merge → fixOrphanedToolUse → fixOrphanedToolResults → sanitize`. Covers the Anthropic and Vertex-Claude drivers (streaming + non-streaming). Merging first recombines split parallel results so legitimately-paired results are never dropped.
- **Bedrock** (`bedrock/index.ts`): add `fixOrphanedToolResults` (paired by `toolUseId`), wired into `updateConversation`.
- **OpenAI** (`openai/index.ts`): add `fixOrphanedToolResults` (drops `function_call_output` whose `call_id` has no `function_call` item), wired into both execute paths.
- **Gemini** (`vertexai/models/gemini.ts`): add `fixOrphanedToolResults` (`functionResponse` paired to `functionCall` by name in the preceding `model` content), wired into `getGeminiPayload` after `mergeConsecutiveRole`.

The drop is surgical — only a result whose call is genuinely absent is removed (and the message/content is dropped only if it becomes empty); all legitimately-paired results are retained.

## Reproduction & tests
- `drivers/test/orphaned-tool-result-payload.test.ts` — drives the real Claude send-prep (`getClaudePayload`) end-to-end and audits the produced payload for the exact pairing condition the API validates. **Verified RED** against the unfixed pipeline (orphan reaches the payload), **GREEN** with the fix.
- `drivers/test/orphaned-tool-use.test.ts` — unit tests for `fixOrphanedToolResults` in Claude, Bedrock, and OpenAI (orphan dropped, valid + parallel retained, empties handled).
- `drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts` — unit tests for the Gemini mirror.

## Test plan
- [x] `vitest run` on orphan/merge/gemini suites — 64 passed
- [x] `@llumiverse/drivers` build / typecheck clean
- [x] Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>