### PR TITLE
ci: automerge release version-bump PRs

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -23,12 +23,15 @@ Note: this is distinct from the existing `maintenance` ruleset, which targets ba
 `release/X.Y` prefix.
 
 When importing, an admin must configure the **bypass actors** (left empty in the
-committed JSON, as for `main`) so the release automation can operate on `release/*`:
+committed JSON, as for `main`) so the release automation can operate on `release/*`.
+**Use bypass mode `Exempt`, not `Always`** — "Always" is an interactive break-glass
+prompt a non-interactive app token can't perform (so the rule stays enforced and the
+create 422s); `Exempt` silently skips evaluation. Add:
 
+- the **release-bot** app (`Exempt`) — studio's `release-cut.yaml` creates the
+  `release/X.Y` line as this app, and
 - the submodule-sync automerge app (so `(sync) Update Git submodule` PRs auto-merge
-  into `release/X.Y`), and
-- the actor used by studio's `release-cut.yaml` for `bump_via=push` to push the
-  version-bump commits past protection (the GitHub App that mints the cross-repo
-  token, or the same deploy-key/automation actor used on `main`). The `bump_via=pr`
-  fallback opens PRs instead and needs no push bypass — use it until the bypass is
-  configured.
+  into `release/X.Y`).
+
+The release-cut **never** bypasses `main`: version bumps to `main` arrive as PRs that
+the approve+merge automation lands.

