### PR TITLE
chore: clean up biome suppressions

### DIFF
--- a/core/src/validation.ts
+++ b/core/src/validation.ts
@@ -12,8 +12,8 @@ const ajv = new Ajv({
     removeAdditional: 'failing',
 });
 
-// biome-ignore lint/suspicious/noTsIgnore: ajv-formats default export inconsistently callable under ESM/CJS interop
-// @ts-ignore - ajv-formats default export is not callable under one of the TS configs in this monorepo
+// biome-ignore lint/suspicious/noTsIgnore: ajv-formats' runtime module.exports is the callable plugin, but its shipped .d.ts declares an ESM default that resolves to a non-callable namespace under module:nodenext; no cast-free import form works
+// @ts-ignore - ajv-formats default export is not callable under module:nodenext ESM resolution
 addFormats(ajv);
 
 function errorMessage(error: unknown): string {

--- a/core/test/utils.test.ts
+++ b/core/test/utils.test.ts
@@ -14,8 +14,11 @@ describe('Core Utilities', () => {
     test('parseJSON', () => {
         const url = new URL('./json.txt', import.meta.url);
         const text = readFileSync(url, 'utf8');
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const json = parseJSON(text)!;
+        const json = parseJSON(text);
+        expect(json).toBeDefined();
+        if (!json) {
+            throw new Error('Expected json.txt to parse');
+        }
         expect((json as JSONObject).key1).toBe('value1 " test');
         expect((json as JSONObject).key2).toBe('value2');
         expect((json as JSONObject).key3).toBe('value3');

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1529,7 +1529,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }),
         );
 
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
+        // biome-ignore lint/style/noNonNullAssertion: jobArn is always returned by a successful CreateModelCustomizationJob response; AWS SDK types it optional
         return jobInfo(job, response.jobArn!);
     }
 

--- a/drivers/src/replicate.ts
+++ b/drivers/src/replicate.ts
@@ -15,7 +15,7 @@ import {
 import { EventStream } from '@llumiverse/core/async';
 import { AbstractDriver } from '@llumiverse/core/driver';
 import { EventSource } from 'eventsource';
-import Replicate, { type Prediction, type Training } from 'replicate';
+import Replicate, { type Model, type Prediction, type Training } from 'replicate';
 
 let cachedTrainableModels: AIModel[] | undefined;
 let cachedTrainableModelsTimestamp: number = 0;
@@ -107,7 +107,7 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
 
         const stream = new EventStream<CompletionChunkObject>();
 
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
+        // biome-ignore lint/style/noNonNullAssertion: urls.stream is populated by Replicate because the prediction was created with stream:true; SDK types it optional
         const source = new EventSource(prediction.urls.stream!);
         source.addEventListener('output', (e: ReplicateEvent) => {
             stream.push({ result: [{ type: 'text', value: e.data }] });
@@ -218,11 +218,10 @@ export class ReplicateDriver extends AbstractDriver<DriverOptions, string> {
         });
         const results = await Promise.all(promises);
         return results
-            .filter((m) => !!m.latest_version)
+            .filter((m): m is Model & Required<Pick<Model, 'latest_version'>> => !!m.latest_version)
             .map((m) => {
                 const fullName = `${m.owner}/${m.name}`;
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const v = m.latest_version!;
+                const v = m.latest_version;
                 return {
                     id: `${fullName}:${v.id}`,
                     name: `${fullName}@${v.cog_version}:${v.id.slice(0, 6)}`,

--- a/drivers/test/api-key-list-models.test.ts
+++ b/drivers/test/api-key-list-models.test.ts
@@ -6,8 +6,11 @@ const TIMEOUT = 30_000;
 
 describe('List models using API keys', () => {
     test.skipIf(!process.env.GEMINI_API_KEY)('Gemini: list models with API key', { timeout: TIMEOUT }, async () => {
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const client = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
+        const apiKey = process.env.GEMINI_API_KEY;
+        if (!apiKey) {
+            throw new Error('GEMINI_API_KEY is required');
+        }
+        const client = new GoogleGenAI({ apiKey });
 
         const pager = await client.models.list({ config: { pageSize: 100 } });
         const models = [];

--- a/drivers/test/conversation.test.ts
+++ b/drivers/test/conversation.test.ts
@@ -417,8 +417,10 @@ describe.skipIf(!hasDrivers).concurrent.each(drivers)(
         );
 
         test.skipIf(!visionModel)(`${name}: multi-turn conversation with image`, { timeout: TIMEOUT }, async () => {
-            // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-            const options = getTextOptions(visionModel!);
+            if (!visionModel) {
+                throw new Error(`Expected vision model for ${name}`);
+            }
+            const options = getTextOptions(visionModel);
 
             // Turn 1: Send an image as base64 (like Studio does)
             // Using Google logo as a simple, accessible test image
@@ -483,8 +485,10 @@ describe.skipIf(!hasDrivers).concurrent.each(drivers)(
         });
 
         test.skipIf(!visionModel)(`${name}: conversation with multiple images`, { timeout: TIMEOUT }, async () => {
-            // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-            const options = getTextOptions(visionModel!);
+            if (!visionModel) {
+                throw new Error(`Expected vision model for ${name}`);
+            }
+            const options = getTextOptions(visionModel);
 
             // Turn 1: Send two images as base64 (like Studio does)
             const googleLogoUrl = 'https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png';

--- a/drivers/test/embeddings.test.ts
+++ b/drivers/test/embeddings.test.ts
@@ -66,12 +66,12 @@ function firstValues(d: Driver) {
 }
 
 if (vertex) {
+    const vertexDriver = vertex;
     describe('VertexAI: embeddings generation', () => {
         test(
             'embeddings for text',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(vertex!)({ type: 'text', text: TEXT });
+                const r = await firstValues(vertexDriver)({ type: 'text', text: TEXT });
                 expect(r.results).toHaveLength(1);
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
                 expect(r.model).toBe('gemini-embedding-2');
@@ -82,8 +82,7 @@ if (vertex) {
         test(
             'embeddings for image (multimodal)',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(vertex!)({ type: 'image', source: imageDataSource() });
+                const r = await firstValues(vertexDriver)({ type: 'image', source: imageDataSource() });
                 expect(r.results).toHaveLength(1);
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
             },
@@ -93,7 +92,7 @@ if (vertex) {
         test(
             'embeddings for batched text inputs',
             async () => {
-                const r = await vertex?.generateEmbeddings({
+                const r = await vertexDriver.generateEmbeddings({
                     inputs: [
                         { type: 'text', text: 'first' },
                         { type: 'text', text: 'second' },
@@ -109,12 +108,12 @@ if (vertex) {
 }
 
 if (bedrock) {
+    const bedrockDriver = bedrock;
     describe('Bedrock: embeddings generation', () => {
         test(
             'embeddings for text (Nova default)',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(bedrock!)({ type: 'text', text: TEXT });
+                const r = await firstValues(bedrockDriver)({ type: 'text', text: TEXT });
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
             },
             TIMEOUT,
@@ -123,8 +122,7 @@ if (bedrock) {
         test(
             'embeddings for image (Nova multimodal)',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(bedrock!)({ type: 'image', source: imageDataSource() });
+                const r = await firstValues(bedrockDriver)({ type: 'image', source: imageDataSource() });
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
             },
             TIMEOUT,
@@ -133,12 +131,12 @@ if (bedrock) {
 }
 
 if (openai) {
+    const openaiDriver = openai;
     describe('OpenAI: embeddings generation', () => {
         test(
             'embeddings for text',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(openai!)({ type: 'text', text: TEXT });
+                const r = await firstValues(openaiDriver)({ type: 'text', text: TEXT });
                 expect(r.results).toHaveLength(1);
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
                 expect(r.model).toBe('text-embedding-3-small');
@@ -150,7 +148,7 @@ if (openai) {
         test(
             'embeddings for batched text inputs',
             async () => {
-                const r = await openai?.generateEmbeddings({
+                const r = await openaiDriver.generateEmbeddings({
                     inputs: [
                         { type: 'text', text: 'alpha' },
                         { type: 'text', text: 'beta' },
@@ -164,12 +162,12 @@ if (openai) {
 }
 
 if (mistral) {
+    const mistralDriver = mistral;
     describe('MistralAI: embeddings generation', () => {
         test(
             'embeddings for text',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(mistral!)({ type: 'text', text: TEXT });
+                const r = await firstValues(mistralDriver)({ type: 'text', text: TEXT });
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
                 expect(r.model).toBe('mistral-embed');
             },
@@ -179,12 +177,12 @@ if (mistral) {
 }
 
 if (watsonx) {
+    const watsonxDriver = watsonx;
     describe('Watsonx: embeddings generation', () => {
         test(
             'embeddings for text',
             async () => {
-                // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-                const r = await firstValues(watsonx!)({ type: 'text', text: TEXT });
+                const r = await firstValues(watsonxDriver)({ type: 'text', text: TEXT });
                 expect(r.results[0].outputs[0].values.length).toBeGreaterThan(0);
                 expect(r.model).toBe('ibm/slate-125m-english-rtrvr');
             },

--- a/drivers/test/orphaned-tool-use.test.ts
+++ b/drivers/test/orphaned-tool-use.test.ts
@@ -32,6 +32,15 @@ import type { Tree } from './__helpers__/test-utils.js';
 
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 
+function requireBedrockContent(message: Message | undefined, messageIndex: number): NonNullable<Message['content']> {
+    const content = message?.content;
+    expect(content).toBeDefined();
+    if (!content) {
+        throw new Error(`Expected Bedrock message content at index ${messageIndex}`);
+    }
+    return content;
+}
+
 describe('fixOrphanedToolUse - Claude', () => {
     test('returns empty array for empty input', () => {
         const result = fixOrphanedToolUseClaude([]);
@@ -383,8 +392,7 @@ describe('fixOrphanedToolUse - Bedrock', () => {
         expect(result[1].role).toBe('user');
 
         // The user message should have synthetic toolResult prepended
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const userContent = result[1].content!;
+        const userContent = requireBedrockContent(result[1], 1);
         expect(userContent).toHaveLength(2);
         expect(userContent[0].toolResult).toBeDefined();
         expect(userContent[0].toolResult?.toolUseId).toBe('tool_1');
@@ -412,8 +420,7 @@ describe('fixOrphanedToolUse - Bedrock', () => {
 
         const result = fixOrphanedToolUseBedrock(messages);
 
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const userContent = result[1].content!;
+        const userContent = requireBedrockContent(result[1], 1);
         expect(userContent).toHaveLength(4); // 3 synthetic toolResults + 1 text
 
         // Verify synthetic toolResults
@@ -443,8 +450,7 @@ describe('fixOrphanedToolUse - Bedrock', () => {
 
         const result = fixOrphanedToolUseBedrock(messages);
 
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const userContent = result[1].content!;
+        const userContent = requireBedrockContent(result[1], 1);
         expect(userContent).toHaveLength(3); // 1 synthetic + 1 real toolResult + 1 text
 
         // Synthetic toolResult for tool_2 should be first
@@ -483,8 +489,7 @@ describe('fixOrphanedToolUse - Bedrock', () => {
         expect(result).toHaveLength(5);
 
         // Check that the last user message has synthetic toolResults
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const lastUserContent = result[4].content!;
+        const lastUserContent = requireBedrockContent(result[4], 4);
         expect(lastUserContent).toHaveLength(3); // 2 synthetic + 1 text
 
         expect(lastUserContent[0].toolResult?.toolUseId).toBe('toolu_search');
@@ -523,8 +528,7 @@ describe('fixOrphanedToolResults - Bedrock', () => {
         ];
 
         const result = fixOrphanedToolResultsBedrock(messages);
-        // biome-ignore lint/style/noNonNullAssertion: content is set above
-        const userContent = result[1].content!;
+        const userContent = requireBedrockContent(result[1], 1);
         expect(userContent).toHaveLength(1);
         expect(userContent[0].toolResult?.toolUseId).toBe('tool_1');
     });
@@ -538,8 +542,8 @@ describe('fixOrphanedToolResults - Bedrock', () => {
 
         const result = fixOrphanedToolResultsBedrock(messages);
         expect(result).toHaveLength(1);
-        // biome-ignore lint/style/noNonNullAssertion: content is set above
-        expect(result[0].content![0].text).toBe('[summary of prior work]');
+        const userContent = requireBedrockContent(result[0], 0);
+        expect(userContent[0].text).toBe('[summary of prior work]');
     });
 
     test('preserves non-toolResult blocks while dropping the orphan', () => {
@@ -555,8 +559,7 @@ describe('fixOrphanedToolResults - Bedrock', () => {
         ];
 
         const result = fixOrphanedToolResultsBedrock(messages);
-        // biome-ignore lint/style/noNonNullAssertion: content is set above
-        const userContent = result[1].content!;
+        const userContent = requireBedrockContent(result[1], 1);
         expect(userContent).toHaveLength(1);
         expect(userContent[0].text).toBe('continue please');
     });

--- a/drivers/test/tools.test.ts
+++ b/drivers/test/tools.test.ts
@@ -206,13 +206,15 @@ describe.concurrent.each(drivers)('Driver $name', ({ name, driver, models }) => 
     test.each(models)(`${name}: generation with tools for %s`, { timeout: TIMEOUT, retry: 1 }, async (model) => {
         const options = getTestOptions(model);
         let r = await driver.execute(PROMPT_WITH_GET_NAME_TOOL, options);
-        expect(r.tool_use).toBeDefined();
-        expect(r.tool_use?.length).toBe(1);
-        expect(r.tool_use?.[0].id).toBeDefined();
-        expect(r.tool_use?.[0].tool_input).toBeDefined();
-        expect(r.tool_use?.[0].tool_name).toBe('get_weather');
-        // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-        const tool_use = r.tool_use!;
+        const tool_use = r.tool_use;
+        expect(tool_use).toBeDefined();
+        if (!tool_use) {
+            throw new Error('Expected tool use in first driver response');
+        }
+        expect(tool_use.length).toBe(1);
+        expect(tool_use[0].id).toBeDefined();
+        expect(tool_use[0].tool_input).toBeDefined();
+        expect(tool_use[0].tool_name).toBe('get_weather');
         r = await driver.execute(
             [
                 {

--- a/examples/src/bedrock.ts
+++ b/examples/src/bedrock.ts
@@ -55,8 +55,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/huggingface.ts
+++ b/examples/src/huggingface.ts
@@ -50,8 +50,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/mistralai.ts
+++ b/examples/src/mistralai.ts
@@ -49,8 +49,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/openai.ts
+++ b/examples/src/openai.ts
@@ -47,8 +47,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/replicate.ts
+++ b/examples/src/replicate.ts
@@ -49,8 +49,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/together.ts
+++ b/examples/src/together.ts
@@ -50,8 +50,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');

--- a/examples/src/vertexai.ts
+++ b/examples/src/vertexai.ts
@@ -48,8 +48,10 @@ async function main() {
     }
 
     // get the recomposed response from the stream chunks
-    // biome-ignore lint/style/noNonNullAssertion: intentional non-null assertion; TS can't prove narrowing here
-    const streamingResponse = stream.completion!;
+    const streamingResponse = stream.completion;
+    if (!streamingResponse) {
+        throw new Error('Streaming completion was not populated');
+    }
 
     console.log('\n# LLM response:', streamingResponse.result);
     console.log('# Response took', streamingResponse.execution_time, 'ms');


### PR DESCRIPTION
## Summary
- Replace test and driver non-null assertions with typed guards, scoped constants, or explicit assertion helpers where values are expected.
- Tighten remaining Biome suppression justifications for package interop and provider SDK typing edge cases.
- Add the explicit Rollup dev dependency captured by the updated lockfile.

## Test Plan
- [x] `../../node_modules/.bin/biome check .`
- [x] `pnpm --prefix composableai/llumiverse/core exec vitest run test/utils.test.ts`
- [x] `pnpm --prefix composableai/llumiverse/drivers exec vitest run test/orphaned-tool-use.test.ts`
- [x] `pnpm --prefix composableai/llumiverse typecheck:test`
