### PR TITLE
feat(drivers): per-provider subpath exports for lazy loading

### DIFF
--- a/drivers/package.json
+++ b/drivers/package.json
@@ -13,6 +13,58 @@
         ".": {
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"
+        },
+        "./openai": {
+            "types": "./lib/openai/drivers.d.ts",
+            "default": "./lib/openai/drivers.js"
+        },
+        "./azure": {
+            "types": "./lib/azure/azure_foundry.d.ts",
+            "default": "./lib/azure/azure_foundry.js"
+        },
+        "./anthropic": {
+            "types": "./lib/anthropic/index.d.ts",
+            "default": "./lib/anthropic/index.js"
+        },
+        "./bedrock": {
+            "types": "./lib/bedrock/index.d.ts",
+            "default": "./lib/bedrock/index.js"
+        },
+        "./vertexai": {
+            "types": "./lib/vertexai/index.d.ts",
+            "default": "./lib/vertexai/index.js"
+        },
+        "./groq": {
+            "types": "./lib/groq/index.d.ts",
+            "default": "./lib/groq/index.js"
+        },
+        "./mistral": {
+            "types": "./lib/mistral/index.d.ts",
+            "default": "./lib/mistral/index.js"
+        },
+        "./watsonx": {
+            "types": "./lib/watsonx/index.d.ts",
+            "default": "./lib/watsonx/index.js"
+        },
+        "./togetherai": {
+            "types": "./lib/togetherai/index.d.ts",
+            "default": "./lib/togetherai/index.js"
+        },
+        "./xai": {
+            "types": "./lib/xai/index.d.ts",
+            "default": "./lib/xai/index.js"
+        },
+        "./replicate": {
+            "types": "./lib/replicate.d.ts",
+            "default": "./lib/replicate.js"
+        },
+        "./huggingface": {
+            "types": "./lib/huggingface_ie.d.ts",
+            "default": "./lib/huggingface_ie.js"
+        },
+        "./test-driver": {
+            "types": "./lib/test-driver/index.d.ts",
+            "default": "./lib/test-driver/index.js"
         }
     },
     "scripts": {

--- a/drivers/src/openai/drivers.ts
+++ b/drivers/src/openai/drivers.ts
@@ -1,0 +1,9 @@
+// Combined entry for the concrete OpenAI-protocol drivers, exposed as the `@llumiverse/drivers/openai`
+// subpath so consumers can lazy-load the OpenAI family per-provider without pulling the whole driver
+// barrel (e.g. via `await import('@llumiverse/drivers/openai')`). Kept separate from ./index.ts — which exports the abstract
+// BaseOpenAIDriver that openai.ts/azure_openai.ts/openai_compatible.ts extend — to avoid an ESM
+// initialization cycle (those files import BaseOpenAIDriver from ./index.js).
+
+export { AzureOpenAIDriver, type AzureOpenAIDriverOptions } from './azure_openai.js';
+export { OpenAIDriver, type OpenAIDriverOptions } from './openai.js';
+export { OpenAICompatibleDriver, type OpenAICompatibleDriverOptions } from './openai_compatible.js';


### PR DESCRIPTION
## Summary
- Add **per-provider subpath exports** to `@llumiverse/drivers` — `@llumiverse/drivers/openai`, `/azure`, `/anthropic`, `/bedrock`, `/vertexai`, `/groq`, `/mistral`, `/watsonx`, `/togetherai`, `/xai`, `/replicate`, `/huggingface`, `/test-driver` — alongside the existing barrel (`.`).
- This lets a consumer import a single provider's driver and load **only that provider's SDK** (e.g. `@google-cloud/aiplatform` for Vertex AI, `openai` for OpenAI, `@aws-sdk/*` for Bedrock) via `await import('@llumiverse/drivers/<provider>')`, instead of pulling the whole driver graph. Keeps unused provider SDKs off a process's startup path and out of single-file bundles.
- Add `openai/drivers.ts`, a small combined entry that re-exports the concrete OpenAI-protocol drivers (`OpenAIDriver`, `AzureOpenAIDriver`, `OpenAICompatibleDriver`). Kept separate from `openai/index.ts` (which exports the abstract `BaseOpenAIDriver` those classes extend) to avoid an ESM initialization cycle.
- **The barrel export is unchanged**, so existing `import { ... } from '@llumiverse/drivers'` consumers are unaffected.

## Test Plan
- [x] `tsc` build emits `lib/<provider>/index.js` + `lib/openai/drivers.js` and matching `.d.ts`
- [x] Barrel import still resolves; each new subpath resolves to the expected driver class(es) (verified by resolving from a packaged install)
- [ ] Provider driver integration tests require provider API keys (not run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)