### PR TITLE
chore(ci): simplify all-models test for release/1.4

### DIFF
--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -49,7 +49,10 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             project: process.env.GOOGLE_PROJECT_ID as string,
             region: process.env.GOOGLE_REGION as string,
         }),
-        models: ['publishers/google/models/gemini-2.5-flash-lite', 'publishers/anthropic/models/claude-sonnet-5'],
+        models: [
+            'publishers/google/models/gemini-2.5-flash-lite',
+            'locations/global/publishers/anthropic/models/claude-sonnet-5',
+        ],
     });
 } else {
     console.warn('Google Vertex tests are skipped: GOOGLE_PROJECT_ID environment variable is not set');
@@ -214,7 +217,7 @@ function getTestOptions(model: string): ExecutionOptions {
     };
 }
 
-describe.concurrent.each(drivers)('Driver $name', ({ name, driver, models }) => {
+describe.each(drivers)('Driver $name', ({ name, driver, models }) => {
     let fetchedModels: AIModel[];
 
     test(`${name}: list models`, { timeout: TIMEOUT, retry: 1 }, async () => {

--- a/drivers/test/all-models.test.ts
+++ b/drivers/test/all-models.test.ts
@@ -49,11 +49,7 @@ if (process.env.GOOGLE_PROJECT_ID && process.env.GOOGLE_REGION) {
             project: process.env.GOOGLE_PROJECT_ID as string,
             region: process.env.GOOGLE_REGION as string,
         }),
-        models: [
-            'publishers/google/models/gemini-2.5-flash-lite',
-            'publishers/anthropic/models/claude-sonnet-4-5',
-            'publishers/anthropic/models/claude-opus-4-6',
-        ],
+        models: ['publishers/google/models/gemini-2.5-flash-lite', 'publishers/anthropic/models/claude-sonnet-5'],
     });
 } else {
     console.warn('Google Vertex tests are skipped: GOOGLE_PROJECT_ID environment variable is not set');
@@ -66,7 +62,7 @@ if (process.env.MISTRAL_API_KEY) {
             apiKey: process.env.MISTRAL_API_KEY as string,
             endpoint_url: (process.env.MISTRAL_ENDPOINT_URL as string) ?? undefined,
         }),
-        models: ['pixtral-large-latest', 'mistral-small-latest', 'mistral-large-latest'],
+        models: ['mistral-small-latest'],
     });
 } else {
     console.warn('MistralAI tests are skipped: MISTRAL_API_KEY environment variable is not set');
@@ -94,7 +90,7 @@ if (process.env.OPENAI_API_KEY) {
         driver: new OpenAIDriver({
             apiKey: process.env.OPENAI_API_KEY as string,
         }),
-        models: ['gpt-5.2', 'gpt-4o-mini'],
+        models: ['gpt-4o-mini', 'gpt-5.4-mini'],
     });
 } else {
     console.warn('OpenAI tests are skipped: OPENAI_API_KEY environment variable is not set');
@@ -123,11 +119,7 @@ if (process.env.BEDROCK_REGION) {
             region: process.env.BEDROCK_REGION as string,
         }),
         //Use foundation models and inference profiles to test the driver
-        models: [
-            'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
-            'us.amazon.nova-micro-v1:0',
-            'ai21.jamba-1-5-mini-v1:0',
-        ],
+        models: ['global.anthropic.claude-haiku-4-5-20251001-v1:0', 'us.amazon.nova-micro-v1:0'],
     });
 } else {
     console.warn('Bedrock tests are skipped: BEDROCK_REGION environment variable is not set');
@@ -158,14 +150,7 @@ if (process.env.WATSONX_API_KEY) {
             projectId: process.env.WATSONX_PROJECT_ID as string,
             endpointUrl: process.env.WATSONX_ENDPOINT_URL as string,
         }),
-        models: [
-            'ibm/granite-3-2-8b-instruct',
-            'ibm/granite-3-2b-instruct',
-            //"ibm/granite-13b-instruct-v2" Does not work with schemas
-            //Non-ibm models don't work, may be account related
-            //"meta/llama-3-3-70b-instruct",
-            //"mistralai/pixtral-12b",
-        ],
+        models: ['ibm/granite-3-2b-instruct'],
     });
 } else {
     console.warn('Watsonx tests are skipped: WATSONX_API_KEY environment variable is not set');
@@ -182,8 +167,7 @@ if (process.env.OPENROUTER_API_KEY) {
             'moonshotai/kimi-k2.5',
             'qwen/qwen3.5-35b-a3b',
             'minimax/minimax-m2.5',
-            'deepseek/deepseek-chat',
-            'google/gemini-3-flash-preview',
+            'google/gemini-3.1-flash-lite',
         ],
     });
 } else {
@@ -258,18 +242,6 @@ describe.concurrent.each(drivers)('Driver $name', ({ name, driver, models }) => 
     test.each(models)(`${name}: execute prompt on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
         const r = await driver.execute(testPrompt_color, getTestOptions(model));
         console.log(`Result for execute ${model}`, JSON.stringify(r));
-        assertCompletionOk(r, model, driver);
-    });
-
-    test.each(models)(`${name}: execute prompt with streaming on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
-        const r = await driver.stream(testPrompt_color, getTestOptions(model));
-        const out = await assertStreamingCompletionOk(r);
-        console.log(`Result for streaming ${model}`, JSON.stringify(out));
-    });
-
-    test.each(models)(`${name}: execute prompt with schema on %s`, { timeout: TIMEOUT, retry: 2 }, async (model) => {
-        const r = await driver.execute(testPrompt_color, { ...getTestOptions(model), result_schema: testSchema_color });
-        console.log(`Result for execute with schema ${model}`, JSON.stringify(r.result));
         assertCompletionOk(r, model, driver);
     });
 


### PR DESCRIPTION
## Summary
- cherry-pick vertesia/llumiverse#510 onto `release/1.4`
- simplify `drivers/test/all-models.test.ts` by reducing model coverage and removing redundant cases to keep CI stable on the release line
- switch the driver suite from concurrent to serial execution for this test file

## Verification
- `pnpm exec biome check drivers/test/all-models.test.ts`
- `pnpm --filter @llumiverse/drivers typecheck:test`
- `pnpm --filter @llumiverse/drivers build`
- `pnpm exec vitest run --passWithNoTests drivers/test/all-models.test.ts`
- `pnpm --filter @llumiverse/drivers test -- test/all-models.test.ts` (fails because the package test script forwards the extra arg in a way that still runs the full suite; unrelated provider-auth failures from expired AWS SSO and invalid Google auth in this environment)