### PR TITLE
fix: default streaming tool support to tool_support

### DIFF
--- a/common/src/capability.test.ts
+++ b/common/src/capability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { getModelCapabilities, supportsToolUse } from './capability.js';
+import { Providers } from './types.js';
+
+describe('xAI Grok tool capabilities', () => {
+    it.each([
+        'grok-2',
+        'grok-3',
+        'grok-4',
+        'grok-4-fast-reasoning',
+    ])('enables tool use for %s via Providers.xai without setting tool_support_streaming', (model) => {
+        const caps = getModelCapabilities(model, Providers.xai);
+        expect(caps.tool_support).toBe(true);
+        expect(caps.tool_support_streaming).toBeUndefined();
+        // Streaming agents must still attach tools when the flag is omitted
+        expect(supportsToolUse(model, Providers.xai, true)).toBe(true);
+        expect(supportsToolUse(model, Providers.xai, false)).toBe(true);
+    });
+
+    it('enables streaming tool use when provider is omitted for grok-* models', () => {
+        const caps = getModelCapabilities('grok-3');
+        expect(caps.tool_support).toBe(true);
+        expect(caps.tool_support_streaming).toBeUndefined();
+        expect(supportsToolUse('grok-3', undefined, true)).toBe(true);
+    });
+});
+
+describe('supportsToolUse streaming default', () => {
+    it('falls back to tool_support when tool_support_streaming is unset', () => {
+        // Vertex Grok records tool_support but not tool_support_streaming
+        expect(getModelCapabilities('grok-3', Providers.vertexai).tool_support).toBe(true);
+        expect(getModelCapabilities('grok-3', Providers.vertexai).tool_support_streaming).toBeUndefined();
+        expect(supportsToolUse('grok-3', Providers.vertexai, true)).toBe(true);
+    });
+
+    it('honors explicit tool_support_streaming: false', () => {
+        // Bedrock runtime Llama has tools but not streaming tools
+        const caps = getModelCapabilities('meta.llama3-1-70b-instruct-v1:0', Providers.bedrock);
+        expect(caps.tool_support).toBe(true);
+        expect(caps.tool_support_streaming).toBe(false);
+        expect(supportsToolUse('meta.llama3-1-70b-instruct-v1:0', Providers.bedrock, true)).toBe(false);
+        expect(supportsToolUse('meta.llama3-1-70b-instruct-v1:0', Providers.bedrock, false)).toBe(true);
+    });
+});

--- a/common/src/capability.ts
+++ b/common/src/capability.ts
@@ -20,8 +20,8 @@ export function getModelCapabilities(model: string, provider?: string | Provider
     capabilities.input.audio = false;
     capabilities.output.audio = false;
     capabilities.output.video = false;
-    // Preserve tool_support_streaming from provider-specific capabilities if set,
-    // otherwise default to false for providers that haven't been verified
+    // tool_support_streaming is optional: when omitted, supportsToolUse falls back to tool_support.
+    // Only set it explicitly to false for models that can tool-call but not while streaming.
     return capabilities;
 }
 
@@ -51,12 +51,12 @@ function _getModelCapabilities(model: string, provider?: string | Providers): Mo
             // model families TogetherAI hosts so is_multimodal is reported correctly.
             return getModelCapabilitiesTogetherAI(model);
         case Providers.xai:
-            // xAI (Grok) models support tool use and are text-based
+            // xAI (Grok) uses the OpenAI Responses API; tool use matches OpenAI-compatible defaults.
+            // Do not set tool_support_streaming — leave it unset so it defaults to tool_support.
             return {
                 input: { text: true, image: model.includes('vision') },
                 output: { text: true },
                 tool_support: true,
-                tool_support_streaming: false, // Conservative - may work but not tested
             };
         default:
             // Guess the provider based on the model name
@@ -65,12 +65,11 @@ function _getModelCapabilities(model: string, provider?: string | Providers): Mo
             } else if (model.startsWith('claude')) {
                 return getModelCapabilitiesAnthropic(model);
             } else if (model.startsWith('grok')) {
-                // xAI Grok models
+                // xAI Grok models (provider omitted — same as Providers.xai)
                 return {
                     input: { text: true, image: model.includes('vision') },
                     output: { text: true },
                     tool_support: true,
-                    tool_support_streaming: false,
                 };
             } else if (model.startsWith('publishers/')) {
                 return getModelCapabilitiesVertexAI(model);
@@ -134,7 +133,12 @@ function getModelCapabilitiesTogetherAI(model: string): ModelCapabilities {
 
 export function supportsToolUse(model: string, provider?: string | Providers, streaming: boolean = false): boolean {
     const capabilities = getModelCapabilities(model, provider);
-    return streaming ? !!capabilities.tool_support_streaming : !!capabilities.tool_support;
+    if (!streaming) {
+        return !!capabilities.tool_support;
+    }
+    // Unset tool_support_streaming means "same as tool_support" (OpenAI-compatible default).
+    // Only an explicit false opts out of tools-while-streaming.
+    return !!(capabilities.tool_support_streaming ?? capabilities.tool_support);
 }
 
 export function modelModalitiesToArray(modalities: ModelModalities): string[] {


### PR DESCRIPTION
## Summary
- Stop hard-coding `tool_support_streaming: false` for xAI Grok (and the provider-less `grok*` name fallback). Leave the flag unset.
- Make `supportsToolUse(..., streaming=true)` fall back to `tool_support` when `tool_support_streaming` is omitted; only an explicit `false` opts out of tools-while-streaming.
- Without this, streamed completions (the common path) omit tools even when `tool_support` is true, so models free-form text "tool calls" instead of structured function calls.

## Test Plan
- [x] `pnpm lint` in `common` — pass
- [x] `pnpm build` in `common` — pass
- [x] `pnpm test` in `common` — pass (includes new `capability.test.ts` for xAI Grok + streaming default / explicit false)