### PR TITLE
fix: Bedrock execute timeout for long responses

### DIFF
--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -99,6 +99,11 @@ type BedrockRuntimeExecutorScope = {
     close(): void;
 };
 
+const BEDROCK_NON_STREAMING_HTTP_TIMEOUT: HttpTimeoutOptions = {
+    headersTimeout: 900_000,
+    bodyTimeout: 900_000,
+};
+
 enum BedrockModelType {
     FoundationModel = 'foundation-model',
     InferenceProfile = 'inference-profile',
@@ -378,6 +383,13 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         };
     }
 
+    private getBedrockNonStreamingHttpTimeout(httpTimeout?: HttpTimeoutOptions): HttpTimeoutOptions {
+        return mergeDriverHttpTimeoutOptions(
+            BEDROCK_NON_STREAMING_HTTP_TIMEOUT,
+            mergeDriverHttpTimeoutOptions(this.options.httpTimeout, httpTimeout),
+        ) as HttpTimeoutOptions;
+    }
+
     private createExecutor(httpTimeout?: HttpTimeoutOptions) {
         return new BedrockRuntime({
             region: this.options.region,
@@ -405,6 +417,14 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         }
 
         const executor = this.getExecutor(options.httpTimeout);
+        return {
+            executor,
+            close: () => executor.destroy(),
+        };
+    }
+
+    private getScopedNonStreamingExecutor(options: Pick<ExecutionOptions, 'httpTimeout'>): BedrockRuntimeExecutorScope {
+        const executor = this.getExecutor(this.getBedrockNonStreamingHttpTimeout(options.httpTimeout));
         return {
             executor,
             close: () => executor.destroy(),
@@ -956,7 +976,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         let conversation = updateConversation(incomingConversation, conversePrompt);
 
         const payload = this.preparePayload(conversation, options);
-        const executorScope = this.getScopedExecutor(options);
+        const executorScope = this.getScopedNonStreamingExecutor(options);
 
         let res: ConverseResponse;
         try {
@@ -1031,7 +1051,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         prompt: TwelvelabsPegasusRequest,
         options: ExecutionOptions,
     ): Promise<Completion> {
-        const executorScope = this.getScopedExecutor(options);
+        const executorScope = this.getScopedNonStreamingExecutor(options);
 
         let res: InvokeModelCommandOutput;
         try {

--- a/drivers/src/http-timeout-wiring.test.ts
+++ b/drivers/src/http-timeout-wiring.test.ts
@@ -99,6 +99,62 @@ describe('driver HTTP timeout wiring', () => {
         driver.destroy();
     });
 
+    it('uses a longer Bedrock timeout default for non-streaming text execution', () => {
+        const driver = new BedrockDriver({
+            region: 'us-east-1',
+        });
+
+        const internals = exposePrivate<{
+            getBedrockRequestHandlerConfig: (httpTimeout?: HttpTimeoutOptions) => BedrockRequestHandlerConfig;
+            getBedrockNonStreamingHttpTimeout: (httpTimeout?: HttpTimeoutOptions) => HttpTimeoutOptions;
+        }>(driver);
+
+        expect(internals.getBedrockRequestHandlerConfig()).toEqual({
+            requestTimeout: 60_000,
+            throwOnRequestTimeout: true,
+            connectionTimeout: 10_000,
+            socketTimeout: 60_000,
+        });
+        expect(internals.getBedrockRequestHandlerConfig(internals.getBedrockNonStreamingHttpTimeout())).toEqual({
+            requestTimeout: 900_000,
+            throwOnRequestTimeout: true,
+            connectionTimeout: 10_000,
+            socketTimeout: 900_000,
+        });
+
+        driver.destroy();
+    });
+
+    it('keeps explicit Bedrock non-streaming timeout overrides field-by-field', () => {
+        const driver = new BedrockDriver({
+            region: 'us-east-1',
+            httpTimeout: {
+                bodyTimeout: 120_000,
+                connectTimeout: 1_000,
+            },
+        });
+
+        const internals = exposePrivate<{
+            getBedrockRequestHandlerConfig: (httpTimeout?: HttpTimeoutOptions) => BedrockRequestHandlerConfig;
+            getBedrockNonStreamingHttpTimeout: (httpTimeout?: HttpTimeoutOptions) => HttpTimeoutOptions;
+        }>(driver);
+
+        expect(
+            internals.getBedrockRequestHandlerConfig(
+                internals.getBedrockNonStreamingHttpTimeout({
+                    headersTimeout: 180_000,
+                }),
+            ),
+        ).toEqual({
+            requestTimeout: 180_000,
+            throwOnRequestTimeout: true,
+            connectionTimeout: 1_000,
+            socketTimeout: 120_000,
+        });
+
+        driver.destroy();
+    });
+
     it('passes the driver fetch to SDK clients that accept a custom fetch implementation', () => {
         const openai = new OpenAIDriver({ apiKey: 'test-key' });
         expectSdkUsesDriverFetch(openai, openai.service);


### PR DESCRIPTION
## Summary
- Use a longer 15 minute HTTP timeout default for non-streaming Bedrock text execution paths that can legitimately sit idle while the model finishes.
- Keep the existing 60 second default for the normal Bedrock request handler and streaming paths unless callers explicitly override `httpTimeout`.
- Add timeout wiring coverage for the Bedrock non-streaming default and explicit field-by-field overrides.

## Test Plan
- `pnpm exec vitest run src/http-timeout-wiring.test.ts --retry 0`
- `pnpm --filter @llumiverse/drivers typecheck:test`
- `pnpm --filter @llumiverse/drivers lint`
- `pnpm --filter @llumiverse/drivers build`

## Notes
- `pnpm --filter @llumiverse/drivers test -- src/http-timeout-wiring.test.ts` was attempted but the package script ran broader provider tests instead of only the file filter; those require cloud provider credentials and failed locally on expired AWS SSO / Google ADC auth.