### PR TITLE
fix(vertexai): retry Gemini 499 cancellations

### DIFF
--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -102,6 +102,15 @@ describe('GeminiModelDefinition Error Handling', () => {
             expect(error.retryable).toBe(true);
         });
 
+        it('should mark a client-closed/cancelled request (499) as retryable despite the 4xx status', () => {
+            const error = modelDef.formatLlumiverseError(
+                driver,
+                { status: 499, message: 'Client Closed Request: The operation was cancelled.' },
+                { provider: 'vertexai', model: 'gemini-2.0-flash', operation: 'execute' },
+            );
+            expect(error.retryable).toBe(true);
+        });
+
         it('should mark DEADLINE_EXCEEDED as retryable even under a 4xx status', () => {
             const error = modelDef.formatLlumiverseError(
                 driver,
@@ -343,7 +352,7 @@ describe('GeminiModelDefinition Error Handling', () => {
 
     describe('isGeminiErrorRetryable', () => {
         it('should classify retryable status codes correctly', () => {
-            const retryableStatusCodes = [408, 429, 500, 502, 503, 504];
+            const retryableStatusCodes = [408, 429, 499, 500, 502, 503, 504];
 
             retryableStatusCodes.forEach((statusCode) => {
                 const result = exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(statusCode);
@@ -369,7 +378,6 @@ describe('GeminiModelDefinition Error Handling', () => {
         it('should classify other 4xx errors as non-retryable', () => {
             expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(402)).toBe(false);
             expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(405)).toBe(false);
-            expect(exposePrivate<GeminiModelInternals>(modelDef).isGeminiErrorRetryable(499)).toBe(false);
         });
 
         it('should treat 400 URL_REJECTED-REJECTED_CLIENT_THROTTLED as retryable', () => {

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -940,6 +940,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
      *
      * Retryable errors (per Google AIP-194):
      * - 408 (REQUEST_TIMEOUT): Request timeout
+     * - 499 (CANCELLED / Client Closed Request): Transport cancellation
      * - 429 (RESOURCE_EXHAUSTED): Rate limit exceeded, quota exhausted
      * - 500 (INTERNAL): Internal server error
      * - 502 (BAD_GATEWAY): Bad gateway
@@ -970,6 +971,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         // Retryable status codes
         if (httpStatusCode === 408) return true; // Request timeout
         if (httpStatusCode === 429) return true; // Rate limit/quota
+        if (httpStatusCode === 499) return true; // Client closed / operation cancelled
         if (httpStatusCode === 502) return true; // Bad gateway
         if (httpStatusCode === 503) return true; // Service unavailable
         if (httpStatusCode === 504) return true; // Gateway timeout
@@ -986,12 +988,12 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             }
         }
 
-        // A transport-level abort (request-timeout / dropped connection, sometimes reported
+        // A transport-level abort/cancel (request-timeout / dropped connection, sometimes reported
         // as 499 client-closed) or a deadline-exceeded is transient and should be retried,
-        // even though it carries a 4xx status. Honor it before the 4xx → non-retryable rule.
+        // even though it carries a 4xx status. Honor it before the 4xx -> non-retryable rule.
         if (message) {
             const lower = message.toLowerCase();
-            if (lower.includes('aborted') || lower.includes('deadline')) return true;
+            if (lower.includes('aborted') || lower.includes('cancelled') || lower.includes('deadline')) return true;
         }
 
         // Non-retryable 4xx client errors


### PR DESCRIPTION
## Summary
- Treat Gemini/Vertex HTTP 499 cancellation responses as retryable provider failures.
- Add coverage for cancelled Client Closed Request responses and include 499 in retryable status classification.

## Test Plan
- pnpm --dir composableai/llumiverse/drivers exec vitest run src/vertexai/models/gemini-error-handling.test.ts
- pnpm --dir composableai/llumiverse/drivers typecheck:test
- pnpm --dir composableai/llumiverse/drivers build
- Pre-commit Biome check on changed files passed

## Not Run
- pnpm --dir composableai/llumiverse/drivers lint (package-level script could not find biome in this checkout; changed files were checked by the pre-commit hook)