### PR TITLE
feat: improve implicit prompt caching

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -627,6 +627,13 @@ export interface StatelessExecutionOptions extends PromptOptions {
     model_options?: ModelOptions;
 
     /**
+     * Stable identity for prompt caching. Providers with cache routing keys receive the value directly;
+     * providers with cache breakpoints use its presence to cache the stable prefix before the final dynamic block.
+     * Providers with fully implicit caching still require an identical prompt prefix.
+     */
+    prompt_cache_key?: string;
+
+    /**
      * Per-call HTTP timeouts for upstream LLM-provider calls. These override
      * the driver's default `DriverOptions.httpTimeout` for this execution only.
      */

--- a/drivers/package.json
+++ b/drivers/package.json
@@ -140,7 +140,7 @@
         "groq-sdk": "^1.3.0",
         "mnemonist": "^0.40.4",
         "node-web-stream-adapters": "^0.2.1",
-        "openai": "^6.45.0",
+        "openai": "^6.46.0",
         "replicate": "^1.4.0",
         "together-ai": "^0.40.0"
     }

--- a/drivers/src/bedrock/converse.ts
+++ b/drivers/src/bedrock/converse.ts
@@ -410,7 +410,20 @@ export async function formatConversePrompt(
         } else {
             schemaText = `The answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema, undefined, 2)}`;
         }
-        system.push({ text: `IMPORTANT: ${schemaText}` });
+        const schemaInstruction = `IMPORTANT: ${schemaText}`;
+        const taskMessage = messages[messages.length - 1];
+        const taskBlock = taskMessage?.content?.[taskMessage.content.length - 1];
+        if (
+            options.prompt_cache_key !== undefined &&
+            options.model.includes('claude') &&
+            taskBlock &&
+            'text' in taskBlock &&
+            taskBlock.text
+        ) {
+            taskBlock.text = `${taskBlock.text}\n\n${schemaInstruction}`;
+        } else {
+            system.push({ text: schemaInstruction });
+        }
     }
 
     // Safety messages are user messages that should be included at the end.

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1441,7 +1441,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
 
             const claudeOptions = model_options as unknown as BedrockClaudeOptions;
-            const cacheEnabled = claudeOptions?.cache_enabled === true;
+            const cacheEnabled = options.prompt_cache_key !== undefined || claudeOptions?.cache_enabled === true;
             if (cacheEnabled) {
                 const cacheTtl = claudeOptions?.cache_ttl;
                 const cachePointBlock = { type: 'default' as const, ...(cacheTtl && { ttl: cacheTtl }) };
@@ -1457,7 +1457,16 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     ];
                 }
 