--- a/.github/workflows/release-automerge.yaml
+++ b/.github/workflows/release-automerge.yaml
@@ -1,0 +1,239 @@
+name: (release) automerge eligible release-cut bump PRs
+run-name: >-
+  ${{
+    github.event.workflow_run.pull_requests[0].number
+    && format(
+      '(release) automerge bump PR #{0}',
+      github.event.workflow_run.pull_requests[0].number
+    )
+    || format(
+      '(release) automerge bump ({0})',
+      github.event.workflow_run.head_branch
+    )
+  }}
+
+on:
+  # zizmor: ignore[dangerous-triggers] Chains after successful release-bump branch
+  # CI, then re-checks the exact head SHA before merging.
+  workflow_run:
+    workflows:
+      - "(test) Build and test"
+      - "(lint) Lint codebase"
+    types:
+      - completed
+    branches:
+      - "release-bump-*"
+
+permissions:
+  actions: read # inspect workflow run status for the exact bump head SHA
+  contents: read # repository metadata access through gh
+  pull-requests: read # inspect PR metadata, labels, and changed files
+
+jobs:
+  approve-and-merge:
+    name: Approve and merge eligible release-cut bump PR
+    if: |
+      github.event.workflow_run.event == 'push' &&
+      startsWith(github.event.workflow_run.head_branch, 'release-bump-')
+    runs-on: ubuntu-latest
+    environment: renovate-automerge
+    timeout-minutes: 5
+    concurrency:
+      group: release-automerge-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: false
+    steps:
+      - name: Check automerge eligibility
+        id: eligibility
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "should_merge=false"
+            echo "pr_url="
+          } >> "$GITHUB_OUTPUT"
+
+          prs_json="$(gh pr list \
+            --repo "$REPO" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --json number,url,author,isDraft,baseRefName,headRefName,headRefOid,headRepository,headRepositoryOwner,isCrossRepository,labels,files,commits \
+            --limit 10)"
+
+          pr_count="$(jq 'length' <<< "$prs_json")"
+          if [[ "$pr_count" == "0" ]]; then
+            echo "No open PR found for $HEAD_BRANCH."
+            exit 0
+          fi
+          if [[ "$pr_count" != "1" ]]; then
+            echo "Expected exactly one open PR for $HEAD_BRANCH, found $pr_count." >&2
+            exit 1
+          fi
+
+          pr_number="$(jq -r '.[0].number' <<< "$prs_json")"
+          pr_url="$(jq -r '.[0].url' <<< "$prs_json")"
+          author_login="$(jq -r '.[0].author.login // ""' <<< "$prs_json")"
+          base_ref="$(jq -r '.[0].baseRefName' <<< "$prs_json")"
+          head_ref="$(jq -r '.[0].headRefName' <<< "$prs_json")"
+          head_sha="$(jq -r '.[0].headRefOid' <<< "$prs_json")"
+          head_repo="$(jq -r '.[0].headRepository.nameWithOwner // ""' <<< "$prs_json")"
+          head_owner="$(jq -r '.[0].headRepositoryOwner.login // ""' <<< "$prs_json")"
+          is_cross_repo="$(jq -r '.[0].isCrossRepository' <<< "$prs_json")"
+          is_draft="$(jq -r '.[0].isDraft' <<< "$prs_json")"
+          repo_owner="${REPO%%/*}"
+
+          # The bump PR is opened by the release-bot app; the automerge app below
+          # (a distinct identity) approves it, so the approval counts. Accept both
+          # forms gh may report for an app author.
+          if [[ "$author_login" != "app/vertesia-release-bot" && "$author_login" != "vertesia-release-bot[bot]" ]]; then
+            echo "Skipping PR #$pr_number: author is $author_login, not the release-bot."
+            exit 0
+          fi
+          if [[ "$head_ref" != "$HEAD_BRANCH" ]]; then
+            echo "Skipping PR #$pr_number: PR head branch $head_ref does not match workflow branch $HEAD_BRANCH."
+            exit 0
+          fi
+          if [[ "$head_ref" != release-bump-* ]]; then
+            echo "Skipping PR #$pr_number: head branch $head_ref is not a release-bump branch."
+            exit 0
+          fi
+          if [[ "$is_cross_repo" != "false" ]]; then
+            echo "Skipping PR #$pr_number: PR is from a fork."
+            exit 0
+          fi
+          if [[ "$head_repo" != "$REPO" ]]; then
+            echo "Skipping PR #$pr_number: head repository is $head_repo, not $REPO."
+            exit 0
+          fi
+          if [[ "$head_owner" != "$repo_owner" ]]; then
+            echo "Skipping PR #$pr_number: head repository owner is $head_owner, not $repo_owner."
+            exit 0
+          fi
+          if [[ "$base_ref" != "main" && ! "$base_ref" =~ ^release/[0-9]+\.[0-9]+$ ]]; then
+            echo "Skipping PR #$pr_number: base branch is $base_ref, not main or release/X.Y."
+            exit 0
+          fi
+          if [[ "$is_draft" != "false" ]]; then
+            echo "Skipping PR #$pr_number: PR is draft."
+            exit 0
+          fi
+          if [[ "$head_sha" != "$HEAD_SHA" ]]; then
+            echo "Skipping PR #$pr_number: workflow SHA $HEAD_SHA does not match current PR head $head_sha."
+            exit 0
+          fi
+          if ! jq -e '.[0].labels | any(.name == "release:automerge")' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: missing release:automerge label."
+            exit 0
+          fi
+          if ! jq -e '.[0].files | all(.changeType == "MODIFIED")' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: PR includes non-modified file changes."
+            jq -r '.[0].files[] | select(.changeType != "MODIFIED") | "- \(.changeType) \(.path)"' <<< "$prs_json"
+            exit 0
+          fi
+
+          # A release-cut bump only ever touches package.json manifests + the lockfile.
+          disallowed_files="$(gh pr diff "$pr_url" --repo "$REPO" --name-only | grep -vE '(^|/)(package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$' || true)"
+          if [[ -n "$disallowed_files" ]]; then
+            echo "Skipping PR #$pr_number: PR changes files outside version manifests/lockfiles."
+            echo "$disallowed_files"
+            exit 0
+          fi
+
+          # Every commit must be the release-cut bump, authored by github-actions[bot].
+          if ! jq -e '
+            .[0].commits as $commits
+            | ($commits | length) > 0
+            and ($commits | all(
+              (
+                .authors | any(
+                  .login == "github-actions[bot]"
+                  or .email == "github-actions[bot]@users.noreply.github.com"
+                  or .name == "github-actions[bot]"
+                )
+              )
+              and (
+                (.messageHeadline | startswith("chore: set "))
+                or (.messageHeadline | startswith("chore: open next dev cycle "))
+              )
+            ))
+          ' <<< "$prs_json" >/dev/null; then
+            echo "Skipping PR #$pr_number: contains commits that are not the expected release-cut bump."
+            exit 0
+          fi
+
+          echo "PR #$pr_number is eligible; verifying required workflows for $HEAD_SHA."
+
+          required_workflows=(
+            "build-and-test.yml"
+            "lint.yml"
+          )
+
+          for workflow in "${required_workflows[@]}"; do
+            runs_json="$(gh run list \
+              --repo "$REPO" \
+              --workflow "$workflow" \
+              --branch "$HEAD_BRANCH" \
+              --commit "$HEAD_SHA" \
+              --json databaseId,status,conclusion,event,headSha,url \
+              --limit 20)"
+            run_json="$(jq -c --arg sha "$HEAD_SHA" '[.[] | select(.headSha == $sha and .event == "push")] | sort_by(.databaseId) | last // empty' <<< "$runs_json")"
+
+            if [[ -z "$run_json" ]]; then
+              echo "Waiting for $workflow to run for $HEAD_SHA."
+              exit 0
+            fi
+
+            status="$(jq -r '.status' <<< "$run_json")"
+            conclusion="$(jq -r '.conclusion // ""' <<< "$run_json")"
+            url="$(jq -r '.url' <<< "$run_json")"
+
+            if [[ "$status" != "completed" ]]; then
+              echo "Waiting for $workflow to complete for $HEAD_SHA: $url"
+              exit 0
+            fi
+            if [[ "$conclusion" != "success" ]]; then
+              echo "Not merging PR #$pr_number: $workflow concluded '$conclusion': $url"
+              exit 0
+            fi
+
+            echo "$workflow passed for $HEAD_SHA: $url"
+          done
+
+          {
+            echo "should_merge=true"
+            echo "pr_url=$pr_url"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate automerge token
+        if: steps.eligibility.outputs.should_merge == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.APP_VERTESIA_RENOVATE_AUTOMERGE_ID }}
+          private-key: ${{ secrets.APP_VERTESIA_RENOVATE_AUTOMERGE_PEM }}
+          permission-actions: read
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Approve and merge eligible release-cut bump PR
+        if: steps.eligibility.outputs.should_merge == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          PR_URL: ${{ steps.eligibility.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+
+          gh pr review "$PR_URL" \
+            --approve \
+            --body "Auto-approved release-cut version bump after build/test and lint passed for ${HEAD_SHA}."
+          gh pr merge "$PR_URL" \
+            --repo "$REPO" \
+            --squash \
+            --delete-branch \
+            --match-head-commit "$HEAD_SHA"


### PR DESCRIPTION
## Summary
Adds `release-automerge.yaml`, which approves and squash-merges the automated
version-bump PRs opened during a release (the `release-bump-*` branches), mirroring
`renovate-automerge.yaml`:

- triggers when `(test) Build and test` + `(lint) Lint codebase` complete for a
  `release-bump-*` branch, re-checks the exact head SHA, and waits for both to pass;
- only acts on a PR opened by the release bot, labeled `release:automerge`, based on
  `main` or `release/X.Y`, that changes nothing but `package.json` / `pnpm-lock.yaml`;
- approves as the renovate-automerge app (a distinct identity, so the approval counts
  against branch protection — no bypass) and squash-merges.

Must live on the default branch (`main`) to fire (`workflow_run` requirement).

## Verification
- `actionlint .github/workflows/release-automerge.yaml` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)