### PR TITLE
fix(gemini): keep split parallel tool responses

### DIFF
--- a/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
+++ b/drivers/src/vertexai/models/gemini-orphaned-tool-result.test.ts
@@ -9,8 +9,23 @@
  */
 
 import type { Content } from '@google/genai';
+import type { ExecutionOptions } from '@llumiverse/core';
 import { describe, expect, test } from 'vitest';
-import { fixOrphanedToolResults } from './gemini.js';
+import { fixOrphanedToolResults, getGeminiPayload } from './gemini.js';
+
+const OPTIONS_WITH_TOOLS = {
+    model: 'gemini-2.5-flash',
+    tools: [
+        { name: 'a', description: '', input_schema: { type: 'object', properties: {} } },
+        { name: 'b', description: '', input_schema: { type: 'object', properties: {} } },
+    ],
+} as unknown as ExecutionOptions;
+
+function functionResponseNames(contents: Content[]): string[] {
+    return contents.flatMap((content) =>
+        (content.parts ?? []).flatMap((part) => (part.functionResponse?.name ? [part.functionResponse.name] : [])),
+    );
+}
 
 describe('fixOrphanedToolResults - Gemini', () => {
     test('returns empty array for empty input', () => {
@@ -82,5 +97,22 @@ describe('fixOrphanedToolResults - Gemini', () => {
         const result = fixOrphanedToolResults(contents);
         expect(result[1].parts).toHaveLength(1);
         expect(result[1].parts?.[0].text).toBe('continue please');
+    });
+});
+
+describe('getGeminiPayload - orphaned tool results', () => {
+    test('retains split parallel functionResponses by merging consecutive user contents before cleanup', () => {
+        const contents: Content[] = [
+            {
+                role: 'model',
+                parts: [{ functionCall: { name: 'a', args: {} } }, { functionCall: { name: 'b', args: {} } }],
+            },
+            { role: 'user', parts: [{ functionResponse: { name: 'a', response: { ok: true } } }] },
+            { role: 'user', parts: [{ functionResponse: { name: 'b', response: { ok: true } } }] },
+        ];
+
+        const payload = getGeminiPayload(OPTIONS_WITH_TOOLS, { contents });
+
+        expect(functionResponseNames(payload.contents as Content[])).toEqual(['a', 'b']);
     });
 });

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -126,14 +126,14 @@ function getProminentPeopleOption(
     }
 }
 
-function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentPrompt): GenerateContentParameters {
+export function getGeminiPayload(options: ExecutionOptions, prompt: GenerateContentPrompt): GenerateContentParameters {
     const model_options = options.model_options as VertexAIGeminiOptions | undefined;
     const tools = getToolDefinitions(options.tools);
 
     // When no tools are provided but conversation contains functionCall/functionResponse parts
     // (e.g. checkpoint summary calls), convert them to text to avoid API errors.
     // Use a local variable to avoid mutating the caller's conversation object.
-    let payloadContents = prompt.contents;
+    let payloadContents = mergeConsecutiveRole(prompt.contents);
     if (!tools && payloadContents) {
         const hasToolParts = payloadContents.some((c) => c.parts?.some((p) => p.functionCall || p.functionResponse));
         if (hasToolParts) {


### PR DESCRIPTION
## Summary

Fixes Gemini payload preparation so split parallel function responses are merged before orphaned-response cleanup. Without this ordering, the second valid response in a consecutive user-response pair can be mistaken for an orphan and dropped.

## Root Cause

Gemini's orphaned functionResponse cleanup is adjacency-based: a response is valid only when the immediately preceding model content contains the matching functionCall. The payload path ran cleanup before merging consecutive user contents, so split parallel responses like model(call a,b), user(response a), user(response b) lost response b.

## Changes

- Run mergeConsecutiveRole(prompt.contents) before fixOrphanedToolResults() in getGeminiPayload().
- Export getGeminiPayload() for a focused payload-boundary regression test.
- Add a test that reproduces the failure by asserting both split responses survive.

## Validation

- pnpm --filter @llumiverse/drivers exec vitest run src/vertexai/models/gemini-orphaned-tool-result.test.ts --retry 0
- pnpm --filter @llumiverse/drivers lint
- pnpm --filter @llumiverse/drivers typecheck:test
- pnpm --filter @llumiverse/drivers build