### PR TITLE
fix(ci): persist deploy key so the npm publish push succeeds

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -47,10 +47,15 @@ jobs:
       contents: write  # required to push version-bump commits
     steps:
       - name: Checkout repository
+        # persist-credentials must stay true so the DEPLOY_KEY SSH config survives
+        # into the publish step, where the script runs `git push origin "$REF"` to
+        # push the version-bump commit past branch protection. With it false, the
+        # push fails with "git@github.com: Permission denied (publickey)".
+        # zizmor: ignore[artipacked] deploy key is scoped to the `build` environment.
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }} # Use deploy key to bypass branch protection rules
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Install pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9


### PR DESCRIPTION
## Summary

The `(publish) NPM packages` workflow fails on a **real (non-dry-run) publish** when it tries to push the version-bump commit:

```
=== Committing version changes ===
[release/1.4 421c304] chore: snapshot 1.4.0-dev....
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
##[error]Process completed with exit code 128.
```

### Root cause

The checkout step uses the deploy key (`ssh-key: ${{ secrets.DEPLOY_KEY }}`) but also set `persist-credentials: false`. That flag makes `actions/checkout` unset the SSH config (`core.sshCommand`) immediately after checkout, so when `publish-all-packages.sh` later runs `git push origin "$REF"` there is no key to authenticate with — hence `Permission denied (publickey)`.

This was a **latent regression**: `persist-credentials: false` was added during a workflow-hardening pass, but the push only runs when `dry_run=false`, and `dry_run` defaults to `true`. So dry runs kept passing and the breakage only surfaced on the first real publish.

### Fix

Set `persist-credentials: true` so the deploy key survives into the publish step where the push happens. The key is scoped to the dedicated `build` environment, so a `zizmor: ignore[artipacked]` annotation is added to keep the security audit green.

## Test Plan

- [x] `actionlint` passes (runs via the repo pre-commit hook)
- [x] Workflow YAML parses; checkout step keeps `ssh-key` and now has `persist-credentials: true`
- [ ] Trigger the workflow with `dry_run=false` and confirm the version-bump commit pushes successfully

## Note

`code-sync.yaml` uses the same `ssh-key` + `persist-credentials: false` + `git push` pattern and likely has the same latent issue, but its push step hasn't actually run since the hardening change (recent failures are in the earlier `sync` job), so it's left out of this focused fix and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>