### PR TITLE
fix(vertexai): retry Gemini URL-fetcher throttle 400s

### DIFF
--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -302,6 +302,69 @@ describe('GeminiModelDefinition Error Handling', () => {
             expect(error.retryable).toBe(true);
         });
 
+        it('should mark URL_REJECTED-REJECTED_PROXY_THROTTLED 400s as retryable', () => {
+            // Reproduces a real CI failure: sys:AnalyzeVideo intake 400'd with this
+            // status, failing the media-transcription integration test.
+            const googleError = {
+                status: 400,
+                message:
+                    'Cannot fetch content from the provided URL. Please ensure the URL is valid ' +
+                    'and accessible by Vertex AI. Vertex AI respects robots.txt rules, so confirm ' +
+                    'the URL is allowed to be crawled. Status: URL_REJECTED-REJECTED_PROXY_THROTTLED',
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'gemini-2.5-flash',
+                operation: 'execute',
+            });
+
+            expect(error.code).toBe(400);
+            expect(error.retryable).toBe(true);
+        });
+
+        it('should mark URL_REJECTED-REJECTED_FC_TOO_MANY_PENDING 400s as retryable', () => {
+            // Reproduces a real CI failure: sys:AnalyzeAudio intake 400'd with this
+            // status, failing the media-transcription integration test.
+            const googleError = {
+                status: 400,
+                message:
+                    'Cannot fetch content from the provided URL. Please ensure the URL is valid ' +
+                    'and accessible by Vertex AI. Vertex AI respects robots.txt rules, so confirm ' +
+                    'the URL is allowed to be crawled. Status: URL_REJECTED-REJECTED_FC_TOO_MANY_PENDING',
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'gemini-2.5-flash',
+                operation: 'execute',
+            });
+
+            expect(error.code).toBe(400);
+            expect(error.retryable).toBe(true);
+        });
+
+        it('should keep permanent URL_REJECTED rejections (robots-denied) non-retryable', () => {
+            // A URL_REJECTED status without a throttle marker is a permanent failure
+            // (e.g. robots.txt denied) and must not be retried.
+            const googleError = {
+                status: 400,
+                message:
+                    'Cannot fetch content from the provided URL. Please ensure the URL is valid ' +
+                    'and accessible by Vertex AI. Vertex AI respects robots.txt rules, so confirm ' +
+                    'the URL is allowed to be crawled. Status: URL_REJECTED-REJECTED_ROBOTS_DENIED',
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'gemini-2.5-flash',
+                operation: 'execute',
+            });
+
+            expect(error.code).toBe(400);
+            expect(error.retryable).toBe(false);
+        });
+
         it('should handle errors without extractable name', () => {
             const googleError = {
                 status: 500,

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -978,11 +978,21 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
         if (httpStatusCode >= 500 && httpStatusCode < 600) return true; // Other 5xx server errors
 
         // Vertex AI URL fetcher transient throttling, surfaced as 400 INVALID_ARGUMENT
-        // but really a Google-side rate limit on the inline-content fetcher.
-        if (httpStatusCode === 400 && message) {
+        // but really a Google-side rate limit on the inline-content fetcher. The fetcher
+        // rejects with a family of transient throttle statuses that share the
+        // THROTTLED / RATE_LIMITED / TOO_MANY_PENDING markers, e.g.
+        //   URL_REJECTED-REJECTED_CLIENT_THROTTLED
+        //   URL_REJECTED-REJECTED_PROXY_THROTTLED
+        //   URL_REJECTED-REJECTED_RATE_LIMITED
+        //   URL_REJECTED-REJECTED_FC_TOO_MANY_PENDING
+        // Match on the marker rather than an exact status so new fetcher-throttle
+        // variants are retried too; permanent URL rejections (robots-denied, unsafe,
+        // unsupported content) lack these markers and fall through to non-retryable.
+        if (httpStatusCode === 400 && message && message.includes('URL_REJECTED')) {
             if (
-                message.includes('URL_REJECTED-REJECTED_CLIENT_THROTTLED') ||
-                message.includes('URL_REJECTED-REJECTED_RATE_LIMITED')
+                message.includes('THROTTLED') ||
+                message.includes('RATE_LIMITED') ||
+                message.includes('TOO_MANY_PENDING')
             ) {
                 return true;
             }


### PR DESCRIPTION
## Summary
When a media file is passed to Gemini **by URL**, Vertex AI's inline content fetcher can reject the request with a `400 INVALID_ARGUMENT` whose message carries a `URL_REJECTED-*` status. These are transient throttles on Google's fetcher, not bad requests, so they should be retried.

`isGeminiErrorRetryable` already allow-listed `REJECTED_CLIENT_THROTTLED` and `REJECTED_RATE_LIMITED`, but two other throttle variants slipped through and caused the caller to fail on the first attempt:
- `URL_REJECTED-REJECTED_PROXY_THROTTLED`
- `URL_REJECTED-REJECTED_FC_TOO_MANY_PENDING`

This generalizes the check: a `400` whose message contains `URL_REJECTED` **and** one of the shared markers `THROTTLED` / `RATE_LIMITED` / `TOO_MANY_PENDING` is treated as retryable. This covers all current and future fetcher-throttle variants, while permanent URL rejections (robots-denied, unsafe, unsupported content) lack these markers and correctly remain non-retryable.

## Changes
- `drivers/src/vertexai/models/gemini.ts` — marker-based detection of transient `URL_REJECTED` fetcher throttles in `isGeminiErrorRetryable`.
- `drivers/src/vertexai/models/gemini-error-handling.test.ts` — regression tests for `REJECTED_PROXY_THROTTLED` and `REJECTED_FC_TOO_MANY_PENDING` (retryable) plus a `REJECTED_ROBOTS_DENIED` guard (non-retryable).

## Test Plan
- [x] `cd drivers && vitest run src/vertexai/models/gemini-error-handling.test.ts` — 35/35 pass (3 new + existing CLIENT_THROTTLED/RATE_LIMITED/plain-400 unchanged)
- [x] `biome lint` on both changed files — clean
- [x] `biome format` on both changed files — clean
- [x] `pnpm typecheck:test` (drivers) — clean