### PR TITLE
feat: add explicit OpenAI cache boundaries

### DIFF
--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -117,6 +117,92 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
         expect(create).toHaveBeenCalledWith(expect.objectContaining({ prompt_cache_key: 'document-prefix' }));
     });
 
+    it('places an explicit cache boundary before the changing final user message', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+        const prompt = [
+            { role: 'system' as const, content: 'review the extraction' },
+            {
+                role: 'user' as const,
+                content: [
+                    {
+                        type: 'input_image' as const,
+                        image_url: 'data:image/jpeg;base64,source',
+                        detail: 'auto' as const,
+                    },
+                    { type: 'input_text' as const, text: 'stable document blocks' },
+                ],
+            },
+            { role: 'user' as const, content: 'changing extraction JSON' },
+        ];
+
+        const completion = await driver.requestTextCompletion(prompt, {
+            model: 'gpt-5.6',
+            prompt_cache_key: 'document-prefix',
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt_cache_options: { mode: 'explicit' },
+                input: [
+                    prompt[0],
+                    {
+                        ...prompt[1],
+                        content: [
+                            {
+                                type: 'input_image',
+                                image_url: 'data:image/jpeg;base64,source',
+                                detail: 'auto',
+                            },
+                            {
+                                type: 'input_text',
+                                text: 'stable document blocks',
+                                prompt_cache_breakpoint: { mode: 'explicit' },
+                            },
+                        ],
+                    },
+                    prompt[2],
+                ],
+            }),
+        );
+        expect(prompt[1].content[1]).not.toHaveProperty('prompt_cache_breakpoint');
+        expect(JSON.stringify(completion.conversation)).not.toContain('prompt_cache_breakpoint');
+    });
+
+    it('keeps implicit caching when the prompt has no stable source and task split', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: 'ok', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+
+        await driver.requestTextCompletion([{ role: 'user', content: 'single request' }], {
+            model: 'gpt-5.6',
+            prompt_cache_key: 'document-prefix',
+        });
+
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ prompt_cache_options: undefined }));
+    });
+
     it('does not duplicate schemas in the prompt when native structured output is supported', async () => {
         const driver = new TestOpenAIResponsesDriver();
         const create = vi.fn().mockResolvedValue({

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -69,6 +69,10 @@ type OpenAIFunctionItem = ResponseInputItem & {
     arguments?: string;
     output?: string;
 };
+type OpenAIPromptCacheConfig = {
+    input: ResponseInputItem[];
+    options?: OpenAI.Responses.ResponseCreateParams['prompt_cache_options'];
+};
 
 // Helper function to convert string to CompletionResult[]
 function textToCompletionResult(text: string): CompletionResult[] {
@@ -95,6 +99,53 @@ function openAIReasoning(effort: string | undefined): OpenAI.Responses.ResponseC
     }
     // Forward provider-native values unchanged so the provider can return an authoritative validation error.
     return { effort } as OpenAI.Responses.ResponseCreateParams['reasoning'];
+}
+
+function hasExplicitPromptCacheBreakpoint(item: ResponseInputItem): boolean {
+    if (!('content' in item) || !Array.isArray(item.content)) {
+        return false;
+    }
+    return item.content.some(
+        (content) => 'prompt_cache_breakpoint' in content && content.prompt_cache_breakpoint?.mode === 'explicit',
+    );
+}
+
+function configureOpenAIPromptCaching(
+    input: ResponseInputItem[],
+    model: string,
+    promptCacheKey: string | undefined,
+): OpenAIPromptCacheConfig {
+    if (!promptCacheKey || !model.toLowerCase().startsWith('gpt-5.6')) {
+        return { input };
+    }
+
+    if (input.some(hasExplicitPromptCacheBreakpoint)) {
+        return { input, options: { mode: 'explicit' } };
+    }
+
+    const userMessageIndexes = input.flatMap((item, index) => ('role' in item && item.role === 'user' ? [index] : []));
+    if (userMessageIndexes.length < 2) {
+        return { input };
+    }
+
+    const sourceIndex = userMessageIndexes.at(-2);
+    if (sourceIndex === undefined) {
+        return { input };
+    }
+    const source = input[sourceIndex] as EasyInputMessage;
+    const content =
+        typeof source.content === 'string'
+            ? [{ type: 'input_text' as const, text: source.content }]
+            : source.content.map((part) => ({ ...part }));
+    const lastContent = content.at(-1);
+    if (!lastContent) {
+        return { input };
+    }
+    lastContent.prompt_cache_breakpoint = { mode: 'explicit' };
+
+    const markedInput = [...input];
+    markedInput[sourceIndex] = { ...source, content };
+    return { input: markedInput, options: { mode: 'explicit' } };
 }
 
 //TODO: Do we need a list?, replace with if statements and modernize?
@@ -154,11 +205,17 @@ export class OpenAIResponsesProtocol {
         const isReasoningModel = isOpenAIReasoningModel(options.model);
         const reasoning = openAIReasoning(model_options?.effort ?? model_options?.reasoning_effort);
 
+        const promptCache = configureOpenAIPromptCaching(
+            conversation,
+            driver.getResponsesRequestModel(options.model),
+            options.prompt_cache_key,
+        );
         const stream = await driver.service.responses.create({
             stream: true,
             model: driver.getResponsesRequestModel(options.model),
             prompt_cache_key: options.prompt_cache_key,
-            input: conversation,
+            prompt_cache_options: promptCache.options,
+            input: promptCache.input,
             reasoning,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
             top_p: isReasoningModel ? undefined : model_options?.top_p,
@@ -213,11 +270,17 @@ export class OpenAIResponsesProtocol {
         const isReasoningModel = isOpenAIReasoningModel(options.model);
         const reasoning = openAIReasoning(model_options?.effort ?? model_options?.reasoning_effort);
 
+        const promptCache = configureOpenAIPromptCaching(
+            conversation,
+            driver.getResponsesRequestModel(options.model),
+            options.prompt_cache_key,
+        );
         const res = await driver.service.responses.create({
             stream: false,
             model: driver.getResponsesRequestModel(options.model),
             prompt_cache_key: options.prompt_cache_key,
-            input: conversation,
+            prompt_cache_options: promptCache.options,
+            input: promptCache.input,
             reasoning,
             temperature: isReasoningModel ? undefined : model_options?.temperature,
             top_p: isReasoningModel ? undefined : model_options?.top_p,


### PR DESCRIPTION
## Summary
- enable GPT-5.6 Responses explicit prompt caching when a routing key and stable source/task split are present
- place the cache breakpoint after the stable penultimate user message while keeping the final task dynamic
- preserve caller-provided breakpoints, avoid mutating the conversation, and retain implicit caching when no safe split exists

## Verification
- `pnpm --filter @llumiverse/drivers test -- error-handling.test.ts` (410 passed, 19 skipped)
- `pnpm --filter @llumiverse/drivers typecheck:test`
- `pnpm --filter @llumiverse/drivers lint`
- `pnpm --filter @llumiverse/drivers build`
- live OpenAI Responses check: a changed final task reused 15,049 of 19,750 prompt tokens and wrote no new cache tokens