### PR TITLE
fix(togetherai): use Chat Completions for vision (Together lacks /v1/responses)

### DIFF
--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -40,10 +40,13 @@ function _getModelCapabilities(model: string, provider?: string | Providers): Mo
             // Azure Foundry uses OpenAI capabilities
             return getModelCapabilitiesAzureFoundry(model);
         case Providers.groq:
-        case Providers.togetherai:
         case Providers.mistralai:
             // These providers host text models that generally support tool use
             return getModelCapabilitiesOpenAICompatible(model);
+        case Providers.togetherai:
+            // Same OpenAI-compatible tool-use default, but also flag the natively-multimodal
+            // model families TogetherAI hosts so is_multimodal is reported correctly.
+            return getModelCapabilitiesTogetherAI(model);
         case Providers.xai:
             // xAI (Grok) models support tool use and are text-based
             return {
@@ -97,6 +100,33 @@ function getModelCapabilitiesOpenAICompatible(model: string): ModelCapabilities 
         tool_support: !isNonToolModel,
         tool_support_streaming: !isNonToolModel,
     };
+}
+
+// TogetherAI vision-capable model families. Conservative on purpose: only families that are
+// natively multimodal when served on Together are listed, so text-only models are not falsely
+// flagged as multimodal. This list can be extended as Together adds vision models.
+const TOGETHER_VISION_PATTERNS = [
+    'vision', // meta-llama/Llama-3.2-*-Vision-Instruct
+    'llama-4', // Llama 4 Scout / Maverick are natively multimodal
+    'gemma-3', // Gemma 3 is multimodal (gemma-2 and earlier are text-only)
+    'qwen2-vl',
+    'qwen2.5-vl',
+    '-vl-', // generic Qwen*-VL / other *-VL-* naming
+];
+
+/**
+ * TogetherAI capability resolver. Starts from the OpenAI-compatible defaults (tool_support, etc.)
+ * and additionally marks `input.image: true` for known natively-multimodal families, so the
+ * driver's `is_multimodal` flag is accurate. TogetherAI vision requests are sent via the Chat
+ * Completions API (see TogetherAIDriver.useChatCompletionsApi()).
+ */
+function getModelCapabilitiesTogetherAI(model: string): ModelCapabilities {
+    const caps = getModelCapabilitiesOpenAICompatible(model);
+    const normalized = model.toLowerCase();
+    if (TOGETHER_VISION_PATTERNS.some((p) => normalized.includes(p))) {
+        caps.input = { ...caps.input, image: true };
+    }
+    return caps;
 }
 
 export function supportsToolUse(model: string, provider?: string | Providers, streaming: boolean = false): boolean {

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -17,11 +17,10 @@ import Groq from 'groq-sdk';
 import type { ChatCompletionMessageParam, ChatCompletionTool } from 'groq-sdk/resources/chat/completions';
 import type { FunctionParameters } from 'groq-sdk/resources/shared';
 import type OpenAI from 'openai';
-import { formatOpenAILikeMultimodalPrompt } from '../openai/openai_format.js';
+import { convertResponseItemsToChatMessages, formatOpenAILikeMultimodalPrompt } from '../openai/openai_format.js';
 import { truncateDataUrlForDebug } from '../shared/debug-prompt.js';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
-type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
 type GroqToolCallMessage = {
     tool_calls?: Array<{
         id: string;
@@ -332,129 +331,13 @@ function updateConversation(
 }
 
 /**
- * Convert ResponseInputItem[] to Groq ChatCompletionMessageParam[]
+ * Convert ResponseInputItem[] to Groq ChatCompletionMessageParam[].
+ *
+ * Delegates to the shared Response->Chat-Completions converter in openai_format.ts.
+ * The `as unknown as` cast bridges the structurally-identical `ChatCompletionMessageParam`
+ * types from the `openai` and `groq-sdk` packages (same OpenAI wire format, distinct nominal
+ * declarations).
  */
 function convertResponseItemsToGroqMessages(items: ResponseInputItem[]): ChatCompletionMessageParam[] {
-    const messages: ChatCompletionMessageParam[] = [];
-
-    for (const item of items) {
-        // Handle EasyInputMessage (has role and content)
-        if ('role' in item && 'content' in item) {
-            const msg = item as EasyInputMessage;
-            const role = msg.role;
-
-            // Handle system/developer messages
-            if (role === 'system' || role === 'developer') {
-                let content: string;
-                if (typeof msg.content === 'string') {
-                    content = msg.content;
-                } else if (Array.isArray(msg.content)) {
-                    content = msg.content
-                        .filter((part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text')
-                        .map((part) => part.text)
-                        .join('\n');
-                } else {
-                    content = '';
-                }
-                messages.push({ role: 'system', content });
-                continue;
-            }
-
-            // Handle user messages
-            if (role === 'user') {
-                let content:
-                    | string
-                    | Array<
-                          | { type: 'text'; text: string }
-                          | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }
-                      >;
-                if (typeof msg.content === 'string') {
-                    content = msg.content;
-                } else if (Array.isArray(msg.content)) {
-                    const parts: Array<
-                        | { type: 'text'; text: string }
-                        | { type: 'image_url'; image_url: { url: string; detail?: 'auto' | 'low' | 'high' } }
-                    > = [];
-                    for (const part of msg.content) {
-                        if (part.type === 'input_text') {
-                            parts.push({ type: 'text', text: part.text });
-                        } else if (part.type === 'input_image') {
-                            const imgPart = part as OpenAI.Responses.ResponseInputImage;
-                            if (imgPart.image_url) {
-                                const image_url: { url: string; detail?: 'auto' | 'low' | 'high' } = {
-                                    url: imgPart.image_url,
-                                };
-
-                                if (imgPart.detail) {
-                                    image_url.detail = imgPart.detail as 'auto' | 'low' | 'high';
-                                }
-
-                                parts.push({
-                                    type: 'image_url',
-                                    image_url,
-                                });
-                            }
-                        }
-                    }
-                    content = parts.length > 0 ? parts : '';
-                } else {
-                    content = '';
-                }
-                messages.push({ role: 'user', content });
-                continue;
-            }
-
-            // Handle assistant messages
-            if (role === 'assistant') {
-                let content: string | null;
-                if (typeof msg.content === 'string') {
-                    content = msg.content;
-                } else if (Array.isArray(msg.content)) {
-                    content =
-                        msg.content
-                            .filter((part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text')
-                            .map((part) => part.text)
-                            .join('\n') || null;
-                } else {
-                    content = null;
-                }
-                messages.push({ role: 'assistant', content });
-                continue;
-            }
-        }
-
-        // Handle function_call_output (tool response)
-        if ('type' in item && item.type === 'function_call_output') {
-            const output = item as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
-            messages.push({
-                role: 'tool',
-                tool_call_id: output.call_id,
-                content: typeof output.output === 'string' ? output.output : JSON.stringify(output.output),
-            });
-            continue;
-        }
-
-        // Handle function_call (assistant tool call)
-        if ('type' in item && item.type === 'function_call') {
-            const call = item as OpenAI.Responses.ResponseFunctionToolCall;
-            // Groq expects tool_calls in assistant message, but we handle them separately
-            // This is a simplification - in practice tool_calls come from model responses
-            messages.push({
-                role: 'assistant',
-                content: null,
-                tool_calls: [
-                    {
-                        id: call.call_id,
-                        type: 'function',
-                        function: {
-                            name: call.name,
-                            arguments: call.arguments,
-                        },
-                    },
-                ],
-            });
-        }
-    }
-
-    return messages;
+    return convertResponseItemsToChatMessages(items) as unknown as ChatCompletionMessageParam[];
 }

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -55,7 +55,7 @@ import {
     RateLimitError,
     UnprocessableEntityError,
 } from 'openai/error';
-import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
+import { convertResponseItemsToChatMessages, formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 
 // Response API types
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
@@ -141,6 +141,20 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         this.formatPrompt = formatOpenAILikeMultimodalPrompt;
     }
 
+    /**
+     * Whether requests must be sent via the OpenAI *Chat Completions* API (`/v1/chat/completions`)
+     * instead of the newer *Responses* API (`/v1/responses`).
+     *
+     * The default (`false`) uses the Responses API, matching OpenAI/Azure. Providers whose
+     * OpenAI-compatible surface only implements Chat Completions (e.g. TogetherAI) override this to
+     * `true`. When enabled, the request methods convert the `ResponseInputItem[]` conversation to
+     * Chat Completions messages (images become `image_url`) and call `chat.completions.create`.
+     * All shared conversation/stripping/tool-call handling is unchanged.
+     */
+    protected useChatCompletionsApi(): boolean {
+        return false;
+    }
+
     extractDataFromResponse(_options: ExecutionOptions, result: OpenAI.Responses.Response): Completion {
         const tokenInfo = mapUsage(result.usage);
 
@@ -207,6 +221,23 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         const isReasoningModel = isOpenAIReasoningModel(options.model);
         const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
         const reasoning = effort ? { effort } : undefined;
+
+        // Chat Completions API path (providers without the Responses API, e.g. TogetherAI).
+        // The result_schema instruction is already injected into the prompt by
+        // formatOpenAILikeMultimodalPrompt, so no response_format is required here.
+        if (this.useChatCompletionsApi()) {
+            const chatStream = await this.service.chat.completions.create({
+                stream: true,
+                model: options.model,
+                messages: convertResponseItemsToChatMessages(conversation),
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_tokens: model_options?.max_tokens,
+                tools: useTools ? getChatCompletionsToolDefinitions(options.tools) : undefined,
+                stream_options: { include_usage: true },
+            });
+            return mapChatCompletionStream(chatStream);
+        }
 
         const stream = await this.service.responses.create({
             stream: true,
@@ -275,30 +306,51 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
         const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
         const reasoning = effort ? { effort } : undefined;
 
-        const res = await this.service.responses.create({
-            stream: false,
-            model: options.model,
-            input: conversation,
-            reasoning,
-            temperature: isReasoningModel ? undefined : model_options?.temperature,
-            top_p: isReasoningModel ? undefined : model_options?.top_p,
-            max_output_tokens: model_options?.max_tokens, //TODO: use max_tokens for older models, currently relying on OpenAI to handle it
-            tools: useTools ? toolDefs : undefined,
-            text: parsedSchema
-                ? {
-                      format: {
-                          type: 'json_schema',
-                          name: 'format_output',
-                          schema: parsedSchema,
-                          strict: strictMode,
-                      },
-                  }
-                : undefined,
-        });
+        let completion: Completion;
 
-        const completion = this.extractDataFromResponse(options, res);
-        if (options.include_original_response) {
-            completion.original_response = res;
+        // Chat Completions API path (providers without the Responses API, e.g. TogetherAI).
+        // The result_schema instruction is already injected into the prompt by
+        // formatOpenAILikeMultimodalPrompt, so no response_format is required here.
+        if (this.useChatCompletionsApi()) {
+            const res = await this.service.chat.completions.create({
+                stream: false,
+                model: options.model,
+                messages: convertResponseItemsToChatMessages(conversation),
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_tokens: model_options?.max_tokens,
+                tools: useTools ? getChatCompletionsToolDefinitions(options.tools) : undefined,
+            });
+            completion = extractDataFromChatCompletion(res);
+            if (options.include_original_response) {
+                completion.original_response = res;
+            }
+        } else {
+            const res = await this.service.responses.create({
+                stream: false,
+                model: options.model,
+                input: conversation,
+                reasoning,
+                temperature: isReasoningModel ? undefined : model_options?.temperature,
+                top_p: isReasoningModel ? undefined : model_options?.top_p,
+                max_output_tokens: model_options?.max_tokens, //TODO: use max_tokens for older models, currently relying on OpenAI to handle it
+                tools: useTools ? toolDefs : undefined,
+                text: parsedSchema
+                    ? {
+                          format: {
+                              type: 'json_schema',
+                              name: 'format_output',
+                              schema: parsedSchema,
+                              strict: strictMode,
+                          },
+                      }
+                    : undefined,
+            });
+
+            completion = this.extractDataFromResponse(options, res);
+            if (options.include_original_response) {
+                completion.original_response = res;
+            }
         }
 
         conversation = updateConversation(conversation, createAssistantMessageFromCompletion(completion));
@@ -1048,6 +1100,163 @@ export function mapResponseStream(
                         result: [],
                         finish_reason: responseFinishReason(event.response, finalTools),
                         token_usage: mapUsage(event.response.usage),
+                    } satisfies CompletionChunkObject;
+                }
+            }
+        },
+    };
+}
+
+// ========= Chat Completions API helpers =========
+// Used by OpenAI-compatible providers that only implement /v1/chat/completions and lack the
+// Responses API (e.g. TogetherAI). See BaseOpenAIDriver.useChatCompletionsApi().
+
+type ChatCompletionUsage = {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details?: { cached_tokens?: number | null } | null;
+};
+
+function getChatCompletionsToolDefinitions(
+    tools: ToolDefinition[] | undefined | null,
+): OpenAI.Chat.Completions.ChatCompletionTool[] | undefined {
+    if (!tools || tools.length === 0) {
+        return undefined;
+    }
+    return tools.map(getChatCompletionToolDefinition);
+}
+
+function getChatCompletionToolDefinition(toolDef: ToolDefinition): OpenAI.Chat.Completions.ChatCompletionFunctionTool {
+    let parsedSchema: JSONSchema | undefined;
+    let strictMode = false;
+    if (toolDef.input_schema) {
+        try {
+            parsedSchema = openAISchemaFormat(toolDef.input_schema as JSONSchema);
+            strictMode = true;
+        } catch {
+            parsedSchema = limitedSchemaFormat(toolDef.input_schema as JSONSchema);
+            strictMode = false;
+        }
+    }
+
+    return {
+        type: 'function',
+        function: {
+            name: toolDef.name,
+            description: toolDef.description,
+            parameters: parsedSchema ?? undefined,
+            strict: strictMode,
+        },
+    };
+}
+
+function extractChatCompletionToolUse(
+    message: OpenAI.Chat.Completions.ChatCompletionMessage | undefined,
+): ToolUse<unknown>[] | undefined {
+    const toolCalls = message?.tool_calls;
+    if (!toolCalls || toolCalls.length === 0) {
+        return undefined;
+    }
+    const tools: ToolUse<unknown>[] = [];
+    for (const toolCall of toolCalls) {
+        if (toolCall.type !== 'function') {
+            continue;
+        }
+        tools.push({
+            id: toolCall.id,
+            tool_name: toolCall.function.name,
+            tool_input: safeJsonParse(toolCall.function.arguments),
+        });
+    }
+    return tools.length > 0 ? tools : undefined;
+}
+
+function mapChatUsage(usage?: ChatCompletionUsage | null): ExecutionTokenUsage | undefined {
+    if (!usage) {
+        return undefined;
+    }
+    const cachedTokens = usage.prompt_tokens_details?.cached_tokens;
+    return {
+        prompt: usage.prompt_tokens,
+        result: usage.completion_tokens,
+        total: usage.total_tokens,
+        prompt_cached: cachedTokens ?? undefined,
+        prompt_new: usage.prompt_tokens - (cachedTokens ?? 0),
+    };
+}
+
+function chatCompletionFinishReason(reason: string | null | undefined): string | undefined {
+    if (reason === 'tool_calls' || reason === 'function_call') {
+        return 'tool_use';
+    }
+    return reason ?? 'stop';
+}
+
+function extractDataFromChatCompletion(result: OpenAI.Chat.Completions.ChatCompletion): Completion {
+    const choice = result.choices?.[0];
+    const message = choice?.message;
+    const rawContent = message?.content;
+    const text = typeof rawContent === 'string' ? rawContent : '';
+    const tools = extractChatCompletionToolUse(message);
+
+    return {
+        result: textToCompletionResult(text),
+        token_usage: mapChatUsage(result.usage),
+        finish_reason: tools && tools.length > 0 ? 'tool_use' : chatCompletionFinishReason(choice?.finish_reason),
+        tool_use: tools,
+    };
+}
+
+/**
+ * Map a Chat Completions stream to Llumiverse CompletionChunkObjects.
+ *
+ * Tool-call deltas are keyed by their array `index` (the tool call `id` and `name` only arrive on
+ * the first delta; `arguments` stream as string fragments). A stable synthetic id (`tool_<index>`)
+ * lets the shared stream accumulator concatenate arguments and restore the real id at the end,
+ * mirroring the Responses-API streaming path.
+ */
+export function mapChatCompletionStream(
+    stream: AsyncIterable<OpenAI.Chat.Completions.ChatCompletionChunk>,
+): AsyncIterable<CompletionChunkObject> {
+    return {
+        async *[Symbol.asyncIterator]() {
+            for await (const chunk of stream) {
+                const choice = chunk.choices?.[0];
+
+                if (choice?.delta?.tool_calls) {
+                    for (const toolCall of choice.delta.tool_calls) {
+                        const syntheticId = `tool_${toolCall.index}`;
+                        const toolUse: ToolUse<unknown> & { _actual_id?: string } = {
+                            id: syntheticId,
+                            _actual_id: toolCall.id,
+                            tool_name: toolCall.function?.name ?? '',
+                            tool_input: toolCall.function?.arguments ?? '',
+                        };
+                        yield {
+                            result: [],
+                            tool_use: [toolUse],
+                        } satisfies CompletionChunkObject;
+                    }
+                }
+
+                const deltaText = choice?.delta?.content;
+                if (deltaText) {
+                    yield {
+                        result: textToCompletionResult(deltaText),
+                    } satisfies CompletionChunkObject;
+                }
+
+                if (choice?.finish_reason || chunk.usage) {
+                    // A usage-only trailing chunk (choices=[] when stream_options.include_usage) has no
+                    // finish_reason; leave it undefined so the accumulator keeps any prior reason
+                    // (e.g. 'tool_use') rather than overwriting it with a default.
+                    yield {
+                        result: [],
+                        finish_reason: choice?.finish_reason
+                            ? chatCompletionFinishReason(choice.finish_reason)
+                            : undefined,
+                        token_usage: mapChatUsage(chunk.usage),
                     } satisfies CompletionChunkObject;
                 }
             }

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -203,3 +203,131 @@ export interface OpenAIPromptFormatterOptions {
     useToolForFormatting?: boolean;
     schema?: object;
 }
+
+// Chat Completions API types
+type ChatCompletionMessageParam = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+type ChatCompletionContentPart = OpenAI.Chat.Completions.ChatCompletionContentPart;
+
+/**
+ * Convert Response API items (`ResponseInputItem[]`) into Chat Completions messages
+ * (`ChatCompletionMessageParam[]`).
+ *
+ * Some OpenAI-compatible providers expose only the *Chat Completions* surface and do NOT
+ * implement the newer *Responses* API (e.g. TogetherAI, Groq). Those drivers still build
+ * their prompts/conversations as `ResponseInputItem[]` — so all the shared conversation,
+ * stripping and tool-handling logic keeps working — and convert to Chat Completions messages
+ * right before the request. Crucially, images become `{ type: 'image_url', image_url: { url } }`
+ * (the Chat Completions shape) instead of the Responses `input_image` shape, which those
+ * providers silently ignore.
+ */
+export function convertResponseItemsToChatMessages(items: ResponseInputItem[]): ChatCompletionMessageParam[] {
+    const messages: ChatCompletionMessageParam[] = [];
+
+    for (const item of items) {
+        // Handle EasyInputMessage (has role and content)
+        if ('role' in item && 'content' in item) {
+            const msg = item as EasyInputMessage;
+            const role = msg.role;
+
+            // Handle system/developer messages
+            if (role === 'system' || role === 'developer') {
+                let content: string;
+                if (typeof msg.content === 'string') {
+                    content = msg.content;
+                } else if (Array.isArray(msg.content)) {
+                    content = msg.content
+                        .filter((part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text')
+                        .map((part) => part.text)
+                        .join('\n');
+                } else {
+                    content = '';
+                }
+                messages.push({ role: 'system', content });
+                continue;
+            }
+
+            // Handle user messages (text + images)
+            if (role === 'user') {
+                let content: string | ChatCompletionContentPart[];
+                if (typeof msg.content === 'string') {
+                    content = msg.content;
+                } else if (Array.isArray(msg.content)) {
+                    const parts: ChatCompletionContentPart[] = [];
+                    for (const part of msg.content) {
+                        if (part.type === 'input_text') {
+                            parts.push({ type: 'text', text: part.text });
+                        } else if (part.type === 'input_image') {
+                            const imgPart = part as OpenAI.Responses.ResponseInputImage;
+                            if (imgPart.image_url) {
+                                const image_url: { url: string; detail?: 'auto' | 'low' | 'high' } = {
+                                    url: imgPart.image_url,
+                                };
+                                // Chat Completions only accepts auto|low|high; the Responses-only
+                                // 'original' detail is dropped (TogetherAI ignores detail anyway).
+                                if (imgPart.detail && imgPart.detail !== 'original') {
+                                    image_url.detail = imgPart.detail;
+                                }
+                                parts.push({ type: 'image_url', image_url });
+                            }
+                        }
+                    }
+                    content = parts.length > 0 ? parts : '';
+                } else {
+                    content = '';
+                }
+                messages.push({ role: 'user', content });
+                continue;
+            }
+
+            // Handle assistant messages
+            if (role === 'assistant') {
+                let content: string | null;
+                if (typeof msg.content === 'string') {
+                    content = msg.content;
+                } else if (Array.isArray(msg.content)) {
+                    content =
+                        msg.content
+                            .filter((part): part is OpenAI.Responses.ResponseInputText => part.type === 'input_text')
+                            .map((part) => part.text)
+                            .join('\n') || null;
+                } else {
+                    content = null;
+                }
+                messages.push({ role: 'assistant', content });
+                continue;
+            }
+        }
+
+        // Handle function_call_output (tool response)
+        if ('type' in item && item.type === 'function_call_output') {
+            const output = item as OpenAI.Responses.ResponseInputItem.FunctionCallOutput;
+            messages.push({
+                role: 'tool',
+                tool_call_id: output.call_id,
+                content: typeof output.output === 'string' ? output.output : JSON.stringify(output.output),
+            });
+            continue;
+        }
+
+        // Handle function_call (assistant tool call)
+        if ('type' in item && item.type === 'function_call') {
+            const call = item as OpenAI.Responses.ResponseFunctionToolCall;
+            messages.push({
+                role: 'assistant',
+                content: null,
+                tool_calls: [
+                    {
+                        id: call.call_id,
+                        type: 'function',
+                        function: {
+                            name: call.name,
+                            arguments: call.arguments,
+                        },
+                    },
+                ],
+            });
+        }
+    }
+
+    return messages;
+}

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -40,6 +40,17 @@ export class TogetherAIDriver extends BaseOpenAIDriver {
         });
     }
 
+    /**
+     * TogetherAI's OpenAI-compatible surface only implements Chat Completions (`/v1/chat/completions`)
+     * and does NOT support the Responses API (`/v1/responses`). Requests must therefore go through
+     * Chat Completions, where images are sent as `image_url` parts. Sending them via the Responses API
+     * makes vision requests fail: `openai/gpt-oss-120b` returns HTTP 400 "does not support the Responses
+     * api", while MiniMax/Kimi return 200 but never receive the image ("no content").
+     */
+    protected override useChatCompletionsApi(): boolean {
+        return true;
+    }
+
     async listModels(): Promise<AIModel[]> {
         const result = await this.service.get<TogetherModel[]>('/models');
         return result

--- a/drivers/test/togetherai-chat-completions.test.ts
+++ b/drivers/test/togetherai-chat-completions.test.ts
@@ -1,0 +1,140 @@
+import type { CompletionChunkObject, ToolUse } from '@llumiverse/core';
+import type OpenAI from 'openai';
+import { describe, expect, test } from 'vitest';
+import { mapChatCompletionStream } from '../src/openai/index.js';
+import { convertResponseItemsToChatMessages } from '../src/openai/openai_format.js';
+
+type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
+type ChatCompletionChunk = OpenAI.Chat.Completions.ChatCompletionChunk;
+
+async function* streamChunks(chunks: ChatCompletionChunk[]): AsyncIterable<ChatCompletionChunk> {
+    for (const chunk of chunks) {
+        yield chunk;
+    }
+}
+
+async function collect(stream: AsyncIterable<CompletionChunkObject>): Promise<CompletionChunkObject[]> {
+    const out: CompletionChunkObject[] = [];
+    for await (const chunk of stream) {
+        out.push(chunk);
+    }
+    return out;
+}
+
+describe('convertResponseItemsToChatMessages (Response API -> Chat Completions)', () => {
+    test('maps a user input_image to a Chat Completions image_url part', () => {
+        const items = [
+            {
+                type: 'message',
+                role: 'user',
+                content: [
+                    { type: 'input_text', text: 'What is in this image?' },
+                    { type: 'input_image', image_url: 'data:image/jpeg;base64,AAAA', detail: 'auto' },
+                ],
+            },
+        ] as ResponseInputItem[];
+
+        const messages = convertResponseItemsToChatMessages(items);
+
+        expect(messages).toHaveLength(1);
+        const msg = messages[0] as unknown as { role: string; content: Array<Record<string, unknown>> };
+        expect(msg.role).toBe('user');
+        expect(msg.content).toEqual([
+            { type: 'text', text: 'What is in this image?' },
+            { type: 'image_url', image_url: { url: 'data:image/jpeg;base64,AAAA', detail: 'auto' } },
+        ]);
+    });
+
+    test('maps system messages, tool outputs, and tool calls', () => {
+        const items = [
+            { type: 'message', role: 'system', content: 'You are helpful.' },
+            { type: 'function_call', call_id: 'call_1', name: 'search', arguments: '{"q":"cats"}' },
+            { type: 'function_call_output', call_id: 'call_1', output: 'result text' },
+        ] as ResponseInputItem[];
+
+        const messages = convertResponseItemsToChatMessages(items) as unknown as Array<Record<string, unknown>>;
+
+        expect(messages[0]).toEqual({ role: 'system', content: 'You are helpful.' });
+        expect(messages[1]).toEqual({
+            role: 'assistant',
+            content: null,
+            tool_calls: [{ id: 'call_1', type: 'function', function: { name: 'search', arguments: '{"q":"cats"}' } }],
+        });
+        expect(messages[2]).toEqual({ role: 'tool', tool_call_id: 'call_1', content: 'result text' });
+    });
+});
+
+describe('mapChatCompletionStream (Chat Completions streaming)', () => {
+    test('accumulates text deltas and terminal finish/usage', async () => {
+        const chunks = [
+            { choices: [{ index: 0, delta: { content: 'Hello ' }, finish_reason: null }] },
+            { choices: [{ index: 0, delta: { content: 'world' }, finish_reason: null }] },
+            { choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] },
+            {
+                choices: [],
+                usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+            },
+        ] as unknown as ChatCompletionChunk[];
+
+        const out = await collect(mapChatCompletionStream(streamChunks(chunks)));
+
+        const text = out
+            .flatMap((c) => c.result ?? [])
+            .map((r) => (r.type === 'text' ? r.value : ''))
+            .join('');
+        expect(text).toBe('Hello world');
+
+        // The 'stop' finish chunk carries finish_reason; the usage-only chunk must NOT overwrite it.
+        expect(out.some((c) => c.finish_reason === 'stop')).toBe(true);
+        const usageChunk = out.find((c) => c.token_usage);
+        expect(usageChunk?.token_usage).toMatchObject({ prompt: 10, result: 5, total: 15 });
+        expect(usageChunk?.finish_reason).toBeUndefined();
+    });
+
+    test('streams tool call deltas keyed by index and maps finish_reason to tool_use', async () => {
+        const chunks = [
+            {
+                choices: [
+                    {
+                        index: 0,
+                        delta: {
+                            tool_calls: [
+                                {
+                                    index: 0,
+                                    id: 'call_abc',
+                                    type: 'function',
+                                    function: { name: 'get_weather', arguments: '{"ci' },
+                                },
+                            ],
+                        },
+                        finish_reason: null,
+                    },
+                ],
+            },
+            {
+                choices: [
+                    {
+                        index: 0,
+                        delta: { tool_calls: [{ index: 0, function: { arguments: 'ty":"Paris"}' } }] },
+                        finish_reason: null,
+                    },
+                ],
+            },
+            { choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }] },
+        ] as unknown as ChatCompletionChunk[];
+
+        const out = await collect(mapChatCompletionStream(streamChunks(chunks)));
+
+        const toolChunks = out.filter((c) => c.tool_use && c.tool_use.length > 0);
+        const first = toolChunks[0].tool_use?.[0] as ToolUse<unknown> & { _actual_id?: string };
+        expect(first.id).toBe('tool_0');
+        expect(first._actual_id).toBe('call_abc');
+        expect(first.tool_name).toBe('get_weather');
+
+        // Argument fragments arrive across chunks and concatenate to valid JSON.
+        const args = toolChunks.map((c) => (c.tool_use?.[0].tool_input as string) ?? '').join('');
+        expect(args).toBe('{"city":"Paris"}');
+
+        expect(out.some((c) => c.finish_reason === 'tool_use')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Symptom

TogetherAI vision/image requests fail:

- `openai/gpt-oss-120b` -> **HTTP 400** `"The requested model does not support the Responses api."`
- `MiniMaxAI/MiniMax-M3`, `moonshotai/Kimi-K2.6` -> **HTTP 200** but the model never receives the image and replies **"no content"**.

The same models work on OpenRouter, which *does* implement `/v1/responses` and forwards images.

## Root cause

`TogetherAIDriver extends BaseOpenAIDriver`, and the base driver issues every request via `this.service.responses.create(...)` (the OpenAI **Responses** API), formatting images as `input_image` content parts.

But TogetherAI's OpenAI-compatible surface is **Chat Completions** (`/v1/chat/completions`) and does **not** implement the Responses API. On Chat Completions, images must be sent as `messages[].content[] = { type: "image_url", image_url: { url } }`. So `gpt-oss` rejects the endpoint outright (400) and MiniMax/Kimi accept the request but the `input_image` part is never routed to the model.

## Fix

Mirrors the working `GroqDriver` precedent (also OpenAI-compatible Chat Completions):

- **`BaseOpenAIDriver`**: new `protected useChatCompletionsApi(): boolean` hook (default `false`, so OpenAI/Azure/xAI/etc. are unchanged). When `true`, both `requestTextCompletion` and `requestTextCompletionStream` convert the `ResponseInputItem[]` conversation to `ChatCompletionMessageParam[]` (images -> `image_url`) and call `this.service.chat.completions.create(...)`, with Chat-Completions response/usage/streaming extraction (`extractDataFromChatCompletion`, `mapChatUsage`, `mapChatCompletionStream`, `getChatCompletionsToolDefinitions`).
- **`TogetherAIDriver`**: overrides `useChatCompletionsApi()` to `true`.
- The conversation stays in `ResponseInputItem[]` form throughout, so **all** existing base-class behavior is preserved: tool calls, orphaned tool-use/result repair, json/schema handling (the schema instruction is already prompt-injected by `formatOpenAILikeMultimodalPrompt`), prompt/heartbeat stripping, and token usage. `image_detail` is kept harmless (Together ignores it; the Responses-only `original` detail is dropped).
- **De-duplication**: Groq's `ResponseInputItem[] -> ChatCompletionMessageParam[]` converter is lifted into the shared `convertResponseItemsToChatMessages` in `openai_format.ts`; `GroqDriver` now delegates to it (removing ~120 duplicated lines; a structural `as unknown as` cast bridges the identical `openai` vs `groq-sdk` message types).

### Streaming detail

Chat-Completions tool-call deltas are keyed by their array `index` (id/name only arrive on the first delta; `arguments` stream as fragments), using a stable synthetic id (`tool_<index>`) so the shared stream accumulator concatenates arguments and restores the real id — same contract as the Responses path. A usage-only trailing chunk (`choices: []` with `stream_options.include_usage`) intentionally emits **no** `finish_reason`, so it can't overwrite a prior `tool_use`.

## Secondary fix (included)

`common/src/capability.ts` previously routed `togetherai` to the text-only OpenAI-compatible default, so no Together model was ever flagged multimodal and `is_multimodal` in the driver was always `false`. Added a dedicated `getModelCapabilitiesTogetherAI` resolver that marks `input.image: true` for natively-multimodal families (`vision`, `llama-4`, `gemma-3`, `qwen*-vl`). The pattern list is deliberately conservative to avoid false positives and can be extended as Together adds vision models.

## Verification

- `pnpm build` clean for `common`, `core`, and `drivers` (tsc).
- `drivers` `typecheck:test` clean.
- `biome check` clean on all changed files.
- Existing driver unit tests pass (61) plus new `drivers/test/togetherai-chat-completions.test.ts` (4): converter image/tool mapping, streaming text + usage accumulation, tool-call delta accumulation, and finish_reason mapping. No live API credentials required.

Not verified against the live Together API (no creds in this environment); the change is type-checked, unit-tested and follows the proven Groq Chat-Completions pattern.