### PR TITLE
Refactor TogetherAI driver onto OpenAI base

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -85,7 +85,7 @@ export const ProviderList: Record<Providers, ProviderParams> = {
     togetherai: {
         id: Providers.togetherai,
         name: 'Together AI',
-        requiresApiKey: false,
+        requiresApiKey: true,
         requiresEndpointUrl: false,
         supportSearch: false,
     },

--- a/drivers/src/http-timeout-wiring.test.ts
+++ b/drivers/src/http-timeout-wiring.test.ts
@@ -119,6 +119,10 @@ describe('driver HTTP timeout wiring', () => {
         expectSdkUsesDriverFetch(compatible, compatible.service);
         compatible.destroy();
 
+        const together = new TogetherAIDriver({ apiKey: 'test-key' });
+        expectSdkUsesDriverFetch(together, together.service);
+        together.destroy();
+
         const anthropic = new AnthropicDriver({ apiKey: 'test-key' });
         expectSdkUsesDriverFetch(anthropic, anthropic.client);
         anthropic.destroy();
@@ -140,10 +144,6 @@ describe('driver HTTP timeout wiring', () => {
         const mistral = new MistralAIDriver({ apiKey: 'test-key' });
         await expectFetchClientUsesDriverFetch(mistral, mistral.client);
         mistral.destroy();
-
-        const together = new TogetherAIDriver({ apiKey: 'test-key' });
-        await expectFetchClientUsesDriverFetch(together, together.fetchClient);
-        together.destroy();
 
         const watsonx = new WatsonxDriver({
             apiKey: 'test-key',

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -39,6 +39,38 @@ class TestOpenAIDriver extends BaseOpenAIDriver {
     }
 }
 
+describe('BaseOpenAIDriver usage mapping', () => {
+    it('maps Together flat cached_tokens usage into prompt_cached', () => {
+        const driver = new TestOpenAIDriver();
+        const response = {
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+                },
+            ],
+            usage: {
+                input_tokens: 100,
+                output_tokens: 20,
+                total_tokens: 120,
+                cached_tokens: 45,
+            },
+        } as unknown as OpenAI.Responses.Response;
+
+        const completion = driver.extractDataFromResponse({ model: 'test-model' }, response);
+
+        expect(completion.token_usage).toEqual({
+            prompt: 100,
+            result: 20,
+            total: 120,
+            prompt_cached: 45,
+            prompt_new: 55,
+        });
+    });
+});
+
 describe('BaseOpenAIDriver Error Handling', () => {
     let driver: TestOpenAIDriver;
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -66,6 +66,12 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     reasoning_effort?: string;
 };
 type OpenAIErrorWithStatus = Error & { status?: unknown };
+type OpenAIUsageWithProviderDetails = OpenAI.Responses.ResponseUsage & {
+    cached_tokens?: number | null;
+    prompt_tokens_details?: {
+        cached_tokens?: number | null;
+    } | null;
+};
 type MutableRoleItem = { role: 'user' | 'developer' | 'system' | 'assistant' };
 type MutableInputImagePart = { type: string; detail?: string };
 type OpenAIFunctionItem = ResponseInputItem & {
@@ -126,6 +132,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         | Providers.azure_openai
         | Providers.xai
         | Providers.azure_foundry
+        | Providers.togetherai
         | Providers.openai_compatible;
     abstract service: OpenAI | AzureOpenAI;
 
@@ -187,7 +194,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
 
         let parsedSchema: JSONSchema | undefined;
         let strictMode = false;
-        if (options.result_schema && supportsSchema(options.model)) {
+        if (options.result_schema && supportsSchema(options.model, this.provider)) {
             try {
                 parsedSchema = openAISchemaFormat(options.result_schema);
                 strictMode = true;
@@ -229,7 +236,8 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         if (
             options.model_options?._option_id !== undefined &&
             options.model_options?._option_id !== 'openai-text' &&
-            options.model_options?._option_id !== 'openai-thinking'
+            options.model_options?._option_id !== 'openai-thinking' &&
+            options.model_options?._option_id !== 'text-fallback'
         ) {
             this.logger.debug({ options: options.model_options }, 'Unexpected option id');
         }
@@ -253,7 +261,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
 
         let parsedSchema: JSONSchema | undefined;
         let strictMode = false;
-        if (options.result_schema && supportsSchema(options.model)) {
+        if (options.result_schema && supportsSchema(options.model, this.provider)) {
             try {
                 parsedSchema = openAISchemaFormat(options.result_schema);
                 strictMode = true;
@@ -480,7 +488,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         const models = filter ? result.filter(filter) : result;
         const aiModels = models
             .map((m) => {
-                const modelCapability = getModelCapabilities(m.id, 'openai');
+                const modelCapability = getModelCapabilities(m.id, this.provider);
                 let owner = m.owned_by;
                 if (owner === 'system') {
                     owner = 'openai';
@@ -882,16 +890,18 @@ function jobInfo(job: OpenAI.FineTuning.Jobs.FineTuningJob): TrainingJob {
     };
 }
 
-function mapUsage(usage?: OpenAI.Responses.ResponseUsage | null): ExecutionTokenUsage | undefined {
+function mapUsage(usage?: OpenAIUsageWithProviderDetails | null): ExecutionTokenUsage | undefined {
     if (!usage) {
         return undefined;
     }
+    const cachedTokens =
+        usage.input_tokens_details?.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens ?? usage.cached_tokens;
     return {
         prompt: usage.input_tokens,
         result: usage.output_tokens,
         total: usage.total_tokens,
-        prompt_cached: usage.input_tokens_details?.cached_tokens ?? undefined,
-        prompt_new: usage.input_tokens - (usage.input_tokens_details?.cached_tokens ?? 0),
+        prompt_cached: cachedTokens ?? undefined,
+        prompt_new: usage.input_tokens - (cachedTokens ?? 0),
     };
 }
 
@@ -1068,12 +1078,12 @@ function convertRoles(items: ResponseInputItem[], model: string): ResponseInputI
 
 //Structured output support is typically aligned with tool use support
 //Not true for realtime models, which do not support structured output, but do support tool use.
-function supportsSchema(model: string): boolean {
+function supportsSchema(model: string, provider: string | Providers): boolean {
     const realtimeModel = model.includes('realtime');
     if (realtimeModel) {
         return false;
     }
-    return supportsToolUse(model, 'openai');
+    return supportsToolUse(model, provider);
 }
 
 /**

--- a/drivers/src/togetherai/index.test.ts
+++ b/drivers/src/togetherai/index.test.ts
@@ -1,0 +1,32 @@
+import { ModelType, Providers } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import { TogetherAIDriver } from './index.js';
+
+describe('TogetherAIDriver', () => {
+    it('maps Together array-shaped model catalog responses', async () => {
+        const driver = new TogetherAIDriver({ apiKey: 'test-key' });
+        const get = vi.fn(async () => [
+            {
+                id: 'Qwen/Qwen3.5-9B',
+                display_name: 'Qwen3.5 9B',
+                organization: 'Qwen',
+                type: 'chat',
+            },
+        ]);
+        driver.service = { get } as unknown as TogetherAIDriver['service'];
+
+        const models = await driver.listModels();
+
+        expect(get).toHaveBeenCalledWith('/models');
+        expect(models).toEqual([
+            expect.objectContaining({
+                id: 'Qwen/Qwen3.5-9B',
+                name: 'Qwen3.5 9B',
+                owner: 'Qwen',
+                provider: Providers.togetherai,
+                type: ModelType.Chat,
+                tool_support: true,
+            }),
+        ]);
+    });
+});

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,145 +1,28 @@
-import type {
-    AIModel,
-    Completion,
-    CompletionChunkObject,
-    DriverOptions,
-    EmbeddingsOptions,
-    EmbeddingsResult,
-    ExecutionOptions,
-    TextFallbackOptions,
-} from '@llumiverse/core';
-import { transformSSEStream } from '@llumiverse/core/async';
-import { AbstractDriver } from '@llumiverse/core/driver';
-import { FetchClient, type ServerSentEvent } from '@vertesia/api-fetch-client';
-import type { TextCompletion, TogetherModelInfo } from './interfaces.js';
+import { type DriverOptions, Providers } from '@llumiverse/core';
+import OpenAI from 'openai';
+import { BaseOpenAIDriver } from '../openai/index.js';
 
-interface TogetherAIDriverOptions extends DriverOptions {
+export interface TogetherAIDriverOptions extends DriverOptions {
     apiKey: string;
+    endpoint?: string;
 }
 
-export class TogetherAIDriver extends AbstractDriver<TogetherAIDriverOptions, string> {
-    static PROVIDER = 'togetherai';
-    provider = TogetherAIDriver.PROVIDER;
-    apiKey: string;
-    fetchClient: FetchClient;
+export class TogetherAIDriver extends BaseOpenAIDriver {
+    static readonly PROVIDER = Providers.togetherai;
+    readonly provider = Providers.togetherai;
+    service: OpenAI;
 
-    constructor(options: TogetherAIDriverOptions) {
-        super(options);
-        this.apiKey = options.apiKey;
-        this.fetchClient = new FetchClient('https://api.together.xyz', this.getDriverFetch()).withHeaders({
-            authorization: `Bearer ${this.apiKey}`,
-        });
-    }
+    constructor(opts: TogetherAIDriverOptions) {
+        super(opts);
 
-    getResponseFormat = (options: ExecutionOptions): { type: string; schema: unknown } | undefined => {
-        return options.result_schema
-            ? {
-                  type: 'json_object',
-                  schema: options.result_schema,
-              }
-            : undefined;
-    };
-
-    async requestTextCompletion(prompt: string, options: ExecutionOptions): Promise<Completion> {
-        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== 'text-fallback') {
-            this.logger.debug({ options: options.model_options }, 'Unexpected option id');
+        if (!opts.apiKey) {
+            throw new Error('apiKey is required');
         }
-        options.model_options = options.model_options as TextFallbackOptions;
 
-        const stop_seq = options.model_options?.stop_sequence ?? [];
-
-        const res = (await this.fetchClient.post('/v1/completions', {
-            payload: {
-                model: options.model,
-                prompt: prompt,
-                response_format: this.getResponseFormat(options),
-                max_tokens: options.model_options?.max_tokens,
-                temperature: options.model_options?.temperature,
-                top_p: options.model_options?.top_p,
-                top_k: options.model_options?.top_k,
-                //logprobs: options.top_logprobs,       //Logprobs output currently not supported
-                frequency_penalty: options.model_options?.frequency_penalty,
-                presence_penalty: options.model_options?.presence_penalty,
-                stop: ['</s>', '[/INST]', ...stop_seq],
-            },
-        })) as TextCompletion;
-        const choice = res.choices[0];
-        const text = choice.text ?? '';
-        const usage = res.usage || {};
-        return {
-            result: [{ type: 'text', value: text }],
-            token_usage: {
-                prompt: usage.prompt_tokens,
-                result: usage.completion_tokens,
-                total: usage.total_tokens,
-            },
-            finish_reason: choice.finish_reason, //Uses expected "stop" , "length" format
-            original_response: options.include_original_response ? res : undefined,
-        };
-    }
-
-    async requestTextCompletionStream(
-        prompt: string,
-        options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
-        if (options.model_options?._option_id !== undefined && options.model_options?._option_id !== 'text-fallback') {
-            this.logger.debug({ options: options.model_options }, 'Unexpected option id');
-        }
-        options.model_options = options.model_options as TextFallbackOptions;
-
-        const stop_seq = options.model_options?.stop_sequence ?? [];
-        const stream = (await this.fetchClient.post('/v1/completions', {
-            payload: {
-                model: options.model,
-                prompt: prompt,
-                max_tokens: options.model_options?.max_tokens,
-                temperature: options.model_options?.temperature,
-                response_format: this.getResponseFormat(options),
-                top_p: options.model_options?.top_p,
-                top_k: options.model_options?.top_k,
-                //logprobs: options.top_logprobs,       //Logprobs output currently not supported
-                frequency_penalty: options.model_options?.frequency_penalty,
-                presence_penalty: options.model_options?.presence_penalty,
-                stream: true,
-                stop: ['</s>', '[/INST]', ...stop_seq],
-            },
-            reader: 'sse',
-        })) as ReadableStream<ServerSentEvent>;
-
-        return transformSSEStream(stream, (data: string) => {
-            const json = JSON.parse(data);
-            return {
-                result: [{ type: 'text', value: json.choices[0]?.text ?? '' }],
-                finish_reason: json.choices[0]?.finish_reason, //Uses expected "stop" , "length" format
-                token_usage: {
-                    prompt: json.usage?.prompt_tokens,
-                    result: json.usage?.completion_tokens,
-                    total: json.usage?.prompt_tokens + json.usage?.completion_tokens,
-                },
-            };
+        this.service = new OpenAI({
+            apiKey: opts.apiKey,
+            baseURL: opts.endpoint ?? 'https://api.together.ai/v1',
+            fetch: this.getDriverFetch(),
         });
-    }
-
-    async listModels(): Promise<AIModel<string>[]> {
-        const models: TogetherModelInfo[] = await this.fetchClient.get('/models/info');
-        //        logObject('#### LIST MODELS RESULT IS', models[0]);
-
-        const aiModels = models.map((m) => {
-            return {
-                id: m.name,
-                name: m.display_name,
-                description: m.description,
-                provider: this.provider,
-            };
-        });
-
-        return aiModels;
-    }
-
-    validateConnection(): Promise<boolean> {
-        throw new Error('Method not implemented.');
-    }
-    generateEmbeddings(_options: EmbeddingsOptions): Promise<EmbeddingsResult> {
-        throw new Error('Method not implemented.');
     }
 }

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -1,10 +1,24 @@
-import { type DriverOptions, Providers } from '@llumiverse/core';
+import {
+    type AIModel,
+    type DriverOptions,
+    getModelCapabilities,
+    ModelType,
+    modelModalitiesToArray,
+    Providers,
+} from '@llumiverse/core';
 import OpenAI from 'openai';
 import { BaseOpenAIDriver } from '../openai/index.js';
 
 export interface TogetherAIDriverOptions extends DriverOptions {
     apiKey: string;
     endpoint?: string;
+}
+
+interface TogetherModel {
+    id: string;
+    display_name?: string;
+    organization?: string;
+    type?: string;
 }
 
 export class TogetherAIDriver extends BaseOpenAIDriver {
@@ -24,5 +38,41 @@ export class TogetherAIDriver extends BaseOpenAIDriver {
             baseURL: opts.endpoint ?? 'https://api.together.ai/v1',
             fetch: this.getDriverFetch(),
         });
+    }
+
+    async listModels(): Promise<AIModel[]> {
+        const result = await this.service.get<TogetherModel[]>('/models');
+        return result
+            .map((model) => {
+                const modelCapability = getModelCapabilities(model.id, this.provider);
+                return {
+                    id: model.id,
+                    name: model.display_name ?? model.id,
+                    provider: this.provider,
+                    owner: model.organization,
+                    type: togetherModelType(model.type),
+                    can_stream: true,
+                    is_multimodal: modelCapability.input.image === true,
+                    input_modalities: modelModalitiesToArray(modelCapability.input),
+                    output_modalities: modelModalitiesToArray(modelCapability.output),
+                    tool_support: modelCapability.tool_support,
+                } satisfies AIModel<string>;
+            })
+            .sort((a, b) => a.id.localeCompare(b.id));
+    }
+}
+
+function togetherModelType(type?: string): ModelType {
+    switch (type) {
+        case 'chat':
+            return ModelType.Chat;
+        case 'code':
+            return ModelType.Code;
+        case 'image':
+            return ModelType.Image;
+        case 'embedding':
+            return ModelType.Embedding;
+        default:
+            return ModelType.Text;
     }
 }


### PR DESCRIPTION
## Summary
- Refactor the TogetherAI driver to use the shared OpenAI-compatible Responses API base driver for inference, streaming, tools, structured output, embeddings, and connection validation.
- Preserve TogetherAI as a first-class provider while adding support for Together-specific cached token usage fields.
- Override TogetherAI model listing to handle the provider catalog response shape and keep model metadata/capability mapping intact.
- Mark TogetherAI as requiring an API key.

## Test Plan
- [x] `pnpm --filter @llumiverse/common build`
- [x] `pnpm --filter @llumiverse/core build`
- [x] `pnpm --filter @llumiverse/drivers build`
- [x] `pnpm --filter @llumiverse/drivers typecheck:test`
- [x] `pnpm --filter @llumiverse/drivers exec vitest run src/togetherai/index.test.ts src/http-timeout-wiring.test.ts src/openai/error-handling.test.ts`
- [x] `../../node_modules/.bin/biome lint drivers/src/togetherai/index.ts drivers/src/togetherai/index.test.ts drivers/src/http-timeout-wiring.test.ts drivers/src/openai/error-handling.test.ts drivers/src/openai/index.ts common/src/types.ts`
- [x] GitHub Actions `(lint) Lint codebase`: passed
- [x] GitHub Actions `(test) Build and test`: passed