-                if (request.messages && request.messages.length >= 4) {
+                if (options.prompt_cache_key !== undefined && request.messages && request.messages.length > 0) {
+                    const lastMessage = request.messages[request.messages.length - 1];
+                    if (lastMessage.content && lastMessage.content.length >= 2) {
+                        lastMessage.content = [
+                            ...lastMessage.content.slice(0, -1),
+                            { cachePoint: cachePointBlock },
+                            lastMessage.content[lastMessage.content.length - 1],
+                        ];
+                    }
+                } else if (request.messages && request.messages.length >= 4) {
                     const pivotMsg = request.messages[request.messages.length - 2];
                     if (pivotMsg.content && Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
                         pivotMsg.content = [...pivotMsg.content, { cachePoint: cachePointBlock }];

--- a/drivers/src/bedrock/prompt-caching.test.ts
+++ b/drivers/src/bedrock/prompt-caching.test.ts
@@ -1,0 +1,110 @@
+import { type ConverseResponse, StopReason } from '@aws-sdk/client-bedrock-runtime';
+import { type DataSource, type ExecutionOptions, PromptRole } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import { formatConversePrompt } from './converse.js';
+import { BedrockDriver } from './index.js';
+
+describe('Bedrock prompt caching', () => {
+    const imageSource = (): DataSource => ({
+        name: 'page.jpg',
+        mime_type: 'image/jpeg',
+        getStream: vi.fn().mockResolvedValue(
+            new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                },
+            }),
+        ),
+        getURL: vi.fn(),
+        getURI: vi.fn(),
+    });
+
+    it('places a cache point after stable source attachments and before the final task', async () => {
+        const options: ExecutionOptions = {
+            model: 'anthropic.claude-sonnet-4-6',
+            prompt_cache_key: 'document-prefix',
+            result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+        };
+        const prompt = await formatConversePrompt(
+            [
+                { role: PromptRole.user, content: 'stable document source', files: [imageSource()] },
+                { role: PromptRole.user, content: 'dynamic extraction task' },
+            ],
+            options,
+        );
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+
+        const payload = driver.preparePayload(prompt, options);
+
+        expect(payload.messages).toEqual([
+            {
+                role: 'user',
+                content: [
+                    { text: 'stable document source' },
+                    { image: { format: 'jpeg', source: { bytes: new Uint8Array([1, 2, 3]) } } },
+                    { cachePoint: { type: 'default' } },
+                    { text: expect.stringContaining('dynamic extraction task') },
+                ],
+            },
+        ]);
+        expect(payload.messages?.[0].content?.[3]).toMatchObject({ text: expect.stringContaining('"value"') });
+    });
+
+    it('keeps the source prefix stable when routed tasks use different schemas', async () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const createPayload = async (task: string, field: string) => {
+            const options: ExecutionOptions = {
+                model: 'anthropic.claude-sonnet-4-6',
+                prompt_cache_key: 'document-prefix',
+                result_schema: { type: 'object', properties: { [field]: { type: 'string' } } },
+            };
+            const prompt = await formatConversePrompt(
+                [
+                    { role: PromptRole.system, content: 'shared system' },
+                    { role: PromptRole.user, content: 'stable document source' },
+                    { role: PromptRole.user, content: task },
+                ],
+                options,
+            );
+            return driver.preparePayload(prompt, options);
+        };
+
+        const extraction = await createPayload('extract fields', 'invoice_number');
+        const review = await createPayload('review fields', 'review_verdict');
+
+        expect(extraction.system).toEqual(review.system);
+        expect(extraction.messages?.[0].content?.slice(0, 2)).toEqual(review.messages?.[0].content?.slice(0, 2));
+        expect(JSON.stringify(extraction.system)).not.toContain('invoice_number');
+        expect(JSON.stringify(review.system)).not.toContain('review_verdict');
+        expect(extraction.messages?.[0].content?.[2]).toMatchObject({
+            text: expect.stringContaining('invoice_number'),
+        });
+        expect(review.messages?.[0].content?.[2]).toMatchObject({ text: expect.stringContaining('review_verdict') });
+    });
+
+    it('reports cache reads and writes in non-streaming usage', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const response = {
+            output: { message: { role: 'assistant', content: [{ text: 'done' }] } },
+            stopReason: StopReason.END_TURN,
+            usage: {
+                inputTokens: 25,
+                outputTokens: 10,
+                totalTokens: 185,
+                cacheReadInputTokens: 100,
+                cacheWriteInputTokens: 50,
+            },
+            metrics: { latencyMs: 1 },
+        } satisfies ConverseResponse;
+
+        expect(driver.getExtractedExecution(response).token_usage).toEqual({
+            prompt: 175,
+            prompt_new: 25,
+            prompt_cached: 100,
+            prompt_cache_write: 50,
+            result: 10,
+            total: 185,
+        });
+    });
+});

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -1,4 +1,4 @@
-import { LlumiverseError, Providers } from '@llumiverse/core';
+import { LlumiverseError, PromptRole, Providers } from '@llumiverse/core';
 import OpenAI from 'openai';
 import {
     APIConnectionError,
@@ -15,7 +15,7 @@ import {
     RateLimitError,
     UnprocessableEntityError,
 } from 'openai/error';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { exposePrivate, getProp } from '../../test/__helpers__/test-utils.js';
 import { OpenAIResponsesDriverBase } from './index.js';
 
@@ -40,7 +40,7 @@ class TestOpenAIResponsesDriver extends OpenAIResponsesDriverBase {
 }
 
 describe('OpenAIResponsesDriverBase usage mapping', () => {
-    it('maps Together flat cached_tokens usage into prompt_cached', () => {
+    it('maps cache read and write usage', () => {
         const driver = new TestOpenAIResponsesDriver();
         const response = {
             status: 'completed',
@@ -56,6 +56,10 @@ describe('OpenAIResponsesDriverBase usage mapping', () => {
                 output_tokens: 20,
                 total_tokens: 120,
                 cached_tokens: 45,
+                input_tokens_details: {
+                    cached_tokens: 45,
+                    cache_write_tokens: 30,
+                },
             },
         } as unknown as OpenAI.Responses.Response;
 
@@ -66,8 +70,93 @@ describe('OpenAIResponsesDriverBase usage mapping', () => {
             result: 20,
             total: 120,
             prompt_cached: 45,
+            prompt_cache_write: 30,
             prompt_new: 55,
         });
+    });
+});
+
+describe('OpenAIResponsesDriverBase prompt caching', () => {
+    it('passes prompt_cache_key to blocking Responses requests', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+
+        await driver.requestTextCompletion([{ role: 'user', content: 'hello' }], {
+            model: 'gpt-5.6',
+            prompt_cache_key: 'document-prefix',
+        });
+
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ prompt_cache_key: 'document-prefix' }));
+    });
+
+    it('passes prompt_cache_key to streaming Responses requests', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue(
+            (async function* () {
+                yield { type: 'response.completed' };
+            })(),
+        );
+        driver.service = { responses: { create } } as unknown as OpenAI;
+
+        await driver.requestTextCompletionStream([{ role: 'user', content: 'hello' }], {
+            model: 'gpt-5.6',
+            prompt_cache_key: 'document-prefix',
+        });
+
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ prompt_cache_key: 'document-prefix' }));
+    });
+
+    it('does not duplicate schemas in the prompt when native structured output is supported', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: '{"value":"ok"}', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+        const options = {
+            model: 'gpt-5.6',
+            result_schema: { type: 'object' as const, properties: { value: { type: 'string' as const } } },
+        };
+        const segments = [{ role: PromptRole.user, content: 'extract' }];
+        const prompt = await driver.createPrompt(segments, options);
+        await driver.requestTextCompletion(prompt, options);
+
+        expect(JSON.stringify(prompt)).not.toContain('<response_schema>');
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                text: expect.objectContaining({
+                    format: expect.objectContaining({ type: 'json_schema' }),
+                }),
+            }),
+        );
+    });
+
+    it('keeps the schema prompt fallback when native structured output is unavailable', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const prompt = await driver.createPrompt([{ role: PromptRole.user, content: 'extract' }], {
+            model: 'gpt-realtime',
+            result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+        });
+
+        expect(JSON.stringify(prompt)).toContain('<response_schema>');
     });
 });
 

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -21,6 +21,8 @@ import {
     OPENAI_DEFAULT_EMBEDDING_MODEL,
     type OpenAiDalleOptions,
     type OpenAiGptImageOptions,
+    type PromptOptions,
+    type PromptSegment,
     type Providers,
     stripBase64ImagesFromConversation,
     stripHeartbeatsFromConversation,
@@ -53,8 +55,10 @@ type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
 type OpenAIErrorWithStatus = Error & { status?: unknown };
 type OpenAIUsageWithProviderDetails = OpenAI.Responses.ResponseUsage & {
     cached_tokens?: number | null;
+    cache_write_tokens?: number | null;
     prompt_tokens_details?: {
         cached_tokens?: number | null;
+        cache_write_tokens?: number | null;
     } | null;
 };
 type MutableRoleItem = { role: 'user' | 'developer' | 'system' | 'assistant' };
@@ -153,6 +157,7 @@ export class OpenAIResponsesProtocol {
         const stream = await driver.service.responses.create({
             stream: true,
             model: driver.getResponsesRequestModel(options.model),
+            prompt_cache_key: options.prompt_cache_key,
             input: conversation,
             reasoning,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
@@ -211,6 +216,7 @@ export class OpenAIResponsesProtocol {
         const res = await driver.service.responses.create({
             stream: false,
             model: driver.getResponsesRequestModel(options.model),
+            prompt_cache_key: options.prompt_cache_key,
             input: conversation,
             reasoning,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
@@ -272,7 +278,11 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
     constructor(opts: OpenAIResponsesDriverBaseOptions) {
         super(opts);
         this.responsesProtocol = new OpenAIResponsesProtocol();
-        this.formatPrompt = formatOpenAILikeMultimodalPrompt;
+    }
+
+    protected async formatPrompt(segments: PromptSegment[], options: PromptOptions): Promise<ResponseInputItem[]> {
+        const resultSchema = supportsSchema(options.model, this.provider) ? undefined : options.result_schema;
+        return formatOpenAILikeMultimodalPrompt(segments, { ...options, result_schema: resultSchema });
     }
 
     /** @internal Resolve the model identifier sent to the Responses transport. */
@@ -685,11 +695,16 @@ function mapUsage(usage?: OpenAIUsageWithProviderDetails | null): ExecutionToken
     }
     const cachedTokens =
         usage.input_tokens_details?.cached_tokens ?? usage.prompt_tokens_details?.cached_tokens ?? usage.cached_tokens;
+    const cacheWriteTokens =
+        usage.input_tokens_details?.cache_write_tokens ??
+        usage.prompt_tokens_details?.cache_write_tokens ??
+        usage.cache_write_tokens;
     return {
         prompt: usage.input_tokens,
         result: usage.output_tokens,
         total: usage.total_tokens,
         prompt_cached: cachedTokens ?? undefined,
+        prompt_cache_write: cacheWriteTokens ?? undefined,
         prompt_new: usage.input_tokens - (cachedTokens ?? 0),
     };
 }

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -1,8 +1,23 @@
-import { PromptRole, type PromptSegment } from '@llumiverse/core';
+import { type DataSource, type ExecutionOptions, PromptRole, type PromptSegment } from '@llumiverse/core';
 import { describe, expect, it, vi } from 'vitest';
-import { formatClaudePrompt } from './claude-messages.js';
+import { anthropicUsageToTokenUsage, formatClaudePrompt, getClaudePayload } from './claude-messages.js';
 
 describe('formatClaudePrompt', () => {
+    const imageSource = (): DataSource => ({
+        name: 'page.jpg',
+        mime_type: 'image/jpeg',
+        getStream: vi.fn().mockResolvedValue(
+            new ReadableStream({
+                start(controller) {
+                    controller.enqueue(new Uint8Array([1, 2, 3]));
+                    controller.close();
+                },
+            }),
+        ),
+        getURL: vi.fn(),
+        getURI: vi.fn(),
+    });
+
     it('warns and skips video attachments', async () => {
         const getStream = vi.fn();
         const warn = vi.fn();
@@ -33,5 +48,116 @@ describe('formatClaudePrompt', () => {
             { file_name: 'clip.mp4', mime_type: 'video/mp4' },
             '[Claude] Skipping unsupported video attachment',
         );
+    });
+
+    it('places a routed cache breakpoint after stable source attachments and before the final task', async () => {
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            prompt_cache_key: 'document-prefix',
+            result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+        };
+        const prompt = await formatClaudePrompt(
+            [
+                { role: PromptRole.user, content: 'stable document source', files: [imageSource()] },
+                { role: PromptRole.user, content: 'dynamic extraction task' },
+            ],
+            options,
+        );
+
+        const { payload } = getClaudePayload(options, prompt);
+
+        expect(payload.messages).toEqual([
+            {
+                role: 'user',
+                content: [
+                    { type: 'text', text: 'stable document source' },
+                    {
+                        type: 'image',
+                        source: { type: 'base64', media_type: 'image/jpeg', data: 'AQID' },
+                        cache_control: { type: 'ephemeral' },
+                    },
+                    { type: 'text', text: expect.stringContaining('dynamic extraction task') },
+                ],
+            },
+        ]);
+        expect(payload.messages[0].content[2]).toMatchObject({ text: expect.stringContaining('"value"') });
+    });
+
+    it('keeps the routed source prefix stable across different tasks and schemas', async () => {
+        const createPayload = async (task: string, field: string) => {
+            const options: ExecutionOptions = {
+                model: 'claude-sonnet-4-6',
+                prompt_cache_key: 'document-prefix',
+                result_schema: { type: 'object', properties: { [field]: { type: 'string' } } },
+            };
+            const prompt = await formatClaudePrompt(
+                [
+                    { role: PromptRole.system, content: 'shared system' },
+                    { role: PromptRole.user, content: 'stable document source' },
+                    { role: PromptRole.user, content: task },
+                ],
+                options,
+            );
+            return getClaudePayload(options, prompt).payload;
+        };
+
+        const extraction = await createPayload('extract fields', 'invoice_number');
+        const review = await createPayload('review fields', 'review_verdict');
+        const extractionContent = extraction.messages[0].content;
+        const reviewContent = review.messages[0].content;
+
+        expect(extraction.system).toEqual(review.system);
+        expect(Array.isArray(extractionContent) ? extractionContent[0] : undefined).toEqual(
+            Array.isArray(reviewContent) ? reviewContent[0] : undefined,
+        );
+        expect(JSON.stringify(extraction.system)).not.toContain('invoice_number');
+        expect(JSON.stringify(review.system)).not.toContain('review_verdict');
+        expect(Array.isArray(extractionContent) ? extractionContent[1] : undefined).toMatchObject({
+            type: 'text',
+            text: expect.stringContaining('invoice_number'),
+        });
+        expect(Array.isArray(reviewContent) ? reviewContent[1] : undefined).toMatchObject({
+            type: 'text',
+            text: expect.stringContaining('review_verdict'),
+        });
+    });
+
+    it('preserves model-option cache controls when no routing identity is supplied', () => {
+        const options: ExecutionOptions = {
+            model: 'claude-sonnet-4-6',
+            model_options: { _option_id: 'anthropic-claude', cache_enabled: true } as never,
+        };
+        const prompt = {
+            system: [{ type: 'text' as const, text: 'stable system prompt' }],
+            messages: [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'task' }] }],
+        };
+
+        const { payload } = getClaudePayload(options, prompt);
+
+        expect(payload.system).toEqual([
+            {
+                type: 'text',
+                text: 'stable system prompt',
+                cache_control: { type: 'ephemeral' },
+            },
+        ]);
+    });
+
+    it('reports Claude cache reads and writes consistently for direct, Vertex, and Bedrock Mantle clients', () => {
+        expect(
+            anthropicUsageToTokenUsage({
+                input_tokens: 25,
+                output_tokens: 10,
+                cache_read_input_tokens: 100,
+                cache_creation_input_tokens: 50,
+            }),
+        ).toEqual({
+            prompt: 175,
+            prompt_new: 25,
+            prompt_cached: 100,
+            prompt_cache_write: 50,
+            result: 10,
+            total: 185,
+        });
     });
 });

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -333,12 +333,15 @@ export async function formatClaudePrompt(
         .filter((s) => s.role === PromptRole.system)
         .map((s) => ({ text: s.content, type: 'text' as const }));
 
+    let schemaText: string | undefined;
     if (options.result_schema) {
-        const schemaText =
+        schemaText =
             options.tools && options.tools.length > 0
                 ? `When not calling tools, the answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema)}`
                 : `The answer must be a JSON object using the following JSON Schema:\n${JSON.stringify(options.result_schema)}`;
-        system.push({ text: schemaText, type: 'text' as const });
+        if (options.prompt_cache_key === undefined) {
+            system.push({ text: schemaText, type: 'text' as const });
+        }
     }
 
     let messages: MessageParam[] = [];
@@ -384,6 +387,18 @@ export async function formatClaudePrompt(
             } else {
                 messages.push(messageParam);
             }
+        }
+    }
+
+    if (schemaText && options.prompt_cache_key !== undefined) {
+        const taskMessage = messages[messages.length - 1];
+        const taskBlock = Array.isArray(taskMessage?.content)
+            ? taskMessage.content[taskMessage.content.length - 1]
+            : undefined;
+        if (taskBlock?.type === 'text') {
+            taskBlock.text = `${taskBlock.text}\n\n${schemaText}`;
+        } else {
+            system.push({ text: schemaText, type: 'text' as const });
         }
     }
 
@@ -719,7 +734,7 @@ export function getClaudePayload(
         ? stripClaudeCacheControlFromTools(options.tools as MessageCreateParamsBase['tools'])
         : undefined;
 
-    const cacheEnabled = model_options?.cache_enabled === true;
+    const cacheEnabled = options.prompt_cache_key !== undefined || model_options?.cache_enabled === true;
     if (cacheEnabled) {
         const cacheTtl = model_options?.cache_ttl as '5m' | '1h' | undefined;
         const cacheControl = { type: 'ephemeral' as const, ...(cacheTtl && { ttl: cacheTtl }) };
@@ -734,7 +749,21 @@ export function getClaudePayload(
             const lastTool = sanitizedTools[sanitizedTools.length - 1] as ClaudeTool & { cache_control?: unknown };
             lastTool.cache_control = cacheControl;
         }
-        if (sanitizedMessages.length >= 4) {
+        if (options.prompt_cache_key !== undefined) {
+            const lastMessage = sanitizedMessages[sanitizedMessages.length - 1];
+            if (lastMessage && Array.isArray(lastMessage.content) && lastMessage.content.length >= 2) {
+                const stablePrefixBlock = lastMessage.content[lastMessage.content.length - 2];
+                if (
+                    typeof stablePrefixBlock === 'object' &&
+                    stablePrefixBlock !== null &&
+                    'type' in stablePrefixBlock &&
+                    stablePrefixBlock.type !== 'thinking' &&
+                    stablePrefixBlock.type !== 'redacted_thinking'
+                ) {
+                    stablePrefixBlock.cache_control = cacheControl;
+                }
+            }
+        } else if (sanitizedMessages.length >= 4) {
             const pivotMsg = sanitizedMessages[sanitizedMessages.length - 2];
             if (Array.isArray(pivotMsg.content) && pivotMsg.content.length > 0) {
                 const lastBlock = pivotMsg.content[pivotMsg.content.length - 1];

--- a/drivers/src/vertexai/models/gemini-prompt-caching.test.ts
+++ b/drivers/src/vertexai/models/gemini-prompt-caching.test.ts
@@ -1,0 +1,43 @@
+import type { GenerateContentResponseUsageMetadata } from '@google/genai';
+import type { ExecutionOptions } from '@llumiverse/core';
+import { describe, expect, it, vi } from 'vitest';
+import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
+import { GeminiModelDefinition, getGeminiPayload } from './gemini.js';
+
+describe('Gemini implicit prompt caching', () => {
+    const prompt: GenerateContentPrompt = {
+        system: { role: 'user', parts: [{ text: 'stable system' }] },
+        contents: [
+            { role: 'user', parts: [{ text: 'stable document source' }] },
+            { role: 'user', parts: [{ text: 'dynamic extraction task' }] },
+        ],
+    };
+    const options: ExecutionOptions = { model: 'gemini-2.5-flash' };
+
+    it('keeps the provider payload identical when a routing identity is supplied', () => {
+        const baseline = getGeminiPayload(options, prompt);
+        const routed = getGeminiPayload({ ...options, prompt_cache_key: 'document-prefix' }, prompt);
+
+        expect(routed).toEqual(baseline);
+    });
+
+    it('reports tokens served by the implicit cache', () => {
+        const model = new GeminiModelDefinition('gemini-2.5-flash');
+        const driver = { logger: { warn: vi.fn() } } as unknown as VertexAIDriver;
+        const usage = {
+            promptTokenCount: 125,
+            cachedContentTokenCount: 100,
+            candidatesTokenCount: 10,
+            totalTokenCount: 135,
+        } satisfies GenerateContentResponseUsageMetadata;
+
+        expect(model.usageMetadataToTokenUsage(driver, usage)).toEqual({
+            prompt: 125,
+            prompt_new: 25,
+            prompt_cached: 100,
+            result: 10,
+            total: 135,
+        });
+        expect(driver.logger.warn).not.toHaveBeenCalled();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,8 +162,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.1
       openai:
-        specifier: ^6.45.0
-        version: 6.45.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3)
+        specifier: ^6.46.0
+        version: 6.46.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3)
       replicate:
         specifier: ^1.4.0
         version: 1.4.0
@@ -1435,8 +1435,8 @@ packages:
     resolution: {integrity: sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==}
     engines: {node: '>=18'}
 
-  openai@6.45.0:
-    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+  openai@6.46.0:
+    resolution: {integrity: sha512-DFg6jEPT2RO+oAyXtddeUJU8zkGy1OQ1AjGzNIJUMQG03TTqvCpy9tBpQ+2VVVnvrl3E56F8GEin2JYtWpITtA==}
     peerDependencies:
       '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
       '@smithy/hash-node': '>=4.3.0 <5'
@@ -2160,7 +2160,7 @@ snapshots:
       '@azure/logger': 1.1.4
       '@azure/storage-blob': 12.27.0
       '@opentelemetry/api': 1.9.1
-      openai: 6.45.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3)
+      openai: 6.46.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3)
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-node'
@@ -3293,7 +3293,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@6.45.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3):
+  openai@6.46.0(@aws-sdk/credential-provider-node@3.972.62)(@smithy/hash-node@4.4.6)(@smithy/signature-v4@5.6.2)(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       '@aws-sdk/credential-provider-node': 3.972.62
       '@smithy/hash-node': 4.4.6


### PR DESCRIPTION
## Summary
- add a provider-neutral prompt cache identity and forward OpenAI routing keys through blocking and streaming Responses requests
- keep native schemas out of cacheable prompt prefixes and report OpenAI cache-write usage
- place Claude cache breakpoints after stable source attachments and before dynamic tasks across Anthropic, Vertex AI, and Bedrock while preserving existing `cache_enabled` behavior
- verify Gemini implicit-cache payload stability and cache usage accounting
- update the OpenAI SDK to 6.46.0

## Verification
- `pnpm run check`
- `pnpm run build`
- `pnpm run typecheck:test`
- `pnpm run test` (625 tests passed; 19 credential-gated live tests skipped)
- Vertex Gemini: a repeated 11,102-token prompt reported 11,062 cached tokens and 40 new tokens on the second request
- Vertex Claude: a repeated stable prefix reported 6,171 cache-write tokens followed by 6,171 cache-read tokens
- Bedrock Claude: a repeated stable prefix reported 6,171 cache-write tokens followed by 6,171 cache-read tokens