### PR TITLE
fix: allow npm release from release/* branches

### DIFF
--- a/.github/bin/publish-all-packages.md
+++ b/.github/bin/publish-all-packages.md
@@ -21,9 +21,9 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 
 ### Parameters
 
-- `--ref` (required): Git reference - `main` for dev builds, `preview` for releases. Publishing releases outside of `preview` branch is forbidden.
+- `--ref` (required): Git reference - `main` for dev builds, a `release/X.Y` branch (e.g. `release/1.4`) for releases. Publishing releases outside of a `release/*` branch is forbidden.
 - `--release-type` (required): The type of the version, either "release" or "snapshot". A "release" means this is a stable version. A "snapshot" means this is a development version.
-  - "release" creates a stable version respecting semantic versioning, such as `1.0.0`. Release can only be performed from the `preview` branch.
+  - "release" creates a stable version respecting semantic versioning, such as `1.0.0`. Release can only be performed from a `release/*` branch (e.g. `release/1.4`).
   - "snapshot" creates a new development version in format `{base}-dev.{date}.{time}`, such as `1.0.0-dev.20260128.144200Z`. Note that the time part contains 'Z', which means that the time is in UTC; it also allows NPM to use leading zeros, as it turns the segment into alphanumeric.
 - `--bump-type` (required): The strategy for changing the version (`minor`, `patch`, `keep`)
   - `minor` increases the minor version in the package version
@@ -44,23 +44,23 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 # Publish snapshot without bump from main
 # (ex: 1.0.0-dev.20260203.000000Z -> 1.0.0-dev.20260204.000000Z)
 ./publish-all-packages.sh \
-    --ref preview \
+    --ref release/1.4 \
     --release-type release \
     --bump-type minor
 
-# Publish release with 'patch' bump from preview
+# Publish release with 'patch' bump from a release branch
 # (ex: 0.24.0-dev.20260203.164053Z -> 0.24.1)
 # (ex: 0.24.0 -> 0.24.1)
 ./publish-all-packages.sh \
-    --ref preview \
+    --ref release/1.4 \
     --release-type release \
     --bump-type patch
 
-# Publish release with minor bump from prevew
+# Publish release with minor bump from a release branch
 # (ex: 0.24.0-dev.20260203.164053Z -> 0.25.0)
 # (ex: 0.24.0 -> 0.25.0)
 ./publish-all-packages.sh \
-    --ref preview \
+    --ref release/1.4 \
     --release-type release \
     --bump-type minor
 ```
@@ -126,7 +126,7 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 
 ### Scenario 2: Publishing official releases
 
-**Purpose**: Publish official releases from `preview`
+**Purpose**: Publish official releases from a `release/*` branch (e.g. `release/1.4`)
 
 **Steps**:
 1. Bumps root `package.json` version using semantic versioning
@@ -149,7 +149,7 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 # ==========
 # Example 1: we had a snapshot version
 # -----
-# params: ref=preview, release_type=release, bump_type=keep
+# params: ref=release/1.4, release_type=release, bump_type=keep
 # ==========
 
 # Before (package.json):
@@ -165,7 +165,7 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 # ==========
 # Example 2: we had a release version
 # -----
-# params: ref=preview, release_type=release, bump_type=patch
+# params: ref=release/1.4, release_type=release, bump_type=patch
 # ==========
 
 # Before (package.json):
@@ -195,10 +195,10 @@ The `publish-all-packages.sh` script handles publishing the following packages i
 # Test publishing logic on main
 ./publish-all-packages.sh --ref main --dry-run --release-type snapshot --bump-type keep
 
-# Test publishing logic on preview
-./publish-all-packages.sh --ref preview --dry-run --release-type release --bump-type minor
-./publish-all-packages.sh --ref preview --dry-run --release-type release --bump-type patch
-./publish-all-packages.sh --ref preview --dry-run --release-type snapshot --bump-type keep
+# Test publishing logic on a release branch
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type release --bump-type minor
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type release --bump-type patch
+./publish-all-packages.sh --ref release/1.4 --dry-run --release-type snapshot --bump-type keep
 ```
 
 **Result**:
@@ -257,7 +257,7 @@ In dry run mode, the script:
 - Dry run enabled by default in GitHub Actions
 - All version updates happen before any publishing
 - Changes push to GitHub before publishing to prevent Git conflicts
-- Restrict publishing from the `preview` branch
+- Restrict publishing to `release/*` branches
 - Portable shell syntax (works on macOS and Linux)
 
 ### Requirements

--- a/.github/bin/publish-all-packages.sh
+++ b/.github/bin/publish-all-packages.sh
@@ -3,7 +3,7 @@ set -e
 
 # Script to publish all llumiverse packages to NPM
 # Usage: publish-all-packages.sh --ref <ref> --release-type <type> --bump-type <type> [--dry-run [true|false]]
-#   --ref: Git reference (main for dev builds, preview for releases)
+#   --ref: Git reference (main for dev builds, release/X.Y for releases, e.g. release/1.4)
 #   --release-type: Release type (release, snapshot). Release creates stable versions, snapshot creates dev versions.
 #   --bump-type: Bump type (minor, patch, keep). How to change the version.
 #   --dry-run: Optional flag for dry run mode (value can be true, false, or omitted which means true)
@@ -329,9 +329,9 @@ if [[ ! "$BUMP_TYPE" =~ ^(minor|patch|keep)$ ]]; then
   exit 1
 fi
 
-# Validate that releases can only be published from 'preview' branch
-if [ "$RELEASE_TYPE" = "release" ] && [ "$REF" != "preview" ]; then
-  echo "Error: Release versions can only be published from the 'preview' branch."
+# Validate that releases can only be published from a release branch (release/X.Y, e.g. release/1.4)
+if [ "$RELEASE_TYPE" = "release" ] && [[ "$REF" != release/* ]]; then
+  echo "Error: Release versions can only be published from a 'release/*' branch (e.g. 'release/1.4')."
   echo "Current branch: $REF"
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Release publishing was gated on the `preview` branch, which no longer exists — `publish-all-packages.sh` rejected every `--release-type release` run.
- Releases are now allowed from any `release/*` branch (e.g. `release/1.4`); the guard uses a `release/*` glob match (`[[ "$REF" != release/* ]]`) instead of an exact `preview` comparison.
- Snapshot publishing from `main` is unchanged — the branch check only applies when `--release-type release`.
- Updated `publish-all-packages.md` to document the new release-branch convention (and fixed a `prevew` typo).

## Verification
- `bash -n .github/bin/publish-all-packages.sh` — syntax OK
- Logic check of the new guard: rejects `preview` / `main`, allows `release/1.4`, `release/2.0`, `release/1.4.1`
- No build/typecheck/test applies — the change is limited to a CI shell script and its markdown doc

## Test Plan
- [ ] Dispatch the `(publish) NPM packages` workflow from `release/1.4` with `release_type=release`, `dry_run=true`; confirm it passes the branch guard and packs correctly
- [ ] Confirm a `release_type=release` run from `main` is rejected with the new error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
