### PR TITLE
fix(stream): reassemble Gemini thought_signature across streamed tool-call chunks

### DIFF
--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -13,6 +13,71 @@ import type { AbstractDriver } from './Driver.js';
 
 type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
 
+/**
+ * Merge a single streamed `tool_use` fragment into the accumulator map keyed by tool id.
+ *
+ * Providers stream a tool call across several chunks. Different fields arrive in
+ * different chunks and must be reassembled:
+ * - `tool_input` arrives as string pieces (concatenated) or partial objects (merged).
+ * - `tool_name` and the provider's real id (`_actual_id`) may only appear in a later chunk.
+ * - `thought_signature` (Gemini 2.5+/3.x thinking models) is an opaque base64 byte string
+ *   that must be passed back verbatim with the assistant turn on the next request.
+ *
+ * Before this helper existed, the inline accumulator merged `tool_input`/`tool_name`/`_actual_id`
+ * but silently dropped `thought_signature` for any chunk after the first for a given tool id.
+ * When a provider delivers the signature in pieces (large high-effort signatures are split
+ * across chunks) or only on a later chunk, the accumulated signature was left truncated or
+ * absent — producing an invalid base64 byte value that the provider rejects with a
+ * "Base64 decoding failed" (TYPE_BYTES) error when the assistant turn is threaded back.
+ *
+ * The signature is therefore reassembled by concatenating fragments in arrival order, exactly
+ * like `tool_input` string pieces. When the whole signature arrives in a single chunk there is
+ * only one fragment, so concatenation is a no-op and the value round-trips byte-identically.
+ *
+ * Exported for unit testing the round-trip in isolation (no network / no full driver).
+ */
+export function accumulateToolUseChunk(
+    accumulatedToolUse: Map<string, StreamingToolUse>,
+    tool: StreamingToolUse,
+): void {
+    const existing = accumulatedToolUse.get(tool.id);
+    if (!existing) {
+        // New tool call
+        accumulatedToolUse.set(tool.id, { ...tool });
+        return;
+    }
+    // Merge tool input (for streaming where arguments come as string pieces)
+    if (tool.tool_input !== null && tool.tool_input !== undefined) {
+        const existingInput = existing.tool_input as unknown;
+        const newInput = tool.tool_input as unknown;
+        if (typeof existingInput === 'string' && typeof newInput === 'string') {
+            // Concatenate string arguments
+            existing.tool_input = (existingInput + newInput) as typeof existing.tool_input;
+        } else if (existingInput && typeof existingInput === 'object' && newInput && typeof newInput === 'object') {
+            // Merge objects
+            existing.tool_input = {
+                ...(existingInput as Record<string, unknown>),
+                ...(newInput as Record<string, unknown>),
+            } as typeof existing.tool_input;
+        } else {
+            existing.tool_input = tool.tool_input;
+        }
+    }
+    // Update tool name if provided (might come in later chunk)
+    if (tool.tool_name) {
+        existing.tool_name = tool.tool_name;
+    }
+    // Reassemble the thought signature: concatenate fragments in arrival order so a
+    // signature split across chunks is restored byte-for-byte instead of being truncated.
+    if (tool.thought_signature) {
+        existing.thought_signature = (existing.thought_signature ?? '') + tool.thought_signature;
+    }
+    // Update actual ID if provided (OpenAI sends id only in first chunk)
+    if (tool._actual_id) {
+        existing._actual_id = tool._actual_id;
+    }
+}
+
 export class DefaultCompletionStream<PromptT = unknown> implements CompletionStream<PromptT> {
     chunks: number; // Counter for number of chunks instead of storing strings
     completion: ExecutionResponse<PromptT> | undefined;
@@ -83,43 +148,7 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
                         // Note: During streaming, tool_input comes as string chunks that need concatenation
                         if (chunk.tool_use && chunk.tool_use.length > 0) {
                             for (const tool of chunk.tool_use) {
-                                const existing = accumulatedToolUse.get(tool.id);
-                                if (existing) {
-                                    // Merge tool input (for streaming where arguments come as string pieces)
-                                    if (tool.tool_input !== null && tool.tool_input !== undefined) {
-                                        const existingInput = existing.tool_input as unknown;
-                                        const newInput = tool.tool_input as unknown;
-                                        if (typeof existingInput === 'string' && typeof newInput === 'string') {
-                                            // Concatenate string arguments
-                                            existing.tool_input = existingInput + newInput;
-                                        } else if (
-                                            existingInput &&
-                                            typeof existingInput === 'object' &&
-                                            newInput &&
-                                            typeof newInput === 'object'
-                                        ) {
-                                            // Merge objects
-                                            existing.tool_input = {
-                                                ...(existingInput as Record<string, unknown>),
-                                                ...(newInput as Record<string, unknown>),
-                                            };
-                                        } else {
-                                            existing.tool_input = tool.tool_input;
-                                        }
-                                    }
-                                    // Update tool name if provided (might come in later chunk)
-                                    if (tool.tool_name) {
-                                        existing.tool_name = tool.tool_name;
-                                    }
-                                    // Update actual ID if provided (OpenAI sends id only in first chunk)
-                                    const streamingTool = tool as StreamingToolUse;
-                                    if (streamingTool._actual_id) {
-                                        existing._actual_id = streamingTool._actual_id;
-                                    }
-                                } else {
-                                    // New tool call
-                                    accumulatedToolUse.set(tool.id, { ...tool });
-                                }
+                                accumulateToolUseChunk(accumulatedToolUse, tool as StreamingToolUse);
                             }
                         }
                         if (Array.isArray(chunk.result) && chunk.result.length > 0) {

--- a/core/test/tool-use-accumulate-signature.test.ts
+++ b/core/test/tool-use-accumulate-signature.test.ts
@@ -1,0 +1,88 @@
+import type { ToolUse } from '@llumiverse/common';
+import { describe, expect, test } from 'vitest';
+import { accumulateToolUseChunk } from '../src/CompletionStream.js';
+
+type StreamingToolUse = ToolUse<unknown> & { _actual_id?: string };
+
+/**
+ * Split a string into N roughly equal pieces, preserving order and content.
+ * Used to simulate a provider streaming a single large value across several chunks.
+ */
+function splitIntoChunks(value: string, pieces: number): string[] {
+    const size = Math.ceil(value.length / pieces);
+    const out: string[] = [];
+    for (let i = 0; i < value.length; i += size) {
+        out.push(value.slice(i, i + size));
+    }
+    return out;
+}
+
+/**
+ * Drive the streaming tool-use accumulator with an ordered list of chunk fragments
+ * (mirrors the per-chunk loop inside DefaultCompletionStream) and return the final tool.
+ */
+function accumulate(fragments: StreamingToolUse[]): StreamingToolUse | undefined {
+    const map = new Map<string, StreamingToolUse>();
+    for (const f of fragments) {
+        accumulateToolUseChunk(map, f);
+    }
+    return Array.from(map.values())[0];
+}
+
+describe('streaming tool_use thought_signature reassembly', () => {
+    // A large, valid base64 signature like Gemini 2.5+/3.x thinking models return on
+    // high-effort turns. Length is a multiple of 4 so it is valid, decodable base64.
+    const bytes = Uint8Array.from({ length: 9000 }, (_v, i) => (i * 37 + 11) % 256);
+    const fullSignature = Buffer.from(bytes).toString('base64');
+
+    test('the fixture signature is valid base64 to begin with', () => {
+        expect(fullSignature.length % 4).toBe(0);
+        expect(Buffer.from(fullSignature, 'base64')).toEqual(Buffer.from(bytes));
+    });
+
+    test('reassembles a signature split across chunks byte-for-byte (valid base64)', () => {
+        // Gemini streams the function call across several chunks. The tool name + signature
+        // arrive in pieces under the same tool id; arguments accumulate in parallel.
+        const pieces = splitIntoChunks(fullSignature, 5);
+        const argPieces = splitIntoChunks('{"query":"weather in Paris"}', 5);
+
+        const fragments: StreamingToolUse[] = pieces.map((sigPiece, idx) => ({
+            id: 'get_weather',
+            tool_name: idx === 0 ? 'get_weather' : '',
+            tool_input: argPieces[idx] ?? '',
+            thought_signature: sigPiece,
+        }));
+
+        const result = accumulate(fragments);
+
+        expect(result).toBeDefined();
+        // The reassembled signature must be byte-identical to what the model emitted...
+        expect(result?.thought_signature).toBe(fullSignature);
+        // ...and therefore still decode as valid base64 (the round-trip Vertex requires).
+        expect(() => Buffer.from(result?.thought_signature ?? '', 'base64')).not.toThrow();
+        expect(Buffer.from(result?.thought_signature ?? '', 'base64')).toEqual(Buffer.from(bytes));
+    });
+
+    test('carries a signature that only appears on a later chunk', () => {
+        // First chunk opens the call with no signature; the signature lands on a later chunk.
+        const fragments: StreamingToolUse[] = [
+            { id: 'plan', tool_name: 'plan', tool_input: '{"steps":' },
+            { id: 'plan', tool_name: '', tool_input: '[]}', thought_signature: fullSignature },
+        ];
+
+        const result = accumulate(fragments);
+
+        expect(result?.thought_signature).toBe(fullSignature);
+    });
+
+    test('preserves a signature delivered whole in a single chunk (no double-encoding)', () => {
+        const fragments: StreamingToolUse[] = [
+            { id: 'plan', tool_name: 'plan', tool_input: '{}', thought_signature: fullSignature },
+        ];
+
+        const result = accumulate(fragments);
+
+        // A single-fragment signature must round-trip unchanged (not concatenated with itself).
+        expect(result?.thought_signature).toBe(fullSignature);
+    });
+});


### PR DESCRIPTION
## Problem

Gemini 2.5+/3.x thinking models attach an opaque, base64-encoded `thought_signature` (TYPE_BYTES) to assistant tool-call parts. That signature must be threaded back **verbatim** on the next request, or the provider rejects the turn.

When a tool call is streamed, the signature does not always arrive in a single chunk:

- Large, high-effort signatures can be split across several streamed chunks.
- The signature may arrive only on a later chunk for a given tool-call id.

The streaming tool_use accumulator in `DefaultCompletionStream` (`core/src/CompletionStream.ts`) merged `tool_input`, `tool_name`, and the provider id across chunks, but silently dropped `thought_signature` for every chunk after the first. The accumulated signature was therefore left truncated (or absent), producing an invalid base64 byte value. When the assistant turn was sent back on the next request, the provider rejected it with:

```
[400] Invalid value at 'contents[N].parts[M].thought_signature' (TYPE_BYTES), Base64 decoding failed
```

## Fix

Extract the per-chunk merge into an exported `accumulateToolUseChunk` helper and concatenate `thought_signature` fragments in arrival order — exactly the way `tool_input` string pieces are already concatenated. A signature delivered whole in a single chunk has exactly one fragment, so it round-trips byte-identically; nothing changes for the common single-chunk case.

## Test

Adds `core/test/tool-use-accumulate-signature.test.ts`, which splits a large valid base64 signature across chunks and asserts the reassembled value is byte-identical and still decodes as valid base64. The test is pure (no network, no full driver). It fails before the fix (truncated/undefined signature) and passes after.

- Before: 2/4 cases fail.
- After: 4/4 pass; full `core` suite green (142 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>