### PR TITLE
docs: require Node 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ Vercel's SDK is fantastic for frontend/full-stack React/Next.js applications.
 
 ## Requirements
 
-* Node.js 22+
+* Node.js 24.x
 * Bun 1.0+ (experimental support)
 
 ## Installation
 
 **For most use cases (recommended):**
 ```bash
-npm install @llumiverse/core @llumiverse/drivers
+pnpm add @llumiverse/core @llumiverse/drivers
 ```
 
 *   `@llumiverse/core`: The interfaces, types, and base abstractions.

--- a/core/README.md
+++ b/core/README.md
@@ -54,14 +54,14 @@ Vercel's SDK is fantastic for frontend/full-stack React/Next.js applications.
 
 ## Requirements
 
-* Node.js 22+
+* Node.js 24.x
 * Bun 1.0+ (experimental support)
 
 ## Installation
 
 **For most use cases (recommended):**
 ```bash
-npm install @llumiverse/core @llumiverse/drivers
+pnpm add @llumiverse/core @llumiverse/drivers
 ```
 
 *   `@llumiverse/core`: The interfaces, types, and base abstractions.

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -54,14 +54,14 @@ Vercel's SDK is fantastic for frontend/full-stack React/Next.js applications.
 
 ## Requirements
 
-* Node.js 22+
+* Node.js 24.x
 * Bun 1.0+ (experimental support)
 
 ## Installation
 
 **For most use cases (recommended):**
 ```bash
-npm install @llumiverse/core @llumiverse/drivers
+pnpm add @llumiverse/core @llumiverse/drivers
 ```
 
 *   `@llumiverse/core`: The interfaces, types, and base abstractions.


### PR DESCRIPTION
## Summary
- Update README prerequisites to recommend Node.js 24.x.
- Keep package-manager guidance aligned with pnpm 11.8.0 via Corepack.

## Test Plan
- `pnpm lint --diagnostic-level=error`
- `git diff --check main...HEAD`