### PR TITLE
fix: improve Claude reasoning and truncation reliability

### DIFF
--- a/common/src/options/context-windows.test.ts
+++ b/common/src/options/context-windows.test.ts
@@ -4,6 +4,8 @@ import { getContextWindowSize, getMaxOutputTokens } from './context-windows.js';
 describe('Claude context window limits', () => {
     it.each([
         'claude-sonnet-5',
+        'claude-fable-5',
+        'claude-mythos-5',
         'claude-sonnet-5-20260701',
         'publishers/anthropic/models/claude-sonnet-5@20260701',
         'us.anthropic.claude-sonnet-5-v1:0',
@@ -19,5 +21,27 @@ describe('Claude context window limits', () => {
         expect(getContextWindowSize('claude-sonnet-4-6')).toBe(200_000);
         expect(getMaxOutputTokens('claude-3-5-sonnet-20241022')).toBe(8192);
         expect(getContextWindowSize('claude-3-5-sonnet-20241022')).toBe(200_000);
+    });
+});
+
+describe('OpenAI context window limits', () => {
+    it.each(['gpt-5', 'gpt-5.2', 'models/gpt-5.3-20260101'])('preserves GPT-5 through 5.3 limits for %s', (model) => {
+        expect(getMaxOutputTokens(model)).toBe(128_000);
+        expect(getContextWindowSize(model)).toBe(400_000);
+    });
+
+    it.each([
+        'gpt-5.4',
+        'gpt-5.6-sol',
+        'models/gpt-5.7-20270101',
+    ])('uses current and future GPT-5 context limits for %s', (model) => {
+        expect(getMaxOutputTokens(model)).toBe(128_000);
+        expect(getContextWindowSize(model)).toBe(1_050_000);
+    });
+
+    it('preserves the larger GPT-5 Pro output limit and o-series limits', () => {
+        expect(getMaxOutputTokens('gpt-5-pro')).toBe(272_000);
+        expect(getMaxOutputTokens('gpt-5.4-pro')).toBe(128_000);
+        expect(getMaxOutputTokens('o4-mini')).toBe(100_000);
     });
 });

--- a/common/src/options/context-windows.test.ts
+++ b/common/src/options/context-windows.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getContextWindowSize, getMaxOutputTokens } from './context-windows.js';
+
+describe('Claude context window limits', () => {
+    it.each([
+        'claude-sonnet-5',
+        'claude-sonnet-5-20260701',
+        'publishers/anthropic/models/claude-sonnet-5@20260701',
+        'us.anthropic.claude-sonnet-5-v1:0',
+        'arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-5-v1:0',
+        'claude-sonnet-5-1',
+    ])('uses future-compatible limits for %s', (model) => {
+        expect(getMaxOutputTokens(model)).toBe(128_000);
+        expect(getContextWindowSize(model)).toBe(1_000_000);
+    });
+
+    it('preserves release limits for older Claude models', () => {
+        expect(getMaxOutputTokens('claude-sonnet-4-6')).toBe(64_000);
+        expect(getContextWindowSize('claude-sonnet-4-6')).toBe(200_000);
+        expect(getMaxOutputTokens('claude-3-5-sonnet-20241022')).toBe(8192);
+        expect(getContextWindowSize('claude-3-5-sonnet-20241022')).toBe(200_000);
+    });
+});

--- a/common/src/options/context-windows.test.ts
+++ b/common/src/options/context-windows.test.ts
@@ -6,6 +6,7 @@ describe('Claude context window limits', () => {
         'claude-sonnet-5',
         'claude-fable-5',
         'claude-mythos-5',
+        'claude-mythos-preview',
         'claude-sonnet-5-20260701',
         'publishers/anthropic/models/claude-sonnet-5@20260701',
         'us.anthropic.claude-sonnet-5-v1:0',
@@ -37,6 +38,11 @@ describe('OpenAI context window limits', () => {
     ])('uses current and future GPT-5 context limits for %s', (model) => {
         expect(getMaxOutputTokens(model)).toBe(128_000);
         expect(getContextWindowSize(model)).toBe(1_050_000);
+    });
+
+    it('recognizes provider-qualified GPT versions', () => {
+        expect(getMaxOutputTokens('us.openai.gpt-5.6-sol-v1:0')).toBe(128_000);
+        expect(getContextWindowSize('us.openai.gpt-5.6-sol-v1:0')).toBe(1_050_000);
     });
 
     it('preserves the larger GPT-5 Pro output limit and o-series limits', () => {

--- a/common/src/options/context-windows.test.ts
+++ b/common/src/options/context-windows.test.ts
@@ -48,6 +48,7 @@ describe('OpenAI context window limits', () => {
     it('preserves the larger GPT-5 Pro output limit and o-series limits', () => {
         expect(getMaxOutputTokens('gpt-5-pro')).toBe(272_000);
         expect(getMaxOutputTokens('gpt-5.4-pro')).toBe(128_000);
+        expect(getMaxOutputTokens('gpt-6-pro')).toBe(128_000);
         expect(getMaxOutputTokens('o4-mini')).toBe(100_000);
     });
 });

--- a/common/src/options/context-windows.ts
+++ b/common/src/options/context-windows.ts
@@ -33,7 +33,8 @@ export function getMaxOutputTokens(model: string): number {
     if (model.includes('o1')) return 100_000;
     if (model.includes('o3') || model.includes('o4')) return 100_000;
     // GPT models
-    if (isOpenAIGptProModel(model) && parseOpenAIGptVersion(model)?.minor === 0) return 272_000;
+    const gptVersion = parseOpenAIGptVersion(model);
+    if (isOpenAIGptProModel(model) && gptVersion?.major === 5 && gptVersion.minor === 0) return 272_000;
     if (isOpenAIGptVersionGTE(model, 5, 0)) return 128_000;
     if (model.includes('gpt-4o')) return 16_384;
     if (model.includes('gpt-4')) return 8_192;

--- a/common/src/options/context-windows.ts
+++ b/common/src/options/context-windows.ts
@@ -1,4 +1,9 @@
-import { isClaudeVersionGTE } from './version-parsing.js';
+import {
+    isClaudeVersionGTE,
+    isOpenAIGptProModel,
+    isOpenAIGptVersionGTE,
+    parseOpenAIGptVersion,
+} from './version-parsing.js';
 
 /**
  * Returns the max output tokens for a given model (provider-agnostic).
@@ -28,7 +33,8 @@ export function getMaxOutputTokens(model: string): number {
     if (model.includes('o1')) return 100_000;
     if (model.includes('o3') || model.includes('o4')) return 100_000;
     // GPT models
-    if (model.includes('gpt-5')) return 128_000;
+    if (isOpenAIGptProModel(model) && parseOpenAIGptVersion(model)?.minor === 0) return 272_000;
+    if (isOpenAIGptVersionGTE(model, 5, 0)) return 128_000;
     if (model.includes('gpt-4o')) return 16_384;
     if (model.includes('gpt-4')) return 8_192;
     if (model.includes('gpt-3.5')) return 4_096;
@@ -71,7 +77,8 @@ export function getContextWindowSize(model: string): number {
     // OpenAI o-series (check before gpt-4 to avoid false matches)
     if (model.includes('o1') || model.includes('o3') || model.includes('o4')) return 200_000;
     // GPT models — check specific variants before generic gpt-4
-    if (model.includes('gpt-5')) return 400_000;
+    if (isOpenAIGptVersionGTE(model, 5, 4)) return 1_050_000;
+    if (isOpenAIGptVersionGTE(model, 5, 0)) return 400_000;
     if (model.includes('gpt-4.1') || model.includes('gpt-4-1')) return 1_000_000;
     if (model.includes('gpt-4-turbo') || model.includes('gpt-4o')) return 128_000;
     if (model.includes('gpt-4')) return 8_000;

--- a/common/src/options/context-windows.ts
+++ b/common/src/options/context-windows.ts
@@ -1,3 +1,5 @@
+import { isClaudeVersionGTE } from './version-parsing.js';
+
 /**
  * Returns the max output tokens for a given model (provider-agnostic).
  * When a model's limits vary by provider, returns a conservative value
@@ -6,7 +8,7 @@
 export function getMaxOutputTokens(model: string): number {
     // Claude models
     if (model.includes('claude')) {
-        if (model.includes('opus-4-7')) return 128_000;
+        if (isClaudeVersionGTE(model, 4, 7)) return 128_000;
         if (model.includes('opus-4-6')) return 128_000;
         if (model.includes('opus-4-5')) return 64_000;
         if (model.includes('opus-')) return 32_768; // Opus 4.0, 4.1
@@ -58,7 +60,7 @@ export function getMaxInputTokens(model: string): number {
 export function getContextWindowSize(model: string): number {
     // Claude models
     if (model.includes('claude')) {
-        // All Claude models use 200K (1M requires beta header, handled separately later)
+        if (isClaudeVersionGTE(model, 4, 7)) return 1_000_000;
         return 200_000;
     }
     // Gemini models

--- a/common/src/options/current-model-options.test.ts
+++ b/common/src/options/current-model-options.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { getOptions } from '../options.js';
+import { OptionType, SharedOptions } from '../types.js';
+
+function effortValues(model: string, provider: string): string[] {
+    const effort = getOptions(model, provider).options.find((option) => option.name === SharedOptions.effort);
+    expect(effort?.type).toBe(OptionType.enum);
+    return effort?.type === OptionType.enum ? Object.values(effort.enum) : [];
+}
+
+describe('current reasoning model options', () => {
+    it('advertises forward-compatible Claude effort for all current families', () => {
+        expect(effortValues('claude-fable-5', 'anthropic')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+        expect(effortValues('claude-mythos-5', 'anthropic')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+        expect(effortValues('claude-sonnet-5', 'anthropic')).toEqual(['low', 'medium', 'high', 'xhigh', 'max']);
+    });
+
+    it('advertises version-specific GPT-5 effort without adding a default', () => {
+        const options = getOptions('gpt-5.6-sol', 'openai');
+        expect(effortValues('gpt-5.6-sol', 'openai')).toEqual(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
+        expect(options.options.find((option) => option.name === SharedOptions.effort)).not.toHaveProperty('default');
+        expect(effortValues('gpt-6', 'openai')).toEqual(['none', 'low', 'medium', 'high', 'xhigh', 'max']);
+    });
+
+    it('advertises current Gemini thinking levels without adding a default', () => {
+        const flash = getOptions('gemini-3.5-flash', 'vertexai');
+        const pro = getOptions('gemini-3.1-pro-preview', 'vertexai');
+        expect(effortValues('gemini-3.5-flash', 'vertexai')).toEqual(['minimal', 'low', 'medium', 'high']);
+        expect(effortValues('gemini-3.1-pro-preview', 'vertexai')).toEqual(['low', 'medium', 'high']);
+        expect(flash.options.find((option) => option.name === SharedOptions.effort)).not.toHaveProperty('default');
+        expect(pro.options.find((option) => option.name === SharedOptions.effort)).not.toHaveProperty('default');
+    });
+});

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -6,6 +6,8 @@ import {
     type ReasoningEffort,
     SharedOptions,
 } from '../types.js';
+import { getMaxOutputTokens } from './context-windows.js';
+import { getOpenAIReasoningEffortLevels, isOpenAIGptVersionGTE } from './version-parsing.js';
 
 // Union type of all OpenAI options
 /**
@@ -180,8 +182,10 @@ export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOp
             }
         } else if (model.includes('o3')) {
             max_tokens_limit = 100000;
-        } else if (model.includes('o4') || model.includes('gpt-5')) {
-            max_tokens_limit = 128000;
+        } else if (model.includes('o4')) {
+            max_tokens_limit = 100000;
+        } else if (isOpenAIGptVersionGTE(model, 5, 0)) {
+            max_tokens_limit = getMaxOutputTokens(model);
         }
 
         const commonOptions: ModelOptionInfoItem[] = [
@@ -201,28 +205,19 @@ export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOp
             },
         ];
 
-        const reasoningOptions: ModelOptionInfoItem[] = isGpt5ProModel(model)
-            ? [
-                  {
-                      name: SharedOptions.effort,
-                      type: OptionType.enum,
-                      enum: { High: 'high' },
-                      default: 'high',
-                      description: 'GPT-5 Pro only supports high reasoning effort.',
-                  },
-              ]
-            : model.includes('o3') || model.includes('o4') || model.includes('gpt-5') || isO1Full(model)
-              ? [
-                    {
-                        name: SharedOptions.effort,
-                        type: OptionType.enum,
-                        enum: { Low: 'low', Medium: 'medium', High: 'high' },
-                        default: 'medium',
-                        description:
-                            'How much effort the model should put into reasoning, lower values result in faster responses and less tokens used.',
-                    },
-                ]
-              : [];
+        const gptEffortLevels = getOpenAIReasoningEffortLevels(model);
+        const reasoningOptions: ModelOptionInfoItem[] =
+            gptEffortLevels || model.includes('o3') || model.includes('o4') || isO1Full(model)
+                ? [
+                      {
+                          name: SharedOptions.effort,
+                          type: OptionType.enum,
+                          enum: gptEffortLevels ?? { Low: 'low', Medium: 'medium', High: 'high' },
+                          description:
+                              'How much effort the model should put into reasoning, lower values result in faster responses and less tokens used.',
+                      },
+                  ]
+                : [];
 
         return {
             _option_id: 'openai-thinking',
@@ -326,13 +321,8 @@ function isReasoningModel(model: string): boolean {
         normalized.includes('o1') ||
         normalized.includes('o3') ||
         normalized.includes('o4') ||
-        normalized.includes('gpt-5')
+        isOpenAIGptVersionGTE(model, 5, 0)
     );
-}
-
-function isGpt5ProModel(model: string): boolean {
-    const modelName = model.toLowerCase().split('/').pop() ?? model.toLowerCase();
-    return /^gpt-5(?:\.\d+)?-pro/.test(modelName);
 }
 
 function isVisionModel(model: string): boolean {

--- a/common/src/options/shared-parsing.ts
+++ b/common/src/options/shared-parsing.ts
@@ -8,7 +8,7 @@
 
 import { type ModelOptionInfoItem, OptionType } from '../types.js';
 import { getMaxOutputTokens } from './context-windows.js';
-import { getAvailableEffortLevels, isClaudeVersionGTE, supportsAdaptiveThinking } from './version-parsing.js';
+import { getAvailableEffortLevels, isClaudeVersionGTE, requiresAdaptiveThinkingOnly } from './version-parsing.js';
 
 // ============================================================================
 // Max tokens
@@ -88,17 +88,14 @@ export function buildClaudeEffortOptions(model: string): ModelOptionInfoItem[] {
 // ============================================================================
 
 /**
- * Thinking budget option — shown for non-adaptive Claude thinking models (3.7, 4.5).
+ * Thinking budget option — shown for Claude models that still accept extended thinking.
  * Setting this enables extended thinking with the given token budget.
  *
- * Returns an empty array for models that don't support extended thinking or that
- * use adaptive thinking instead (where effort is the control knob).
+ * Dual-mode 4.6 models retain the legacy budget control for compatibility.
+ * Models at 4.7+ use adaptive thinking only and do not expose a budget.
  */
 export function buildClaudeThinkingBudgetOption(model: string): ModelOptionInfoItem[] {
-    // Adaptive-only models (Opus 4.7+) don't accept budget_tokens at all.
-    // Adaptive models (Opus/Sonnet 4.6) still accept budget_tokens but it's deprecated;
-    // those models should use effort instead. Show budget only for non-adaptive thinking models.
-    if (!isClaudeVersionGTE(model, 3, 7) || supportsAdaptiveThinking(model)) return [];
+    if (!isClaudeVersionGTE(model, 3, 7) || requiresAdaptiveThinkingOnly(model)) return [];
     return [
         {
             name: 'thinking_budget_tokens',

--- a/common/src/options/version-parsing.test.ts
+++ b/common/src/options/version-parsing.test.ts
@@ -5,7 +5,6 @@ import {
     getOpenAIReasoningEffortLevels,
     isClaudeVersionGTE,
     isGeminiModelVersionGte,
-    isModelFamilyVersionGTE,
     isOpenAIGptVersionGTE,
     parseClaudeVersion,
     parseOpenAIGptVersion,
@@ -68,6 +67,7 @@ describe('OpenAI GPT model version parsing', () => {
     it('uses numeric GTE comparisons rather than string ordering', () => {
         expect(isOpenAIGptVersionGTE('gpt-5.10', 5, 6)).toBe(true);
         expect(isOpenAIGptVersionGTE('gpt-5.2', 5, 6)).toBe(false);
+        expect(parseOpenAIGptVersion('notgpt-6')).toBeNull();
     });
 
     it.each([
@@ -89,14 +89,6 @@ describe('OpenAI GPT model version parsing', () => {
         ['gpt-5.4-pro', { Medium: 'medium', 'High (default)': 'high', 'Extra High': 'xhigh' }],
     ] as const)('advertises documented effort levels for %s', (model, expected) => {
         expect(getOpenAIReasoningEffortLevels(model)).toEqual(expected);
-    });
-});
-
-describe('generic model-family version parsing', () => {
-    it('matches provider-qualified current and future versions', () => {
-        expect(isModelFamilyVersionGTE('us.openai.gpt-5.6-sol-v1:0', 'openai.gpt-', 5, 4)).toBe(true);
-        expect(isModelFamilyVersionGTE('xai.grok-4.10', 'grok-', 4, 3)).toBe(true);
-        expect(isModelFamilyVersionGTE('deepseek.v3.2', 'deepseek.v', 3, 2)).toBe(true);
     });
 });
 

--- a/common/src/options/version-parsing.test.ts
+++ b/common/src/options/version-parsing.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+    getAvailableEffortLevels,
+    getGeminiModelVersion,
+    getOpenAIReasoningEffortLevels,
+    isClaudeVersionGTE,
+    isGeminiModelVersionGte,
+    isOpenAIGptVersionGTE,
+    parseClaudeVersion,
+    parseOpenAIGptVersion,
+    supportsAdaptiveThinking,
+    supportsEffort,
+} from './version-parsing.js';
+
+describe('Claude model version parsing', () => {
+    it.each([
+        ['claude-sonnet-5', { major: 5, minor: 0, variant: 'sonnet' }],
+        ['claude-fable-5-20260701', { major: 5, minor: 0, variant: 'fable' }],
+        ['publishers/anthropic/models/claude-mythos-5@20260701', { major: 5, minor: 0, variant: 'mythos' }],
+        ['us.anthropic.claude-opus-4-8-v1:0', { major: 4, minor: 8, variant: 'opus' }],
+        ['claude-3-7-sonnet-20250219', { major: 3, minor: 7, variant: 'sonnet' }],
+    ] as const)('parses %s', (model, expected) => {
+        expect(parseClaudeVersion(model)).toEqual(expected);
+    });
+
+    it('uses numeric GTE comparisons for current and future families', () => {
+        expect(isClaudeVersionGTE('claude-sonnet-5', 4, 7)).toBe(true);
+        expect(isClaudeVersionGTE('claude-opus-4-10', 4, 8)).toBe(true);
+        expect(isClaudeVersionGTE('claude-sonnet-4-6', 4, 7)).toBe(false);
+    });
+
+    it.each([
+        'claude-fable-5',
+        'claude-mythos-5',
+        'claude-sonnet-5',
+        'claude-opus-4-8',
+    ])('advertises adaptive thinking and current effort levels for %s', (model) => {
+        expect(supportsAdaptiveThinking(model)).toBe(true);
+        expect(supportsEffort(model)).toBe(true);
+        expect(getAvailableEffortLevels(model)).toEqual({
+            Low: 'low',
+            Medium: 'medium',
+            'High (default)': 'high',
+            'Extra High': 'xhigh',
+            Max: 'max',
+        });
+    });
+});
+
+describe('OpenAI GPT model version parsing', () => {
+    it.each([
+        ['gpt-5', { major: 5, minor: 0 }],
+        ['gpt-5.6-sol', { major: 5, minor: 6 }],
+        ['models/gpt-5.4-2026-03-05', { major: 5, minor: 4 }],
+        ['gpt-5.7-pro-20270101', { major: 5, minor: 7 }],
+        ['gpt-6', { major: 6, minor: 0 }],
+    ] as const)('parses %s', (model, expected) => {
+        expect(parseOpenAIGptVersion(model)).toEqual(expected);
+    });
+
+    it('uses numeric GTE comparisons rather than string ordering', () => {
+        expect(isOpenAIGptVersionGTE('gpt-5.10', 5, 6)).toBe(true);
+        expect(isOpenAIGptVersionGTE('gpt-5.2', 5, 6)).toBe(false);
+    });
+
+    it.each([
+        ['gpt-5', { Minimal: 'minimal', Low: 'low', Medium: 'medium', High: 'high' }],
+        ['gpt-5.1', { None: 'none', Low: 'low', Medium: 'medium', High: 'high' }],
+        ['gpt-5.4', { None: 'none', Low: 'low', Medium: 'medium', High: 'high', 'Extra High': 'xhigh' }],
+        [
+            'gpt-5.6-sol',
+            {
+                None: 'none',
+                Low: 'low',
+                Medium: 'medium',
+                High: 'high',
+                'Extra High': 'xhigh',
+                Max: 'max',
+            },
+        ],
+        ['gpt-5-pro', { 'High (only)': 'high' }],
+        ['gpt-5.4-pro', { Medium: 'medium', 'High (default)': 'high', 'Extra High': 'xhigh' }],
+    ] as const)('advertises documented effort levels for %s', (model, expected) => {
+        expect(getOpenAIReasoningEffortLevels(model)).toEqual(expected);
+    });
+});
+
+describe('Gemini model version parsing', () => {
+    it.each([
+        ['gemini-3.5-flash', '3.5'],
+        ['publishers/google/models/gemini-3.1-pro-preview', '3.1'],
+        ['gemini-4-flash', '4'],
+    ])('parses %s', (model, expected) => {
+        expect(getGeminiModelVersion(model)).toBe(expected);
+    });
+
+    it('uses numeric GTE comparisons for future models', () => {
+        expect(isGeminiModelVersionGte('gemini-3.10-flash', '3.5')).toBe(true);
+        expect(isGeminiModelVersionGte('gemini-3.1-pro', '3.5')).toBe(false);
+        expect(isGeminiModelVersionGte('gemini-4-pro', '3.5')).toBe(true);
+    });
+});

--- a/common/src/options/version-parsing.test.ts
+++ b/common/src/options/version-parsing.test.ts
@@ -5,6 +5,7 @@ import {
     getOpenAIReasoningEffortLevels,
     isClaudeVersionGTE,
     isGeminiModelVersionGte,
+    isModelFamilyVersionGTE,
     isOpenAIGptVersionGTE,
     parseClaudeVersion,
     parseOpenAIGptVersion,
@@ -17,6 +18,7 @@ describe('Claude model version parsing', () => {
         ['claude-sonnet-5', { major: 5, minor: 0, variant: 'sonnet' }],
         ['claude-fable-5-20260701', { major: 5, minor: 0, variant: 'fable' }],
         ['publishers/anthropic/models/claude-mythos-5@20260701', { major: 5, minor: 0, variant: 'mythos' }],
+        ['claude-mythos-preview', { major: 5, minor: 0, variant: 'mythos' }],
         ['us.anthropic.claude-opus-4-8-v1:0', { major: 4, minor: 8, variant: 'opus' }],
         ['claude-3-7-sonnet-20250219', { major: 3, minor: 7, variant: 'sonnet' }],
     ] as const)('parses %s', (model, expected) => {
@@ -27,6 +29,10 @@ describe('Claude model version parsing', () => {
         expect(isClaudeVersionGTE('claude-sonnet-5', 4, 7)).toBe(true);
         expect(isClaudeVersionGTE('claude-opus-4-10', 4, 8)).toBe(true);
         expect(isClaudeVersionGTE('claude-sonnet-4-6', 4, 7)).toBe(false);
+    });
+
+    it('does not infer behavior for an unknown Claude family', () => {
+        expect(parseClaudeVersion('claude-unknown-5')).toBeNull();
     });
 
     it.each([
@@ -53,6 +59,7 @@ describe('OpenAI GPT model version parsing', () => {
         ['gpt-5.6-sol', { major: 5, minor: 6 }],
         ['models/gpt-5.4-2026-03-05', { major: 5, minor: 4 }],
         ['gpt-5.7-pro-20270101', { major: 5, minor: 7 }],
+        ['us.openai.gpt-5.6-sol-v1:0', { major: 5, minor: 6 }],
         ['gpt-6', { major: 6, minor: 0 }],
     ] as const)('parses %s', (model, expected) => {
         expect(parseOpenAIGptVersion(model)).toEqual(expected);
@@ -82,6 +89,14 @@ describe('OpenAI GPT model version parsing', () => {
         ['gpt-5.4-pro', { Medium: 'medium', 'High (default)': 'high', 'Extra High': 'xhigh' }],
     ] as const)('advertises documented effort levels for %s', (model, expected) => {
         expect(getOpenAIReasoningEffortLevels(model)).toEqual(expected);
+    });
+});
+
+describe('generic model-family version parsing', () => {
+    it('matches provider-qualified current and future versions', () => {
+        expect(isModelFamilyVersionGTE('us.openai.gpt-5.6-sol-v1:0', 'openai.gpt-', 5, 4)).toBe(true);
+        expect(isModelFamilyVersionGTE('xai.grok-4.10', 'grok-', 4, 3)).toBe(true);
+        expect(isModelFamilyVersionGTE('deepseek.v3.2', 'deepseek.v', 3, 2)).toBe(true);
     });
 });
 

--- a/common/src/options/version-parsing.ts
+++ b/common/src/options/version-parsing.ts
@@ -13,35 +13,6 @@
  */
 
 // ============================================================================
-// Generic Model-Family Version Parsing
-// ============================================================================
-
-/**
- * Check a numeric model-family suffix using major/minor ordering.
- *
- * The family includes the stable part immediately before the version, for
- * example `openai.gpt-`, `xai.grok-`, or `deepseek.v`. This deliberately
- * accepts later versions so new models inherit the newest known behavior.
- */
-export function isModelFamilyVersionGTE(
-    modelString: string,
-    family: string,
-    targetMajor: number,
-    targetMinor: number,
-): boolean {
-    const normalized = modelString.toLowerCase();
-    const familyIndex = normalized.indexOf(family.toLowerCase());
-    if (familyIndex === -1) return false;
-
-    const version = normalized.slice(familyIndex + family.length).match(/^(\d+)(?:[.-](\d+))?/);
-    if (!version) return false;
-
-    const major = Number(version[1]);
-    const minor = Number(version[2] ?? 0);
-    return major > targetMajor || (major === targetMajor && minor >= targetMinor);
-}
-
-// ============================================================================
 // Claude Version Parsing
 // ============================================================================
 

--- a/common/src/options/version-parsing.ts
+++ b/common/src/options/version-parsing.ts
@@ -1,8 +1,8 @@
 /**
- * Version parsing utilities for Claude and Gemini models.
+ * Version parsing utilities for Claude, OpenAI, and Gemini models.
  *
  * Provides version detection helpers that are forward-compatible with future
- * model releases (e.g., Haiku 4.7, Sonnet 4.7, Opus 4.8, Opus 5).
+ * model releases (e.g., Fable 5, Mythos 5, GPT-5.6, and Gemini 3.5).
  *
  * These helpers are used to:
  * - Control option visibility in the UI
@@ -24,8 +24,8 @@ export interface ClaudeVersion {
     major: number;
     /** Minor version number (e.g., 5, 6, 7) */
     minor: number;
-    /** Model variant: opus, sonnet, or haiku */
-    variant: 'opus' | 'sonnet' | 'haiku';
+    /** Model family, for example opus, sonnet, haiku, fable, or mythos. */
+    variant: string;
 }
 
 /**
@@ -43,9 +43,9 @@ export interface ClaudeVersion {
 export function parseClaudeVersion(modelString: string): ClaudeVersion | null {
     // Match pattern: claude-[variant-]-{major}-[optional minor]
     // The minor version is limited to 1-2 digits to avoid matching dates (YYYYMMDD format)
-    const match = modelString.match(/claude-(opus|sonnet|haiku)-?(\d+)(?:-(\d{1,2}))?(?:-|\b)/i);
+    const match = modelString.match(/claude-([a-z][a-z0-9]*)-?(\d+)(?:-(\d{1,2}))?(?:-|\b)/i);
     if (match) {
-        const variant = match[1].toLowerCase() as 'opus' | 'sonnet' | 'haiku';
+        const variant = match[1].toLowerCase();
         const major = parseInt(match[2], 10);
         const minor = match[3] ? parseInt(match[3], 10) : 0;
         return { major, minor, variant };
@@ -56,7 +56,7 @@ export function parseClaudeVersion(modelString: string): ClaudeVersion | null {
     if (fallbackMatch) {
         const major = parseInt(fallbackMatch[1], 10);
         const minor = parseInt(fallbackMatch[2], 10);
-        const variant = fallbackMatch[3].toLowerCase() as 'opus' | 'sonnet' | 'haiku';
+        const variant = fallbackMatch[3].toLowerCase();
         return { major, minor, variant };
     }
 
@@ -89,7 +89,7 @@ export function isClaudeVersionGTE(modelString: string, targetMajor: number, tar
  * Check if a Claude variant model version is greater than or equal to a target version.
  *
  * @param modelString - The model identifier string
- * @param variant - Model variant: "opus" or "sonnet"
+ * @param variant - Model family: "opus" or "sonnet"
  * @param targetMajor - Target major version
  * @param targetMinor - Target minor version
  * @returns true if the model matches the variant and version >= target
@@ -104,6 +104,10 @@ function isClaudeVariantVersionGTE(
     if (!version) return false;
     if (version.variant.toLowerCase() !== variant) return false;
     return version.major > targetMajor || (version.major === targetMajor && version.minor >= targetMinor);
+}
+
+function isClaudeMythosPreview(modelString: string): boolean {
+    return /(?:^|[./])claude-mythos-preview(?:$|[-:@])/i.test(modelString);
 }
 
 /**
@@ -148,7 +152,12 @@ export function requiresAdaptiveThinking(modelString: string): boolean {
  * @returns true if the model supports adaptive thinking
  */
 export function supportsAdaptiveThinking(modelString: string): boolean {
-    return requiresAdaptiveThinking(modelString) || isClaudeVariantVersionGTE(modelString, 'sonnet', 4, 6);
+    return (
+        hasSamplingParameterRestriction(modelString) ||
+        requiresAdaptiveThinking(modelString) ||
+        isClaudeVariantVersionGTE(modelString, 'sonnet', 4, 6) ||
+        isClaudeMythosPreview(modelString)
+    );
 }
 
 /**
@@ -176,7 +185,7 @@ export function isExtendedThinkingDeprecated(modelString: string): boolean {
  * @returns true if extended thinking is removed (returns 400 error)
  */
 export function requiresAdaptiveThinkingOnly(modelString: string): boolean {
-    return hasSamplingParameterRestriction(modelString);
+    return hasSamplingParameterRestriction(modelString) || isClaudeMythosPreview(modelString);
 }
 
 /**
@@ -235,6 +244,9 @@ export function supportsEffort(modelString: string): boolean {
     if (hasSamplingParameterRestriction(modelString)) {
         return true;
     }
+    if (isClaudeMythosPreview(modelString)) {
+        return true;
+    }
     // Opus 4.5+ supports effort
     if (isClaudeVariantVersionGTE(modelString, 'opus', 4, 5)) {
         return true;
@@ -249,13 +261,70 @@ export function supportsEffort(modelString: string): boolean {
 /**
  * Check if a model supports the xhigh effort level.
  *
- * xhigh is only available on Opus 4.7+.
+ * xhigh is available on the sampling-restricted Claude generation and Mythos Preview.
  *
  * @param modelString - The model identifier string
  * @returns true if the model supports xhigh effort
  */
 export function supportsXHighEffort(modelString: string): boolean {
-    return isClaudeVariantVersionGTE(modelString, 'opus', 4, 7);
+    return hasSamplingParameterRestriction(modelString) || isClaudeMythosPreview(modelString);
+}
+
+// ============================================================================
+// OpenAI GPT Version Parsing
+// ============================================================================
+
+export interface OpenAIGptVersion {
+    major: number;
+    minor: number;
+}
+
+/** Parse GPT family versions from bare IDs, snapshots, or provider-qualified paths. */
+export function parseOpenAIGptVersion(modelString: string): OpenAIGptVersion | null {
+    const modelName = modelString.toLowerCase().split('/').pop() ?? modelString.toLowerCase();
+    const match = modelName.match(/^gpt-(\d+)(?:\.(\d+))?(?:-|$)/);
+    if (!match) return null;
+    return { major: Number(match[1]), minor: Number(match[2] ?? '0') };
+}
+
+export function isOpenAIGptVersionGTE(modelString: string, targetMajor: number, targetMinor: number): boolean {
+    const version = parseOpenAIGptVersion(modelString);
+    if (!version) return false;
+    return version.major > targetMajor || (version.major === targetMajor && version.minor >= targetMinor);
+}
+
+export function isOpenAIGptProModel(modelString: string): boolean {
+    const modelName = modelString.toLowerCase().split('/').pop() ?? modelString.toLowerCase();
+    return /^gpt-\d+(?:\.\d+)?-pro(?:-|$)/.test(modelName);
+}
+
+/** Current reasoning-effort metadata, expressed with version thresholds for future GPT releases. */
+export function getOpenAIReasoningEffortLevels(modelString: string): Record<string, string> | null {
+    if (!isOpenAIGptVersionGTE(modelString, 5, 0)) return null;
+
+    if (isOpenAIGptProModel(modelString)) {
+        if (isOpenAIGptVersionGTE(modelString, 5, 2)) {
+            return { Medium: 'medium', 'High (default)': 'high', 'Extra High': 'xhigh' };
+        }
+        return { 'High (only)': 'high' };
+    }
+    if (isOpenAIGptVersionGTE(modelString, 5, 6)) {
+        return {
+            None: 'none',
+            Low: 'low',
+            Medium: 'medium',
+            High: 'high',
+            'Extra High': 'xhigh',
+            Max: 'max',
+        };
+    }
+    if (isOpenAIGptVersionGTE(modelString, 5, 2)) {
+        return { None: 'none', Low: 'low', Medium: 'medium', High: 'high', 'Extra High': 'xhigh' };
+    }
+    if (isOpenAIGptVersionGTE(modelString, 5, 1)) {
+        return { None: 'none', Low: 'low', Medium: 'medium', High: 'high' };
+    }
+    return { Minimal: 'minimal', Low: 'low', Medium: 'medium', High: 'high' };
 }
 
 /**

--- a/common/src/options/version-parsing.ts
+++ b/common/src/options/version-parsing.ts
@@ -13,6 +13,35 @@
  */
 
 // ============================================================================
+// Generic Model-Family Version Parsing
+// ============================================================================
+
+/**
+ * Check a numeric model-family suffix using major/minor ordering.
+ *
+ * The family includes the stable part immediately before the version, for
+ * example `openai.gpt-`, `xai.grok-`, or `deepseek.v`. This deliberately
+ * accepts later versions so new models inherit the newest known behavior.
+ */
+export function isModelFamilyVersionGTE(
+    modelString: string,
+    family: string,
+    targetMajor: number,
+    targetMinor: number,
+): boolean {
+    const normalized = modelString.toLowerCase();
+    const familyIndex = normalized.indexOf(family.toLowerCase());
+    if (familyIndex === -1) return false;
+
+    const version = normalized.slice(familyIndex + family.length).match(/^(\d+)(?:[.-](\d+))?/);
+    if (!version) return false;
+
+    const major = Number(version[1]);
+    const minor = Number(version[2] ?? 0);
+    return major > targetMajor || (major === targetMajor && minor >= targetMinor);
+}
+
+// ============================================================================
 // Claude Version Parsing
 // ============================================================================
 
@@ -24,8 +53,12 @@ export interface ClaudeVersion {
     major: number;
     /** Minor version number (e.g., 5, 6, 7) */
     minor: number;
-    /** Model family, for example opus, sonnet, haiku, fable, or mythos. */
-    variant: string;
+    /** Model family: opus, sonnet, haiku, fable, or mythos. */
+    variant: 'opus' | 'sonnet' | 'haiku' | 'fable' | 'mythos';
+}
+
+function isClaudeVariant(value: string): value is ClaudeVersion['variant'] {
+    return value === 'opus' || value === 'sonnet' || value === 'haiku' || value === 'fable' || value === 'mythos';
 }
 
 /**
@@ -41,22 +74,28 @@ export interface ClaudeVersion {
  * @returns Parsed version info, or null if not parseable
  */
 export function parseClaudeVersion(modelString: string): ClaudeVersion | null {
+    if (/claude-mythos-preview(?:-|\b)/i.test(modelString)) {
+        return { major: 5, minor: 0, variant: 'mythos' };
+    }
+
     // Match pattern: claude-[variant-]-{major}-[optional minor]
     // The minor version is limited to 1-2 digits to avoid matching dates (YYYYMMDD format)
-    const match = modelString.match(/claude-([a-z][a-z0-9]*)-?(\d+)(?:-(\d{1,2}))?(?:-|\b)/i);
+    const match = modelString.match(/claude-(opus|sonnet|haiku|fable|mythos)-?(\d+)(?:-(\d{1,2}))?(?:-|\b)/i);
     if (match) {
         const variant = match[1].toLowerCase();
+        if (!isClaudeVariant(variant)) return null;
         const major = parseInt(match[2], 10);
         const minor = match[3] ? parseInt(match[3], 10) : 0;
         return { major, minor, variant };
     }
 
     // Fallback for older format: claude-3-7-sonnet-20250219
-    const fallbackMatch = modelString.match(/claude-(\d+)-(\d+)-(\w+)/i);
+    const fallbackMatch = modelString.match(/claude-(\d+)-(\d+)-(opus|sonnet|haiku|fable|mythos)(?:-|\b)/i);
     if (fallbackMatch) {
         const major = parseInt(fallbackMatch[1], 10);
         const minor = parseInt(fallbackMatch[2], 10);
         const variant = fallbackMatch[3].toLowerCase();
+        if (!isClaudeVariant(variant)) return null;
         return { major, minor, variant };
     }
 
@@ -106,10 +145,6 @@ function isClaudeVariantVersionGTE(
     return version.major > targetMajor || (version.major === targetMajor && version.minor >= targetMinor);
 }
 
-function isClaudeMythosPreview(modelString: string): boolean {
-    return /(?:^|[./])claude-mythos-preview(?:$|[-:@])/i.test(modelString);
-}
-
 /**
  * Check if a model requires sampling parameter removal (behavior: sampling params removed on Opus 4.7+).
  *
@@ -153,10 +188,9 @@ export function requiresAdaptiveThinking(modelString: string): boolean {
  */
 export function supportsAdaptiveThinking(modelString: string): boolean {
     return (
-        hasSamplingParameterRestriction(modelString) ||
+        isClaudeVersionGTE(modelString, 5, 0) ||
         requiresAdaptiveThinking(modelString) ||
-        isClaudeVariantVersionGTE(modelString, 'sonnet', 4, 6) ||
-        isClaudeMythosPreview(modelString)
+        isClaudeVariantVersionGTE(modelString, 'sonnet', 4, 6)
     );
 }
 
@@ -185,7 +219,7 @@ export function isExtendedThinkingDeprecated(modelString: string): boolean {
  * @returns true if extended thinking is removed (returns 400 error)
  */
 export function requiresAdaptiveThinkingOnly(modelString: string): boolean {
-    return hasSamplingParameterRestriction(modelString) || isClaudeMythosPreview(modelString);
+    return hasSamplingParameterRestriction(modelString);
 }
 
 /**
@@ -244,9 +278,6 @@ export function supportsEffort(modelString: string): boolean {
     if (hasSamplingParameterRestriction(modelString)) {
         return true;
     }
-    if (isClaudeMythosPreview(modelString)) {
-        return true;
-    }
     // Opus 4.5+ supports effort
     if (isClaudeVariantVersionGTE(modelString, 'opus', 4, 5)) {
         return true;
@@ -267,7 +298,7 @@ export function supportsEffort(modelString: string): boolean {
  * @returns true if the model supports xhigh effort
  */
 export function supportsXHighEffort(modelString: string): boolean {
-    return hasSamplingParameterRestriction(modelString) || isClaudeMythosPreview(modelString);
+    return hasSamplingParameterRestriction(modelString);
 }
 
 // ============================================================================
@@ -281,8 +312,7 @@ export interface OpenAIGptVersion {
 
 /** Parse GPT family versions from bare IDs, snapshots, or provider-qualified paths. */
 export function parseOpenAIGptVersion(modelString: string): OpenAIGptVersion | null {
-    const modelName = modelString.toLowerCase().split('/').pop() ?? modelString.toLowerCase();
-    const match = modelName.match(/^gpt-(\d+)(?:\.(\d+))?(?:-|$)/);
+    const match = modelString.toLowerCase().match(/(?:^|[./])(?:openai\.)?gpt-(\d+)(?:\.(\d+))?(?:-|[.:@]|$)/);
     if (!match) return null;
     return { major: Number(match[1]), minor: Number(match[2] ?? '0') };
 }
@@ -294,8 +324,7 @@ export function isOpenAIGptVersionGTE(modelString: string, targetMajor: number, 
 }
 
 export function isOpenAIGptProModel(modelString: string): boolean {
-    const modelName = modelString.toLowerCase().split('/').pop() ?? modelString.toLowerCase();
-    return /^gpt-\d+(?:\.\d+)?-pro(?:-|$)/.test(modelName);
+    return /(?:^|[./])(?:openai\.)?gpt-\d+(?:\.\d+)?-pro(?:-|[.:@]|$)/i.test(modelString);
 }
 
 /** Current reasoning-effort metadata, expressed with version thresholds for future GPT releases. */

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -101,7 +101,7 @@ export interface VertexAIGeminiOptions {
     presence_penalty?: number;
     frequency_penalty?: number;
     seed?: number;
-    effort?: 'low' | 'medium' | 'high';
+    effort?: 'minimal' | 'low' | 'medium' | 'high';
     include_thoughts?: boolean;
     thinking_budget_tokens?: number;
     thinking_level?: ThinkingLevel;
@@ -380,9 +380,12 @@ function getGeminiEffortOptions(model: string): Record<string, string> {
         return { High: 'high' };
     }
     if (model.includes('gemini-3.1-flash-image')) {
-        return { Low: 'low', High: 'high' };
+        return { Minimal: 'minimal', High: 'high' };
     }
-    return { Low: 'low', Medium: 'medium', High: 'high' };
+    if (model.includes('gemini-3.1-pro')) {
+        return { Low: 'low', Medium: 'medium', High: 'high' };
+    }
+    return { Minimal: 'minimal', Low: 'low', Medium: 'medium', High: 'high' };
 }
 
 function getGeminiThinkingOptionItems(model: string): ModelOptionInfoItem[] {

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -417,6 +417,16 @@ export interface CompletionChunkObject {
 }
 
 /**
+ * Internal provider stream contract.
+ *
+ * Native protocol adapters attach a request-local finalizer when conversation
+ * replay requires information that cannot be reconstructed from generic results.
+ */
+export interface DriverCompletionStream extends AsyncIterable<CompletionChunkObject> {
+    finalizeConversation?: () => unknown | Promise<unknown>;
+}
+
+/**
  * Tool definition for LLM tool use.
  * The input_schema uses a permissive type to support both:
  * - AJV's JSONSchemaType<T> for type-safe schema generation

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -707,7 +707,7 @@ export enum OptionType {
     string_list = 'string_list',
 }
 
-export type ReasoningEffort = 'low' | 'medium' | 'high';
+export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 // ============== Model Options ===============
 

--- a/core/src/CompletionStream.ts
+++ b/core/src/CompletionStream.ts
@@ -2,6 +2,7 @@ import {
     type CompletionChunkObject,
     type CompletionResult,
     type CompletionStream,
+    type DriverCompletionStream,
     type DriverOptions,
     type ExecutionOptions,
     type ExecutionResponse,
@@ -108,12 +109,11 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
         let promptNewTokens: number | undefined;
         const httpScope = this.driver.createExecutionHttpAgentScope(this.options);
         let sourceIterator: AsyncIterator<CompletionChunkObject> | undefined;
+        let stream: DriverCompletionStream | undefined;
         let streamCompleted = false;
 
         try {
-            const stream = await httpScope.run(() =>
-                this.driver.requestTextCompletionStream(this.prompt, this.options),
-            );
+            stream = await httpScope.run(() => this.driver.requestTextCompletionStream(this.prompt, this.options));
             const iterator = stream[Symbol.asyncIterator]();
             sourceIterator = iterator;
             while (true) {
@@ -315,12 +315,9 @@ export class DefaultCompletionStream<PromptT = unknown> implements CompletionStr
         };
 
         // Build conversation context for multi-turn support
-        const conversation = this.driver.buildStreamingConversation(
-            this.prompt,
-            accumulatedResults,
-            toolUseArray,
-            this.options,
-        );
+        const conversation = stream?.finalizeConversation
+            ? await stream.finalizeConversation()
+            : this.driver.buildStreamingConversation(this.prompt, accumulatedResults, toolUseArray, this.options);
         if (conversation !== undefined) {
             this.completion.conversation = conversation;
         }

--- a/core/src/Driver.ts
+++ b/core/src/Driver.ts
@@ -7,9 +7,9 @@
 import {
     type AIModel,
     type Completion,
-    type CompletionChunkObject,
     type CompletionStream,
     type DataSource,
+    type DriverCompletionStream,
     type DriverOptions,
     type EmbeddingsOptions,
     type EmbeddingsResult,
@@ -427,10 +427,7 @@ export abstract class AbstractDriver<OptionsT extends DriverOptions = DriverOpti
 
     abstract requestTextCompletion(prompt: PromptT, options: ExecutionOptions): Promise<Completion>;
 
-    abstract requestTextCompletionStream(
-        prompt: PromptT,
-        options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>>;
+    abstract requestTextCompletionStream(prompt: PromptT, options: ExecutionOptions): Promise<DriverCompletionStream>;
 
     async requestImageGeneration(_prompt: PromptT, _options: ExecutionOptions): Promise<Completion> {
         throw new Error('Image generation not implemented.');

--- a/core/src/conversation-utils.ts
+++ b/core/src/conversation-utils.ts
@@ -30,6 +30,8 @@ export interface ConversationMeta {
  * Options for stripping functions
  */
 export interface StripOptions {
+    /** Native protocol unit that generic cleanup must not modify. */
+    preserveSubtree?: (value: unknown) => boolean;
     /**
      * Number of turns to keep images before stripping.
      * - Infinity or undefined: Never strip (default — callers must opt in)
@@ -145,6 +147,19 @@ function isSerializedBedrockVideoBlock(obj: unknown): boolean {
     if (!src.bytes || typeof src.bytes !== 'object') return false;
     const bytes = src.bytes as Record<string, unknown>;
     return typeof bytes._base64 === 'string';
+}
+
+function isBedrockRedactedReasoningBlock(obj: unknown): boolean {
+    if (typeof obj !== 'object' || obj === null) return false;
+    const reasoningContent = (obj as Record<string, unknown>).reasoningContent;
+    if (typeof reasoningContent !== 'object' || reasoningContent === null) return false;
+    const redacted = (reasoningContent as Record<string, unknown>).redactedContent;
+    if (redacted instanceof Uint8Array) return true;
+    return (
+        typeof redacted === 'object' &&
+        redacted !== null &&
+        typeof (redacted as Record<string, unknown>)._base64 === 'string'
+    );
 }
 
 /**
@@ -359,6 +374,10 @@ export function deserializeBinaryFromStorage(obj: unknown): unknown {
 function stripBinaryFromConversationInternal(obj: unknown): unknown {
     if (obj === null || obj === undefined) return obj;
 
+    if (isBedrockRedactedReasoningBlock(obj)) {
+        return serializeBinaryForStorage(obj);
+    }
+
     // Handle Uint8Array directly
     if (obj instanceof Uint8Array) {
         return IMAGE_PLACEHOLDER;
@@ -427,11 +446,15 @@ export function stripBase64ImagesFromConversation(obj: unknown, options?: StripO
         return obj;
     }
 
-    return stripBase64ImagesFromConversationInternal(obj);
+    return stripBase64ImagesFromConversationInternal(obj, options?.preserveSubtree);
 }
 
-function stripBase64ImagesFromConversationInternal(obj: unknown): unknown {
+function stripBase64ImagesFromConversationInternal(
+    obj: unknown,
+    preserveSubtree?: (value: unknown) => boolean,
+): unknown {
     if (obj === null || obj === undefined) return obj;
+    if (preserveSubtree?.(obj)) return obj;
 
     // Handle base64 data URL string directly
     if (typeof obj === 'string' && obj.startsWith('data:image/') && obj.includes(';base64,')) {
@@ -456,7 +479,7 @@ function stripBase64ImagesFromConversationInternal(obj: unknown): unknown {
             if (isAnthropicBase64DocumentBlock(item)) {
                 return { type: 'text', text: DOCUMENT_PLACEHOLDER };
             }
-            return stripBase64ImagesFromConversationInternal(item);
+            return stripBase64ImagesFromConversationInternal(item, preserveSubtree);
         });
     }
 
@@ -467,7 +490,7 @@ function stripBase64ImagesFromConversationInternal(obj: unknown): unknown {
             if (key === META_KEY) {
                 result[key] = value;
             } else {
-                result[key] = stripBase64ImagesFromConversationInternal(value);
+                result[key] = stripBase64ImagesFromConversationInternal(value, preserveSubtree);
             }
         }
         return result;
@@ -513,7 +536,9 @@ export function truncateLargeTextInConversation(obj: unknown, options?: StripOpt
         const messages = getConversationMessages(obj);
         if (messages && messages.length > keepRecent) {
             const cutoff = messages.length - keepRecent;
-            const truncated = messages.map((m, i) => (i < cutoff ? truncateLargeTextInternal(m, maxChars) : m));
+            const truncated = messages.map((m, i) =>
+                i < cutoff ? truncateLargeTextInternal(m, maxChars, options?.preserveSubtree) : m,
+            );
             return setConversationMessages(obj, truncated);
         }
         // No identifiable messages array, or short conversation: leave it full.
@@ -521,7 +546,7 @@ export function truncateLargeTextInConversation(obj: unknown, options?: StripOpt
     }
 
     // Legacy path: truncate every large string in the conversation.
-    return truncateLargeTextInternal(obj, maxChars);
+    return truncateLargeTextInternal(obj, maxChars, options?.preserveSubtree);
 }
 
 /**
@@ -589,8 +614,13 @@ function shouldPreserveMediaPayload(obj: unknown): boolean {
     return false;
 }
 
-function truncateLargeTextInternal(obj: unknown, maxChars: number): unknown {
+function truncateLargeTextInternal(
+    obj: unknown,
+    maxChars: number,
+    preserveSubtree?: (value: unknown) => boolean,
+): unknown {
     if (obj === null || obj === undefined) return obj;
+    if (preserveSubtree?.(obj)) return obj;
 
     // Truncate large strings
     if (typeof obj === 'string') {
@@ -615,7 +645,7 @@ function truncateLargeTextInternal(obj: unknown, maxChars: number): unknown {
     }
 
     if (Array.isArray(obj)) {
-        return obj.map((item) => truncateLargeTextInternal(item, maxChars));
+        return obj.map((item) => truncateLargeTextInternal(item, maxChars, preserveSubtree));
     }
 
     if (typeof obj === 'object') {
@@ -625,16 +655,35 @@ function truncateLargeTextInternal(obj: unknown, maxChars: number): unknown {
         const result: Record<string, unknown> = {};
         for (const [key, value] of Object.entries(obj)) {
             // Preserve metadata without truncation
-            if (key === META_KEY) {
+            if (key === META_KEY || isProtocolIdentifierField(key)) {
                 result[key] = value;
             } else {
-                result[key] = truncateLargeTextInternal(value, maxChars);
+                result[key] = truncateLargeTextInternal(value, maxChars, preserveSubtree);
             }
         }
         return result;
     }
 
     return obj;
+}
+
+const PROTOCOL_IDENTIFIER_FIELDS = new Set([
+    'role',
+    'type',
+    'id',
+    'name',
+    'modelId',
+    'tool_use_id',
+    'toolUseId',
+    'call_id',
+    'signature',
+    'thoughtSignature',
+    'encrypted_content',
+    '_base64',
+]);
+
+function isProtocolIdentifierField(key: string): boolean {
+    return PROTOCOL_IDENTIFIER_FIELDS.has(key);
 }
 
 const HEARTBEAT_OPEN_TAG = '<heartbeat>';
@@ -669,11 +718,12 @@ export function stripHeartbeatsFromConversation(obj: unknown, options?: StripOpt
         return obj;
     }
 
-    return stripHeartbeatsInternal(obj);
+    return stripHeartbeatsInternal(obj, options?.preserveSubtree);
 }
 
-function stripHeartbeatsInternal(obj: unknown): unknown {
+function stripHeartbeatsInternal(obj: unknown, preserveSubtree?: (value: unknown) => boolean): unknown {
     if (obj === null || obj === undefined) return obj;
+    if (preserveSubtree?.(obj)) return obj;
 
     // Replace heartbeat-tagged strings with placeholder
     if (typeof obj === 'string') {
@@ -684,7 +734,7 @@ function stripHeartbeatsInternal(obj: unknown): unknown {
     }
 
     if (Array.isArray(obj)) {
-        return obj.map((item) => stripHeartbeatsInternal(item));
+        return obj.map((item) => stripHeartbeatsInternal(item, preserveSubtree));
     }
 
     if (typeof obj === 'object') {
@@ -694,7 +744,7 @@ function stripHeartbeatsInternal(obj: unknown): unknown {
             if (key === META_KEY) {
                 result[key] = value;
             } else {
-                result[key] = stripHeartbeatsInternal(value);
+                result[key] = stripHeartbeatsInternal(value, preserveSubtree);
             }
         }
         return result;

--- a/drivers/src/anthropic/index.ts
+++ b/drivers/src/anthropic/index.ts
@@ -60,7 +60,7 @@ export class AnthropicDriver extends AbstractDriver<AnthropicDriverOptions, Clau
         if (model_options?._option_id !== undefined && model_options?._option_id !== 'anthropic-claude') {
             this.logger.debug({ options: options.model_options }, 'Unexpected option id');
         }
-        return executeClaudeCompletion(this.client, prompt, options);
+        return executeClaudeCompletion(this.client, prompt, options, this.logger, this.provider);
     }
 
     async requestTextCompletionStream(
@@ -71,7 +71,7 @@ export class AnthropicDriver extends AbstractDriver<AnthropicDriverOptions, Clau
         if (model_options?._option_id !== undefined && model_options?._option_id !== 'anthropic-claude') {
             this.logger.debug({ options: options.model_options }, 'Unexpected option id');
         }
-        return streamClaudeCompletion(this.client, prompt, options);
+        return streamClaudeCompletion(this.client, prompt, options, this.logger, this.provider);
     }
 
     async listModels(_params?: ModelSearchPayload): Promise<AIModel[]> {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -67,6 +67,7 @@ import { AbstractDriver } from '@llumiverse/core/driver';
 import { formatNovaPrompt, type NovaMessagesPrompt } from '@llumiverse/core/formatters';
 import { mergeDriverHttpTimeoutOptions, resolveDriverHttpTimeouts } from '@llumiverse/core/http-agent';
 import { LRUCache } from 'mnemonist';
+import { logClaudeTruncation } from '../shared/claude-messages.js';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import {
@@ -741,6 +742,10 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         let resultText = '';
         let reasoning = '';
 
+        if (options?.model.toLowerCase().includes('claude')) {
+            logClaudeTruncation(this.logger, result.stopReason, { provider: this.provider, model: options.model });
+        }
+
         if (result.output?.message?.content) {
             for (const content of result.output.message.content) {
                 // Get text output
@@ -892,6 +897,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         if (result.messageStop) {
             stop_reason = result.messageStop.stopReason ?? '';
+            if (options?.model.toLowerCase().includes('claude')) {
+                logClaudeTruncation(this.logger, stop_reason, { provider: this.provider, model: options.model });
+            }
         }
 
         if (result.metadata) {

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -67,7 +67,7 @@ import { AbstractDriver } from '@llumiverse/core/driver';
 import { formatNovaPrompt, type NovaMessagesPrompt } from '@llumiverse/core/formatters';
 import { mergeDriverHttpTimeoutOptions, resolveDriverHttpTimeouts } from '@llumiverse/core/http-agent';
 import { LRUCache } from 'mnemonist';
-import { logClaudeTruncation } from '../shared/claude-messages.js';
+import { logClaudeTruncation } from '../shared/claude-stop-reason.js';
 import { resolveClaudeThinking } from '../shared/claude-thinking.js';
 import { truncateBinaryForDebug, uint8ArrayToBase64ForDebug } from '../shared/debug-prompt.js';
 import {
@@ -250,15 +250,17 @@ function collectBedrockNativeStreamBlock(blocks: Map<number, ContentBlock>, even
 function finalizeBedrockNativeBlocks(blocks: Map<number, ContentBlock>): ContentBlock[] {
     return [...blocks.entries()]
         .sort(([left], [right]) => left - right)
-        .map(([, block]) => {
+        .flatMap(([, block]) => {
             if ('toolUse' in block && block.toolUse && typeof block.toolUse.input === 'string') {
                 try {
-                    return { toolUse: { ...block.toolUse, input: JSON.parse(block.toolUse.input) as JSONObject } };
+                    return [{ toolUse: { ...block.toolUse, input: JSON.parse(block.toolUse.input) as JSONObject } }];
                 } catch {
-                    return { toolUse: { ...block.toolUse, input: {} } };
+                    // Invalid streamed JSON is not a complete tool call. Do not put it in native
+                    // replay, where it would require a tool_result the workflow cannot produce.
+                    return [];
                 }
             }
-            return block;
+            return [block];
         });
 }
 

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -134,9 +134,17 @@ export function excludesBedrockReasoningReplay(model: string): boolean {
     return /^(?:(?:us|eu|apac)\.)?deepseek\.r1-v1(?::\d+)?$/.test(modelId);
 }
 
-function hasBedrockReasoningContent(conversation: ConverseRequest): boolean {
+function isBedrockReasoningBlock(value: unknown): boolean {
+    return typeof value === 'object' && value !== null && 'reasoningContent' in value;
+}
+
+function hasBedrockReasoningSignature(conversation: ConverseRequest): boolean {
     return !!conversation.messages?.some((message) =>
-        message.content?.some((block) => 'reasoningContent' in block && !!block.reasoningContent),
+        message.content?.some(
+            (block) =>
+                block.reasoningContent?.reasoningText?.signature !== undefined &&
+                block.reasoningContent.reasoningText.signature.length > 0,
+        ),
     );
 }
 
@@ -158,7 +166,9 @@ function finalizeBedrockConversation(
     completed = incrementConversationTurn(completed) as ConverseRequest;
     const currentTurn = getConversationMeta(completed).turnNumber;
 
-    if (hasBedrockReasoningContent(completed)) {
+    // Bedrock signatures hash every prior message. Applying any caller cleanup to a signed
+    // chain makes the next Converse request fail, so only storage-safe serialization is valid.
+    if (hasBedrockReasoningSignature(completed)) {
         return stripBinaryFromConversation(completed, {
             keepForTurns: Infinity,
             currentTurn,
@@ -169,6 +179,7 @@ function finalizeBedrockConversation(
         keepForTurns: options.stripImagesAfterTurns ?? Infinity,
         currentTurn,
         textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree: isBedrockReasoningBlock,
     };
     let processed = stripBinaryFromConversation(completed, stripOptions);
     processed = truncateLargeTextInConversation(processed, stripOptions);

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -31,6 +31,7 @@ import {
     type CompletionChunkObject,
     type CompletionResult,
     type DataSource,
+    type DriverCompletionStream,
     type DriverOptions,
     deserializeBinaryFromStorage,
     type EmbeddingsOptions,
@@ -43,6 +44,7 @@ import {
     type HttpTimeoutOptions,
     incrementConversationTurn,
     isClaudeVersionGTE,
+    type JSONObject,
     LlumiverseError,
     type LlumiverseErrorContext,
     type ModelOptions,
@@ -119,10 +121,144 @@ function converseFinishReason(reason: string | undefined) {
         case 'end_turn':
             return 'stop';
         case 'max_tokens':
+        case 'model_context_window_exceeded':
             return 'length';
         default:
             return reason;
     }
+}
+
+export function excludesBedrockReasoningReplay(model: string): boolean {
+    const modelId = model.toLowerCase().split('/').pop() ?? '';
+    return /^(?:(?:us|eu|apac)\.)?deepseek\.r1-v1(?::\d+)?$/.test(modelId);
+}
+
+function hasBedrockReasoningContent(conversation: ConverseRequest): boolean {
+    return !!conversation.messages?.some((message) =>
+        message.content?.some((block) => 'reasoningContent' in block && !!block.reasoningContent),
+    );
+}
+
+function finalizeBedrockConversation(
+    conversation: ConverseRequest,
+    assistantMessage: Message,
+    options: ExecutionOptions,
+): ConverseRequest {
+    const replayMessage = excludesBedrockReasoningReplay(options.model)
+        ? {
+              ...assistantMessage,
+              content: assistantMessage.content?.filter((block) => !('reasoningContent' in block)),
+          }
+        : assistantMessage;
+    let completed = updateConversation(conversation, {
+        messages: [replayMessage],
+        modelId: conversation.modelId,
+    });
+    completed = incrementConversationTurn(completed) as ConverseRequest;
+    const currentTurn = getConversationMeta(completed).turnNumber;
+
+    if (hasBedrockReasoningContent(completed)) {
+        return stripBinaryFromConversation(completed, {
+            keepForTurns: Infinity,
+            currentTurn,
+        }) as ConverseRequest;
+    }
+
+    const stripOptions = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+    };
+    let processed = stripBinaryFromConversation(completed, stripOptions);
+    processed = truncateLargeTextInConversation(processed, stripOptions);
+    processed = stripHeartbeatsFromConversation(processed, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+    });
+    return processed as ConverseRequest;
+}
+
+function appendBytes(left: Uint8Array | undefined, right: Uint8Array): Uint8Array {
+    if (!left?.length) return new Uint8Array(right);
+    const combined = new Uint8Array(left.length + right.length);
+    combined.set(left);
+    combined.set(right, left.length);
+    return combined;
+}
+
+function collectBedrockNativeStreamBlock(blocks: Map<number, ContentBlock>, event: ConverseStreamOutput): void {
+    const start = event.contentBlockStart;
+    if (start?.start?.toolUse) {
+        blocks.set(start.contentBlockIndex ?? -1, {
+            toolUse: {
+                toolUseId: start.start.toolUse.toolUseId,
+                name: start.start.toolUse.name,
+                input: '' as unknown as JSONObject,
+            },
+        });
+    } else if (start?.start) {
+        const reasoningStart = start.start as unknown as {
+            reasoningContent?: { redactedContent?: Uint8Array };
+        };
+        if (reasoningStart.reasoningContent?.redactedContent) {
+            blocks.set(start.contentBlockIndex ?? -1, {
+                reasoningContent: { redactedContent: new Uint8Array(reasoningStart.reasoningContent.redactedContent) },
+            });
+        }
+    }
+
+    const blockDelta = event.contentBlockDelta;
+    const delta = blockDelta?.delta;
+    if (!delta) return;
+    const index = blockDelta.contentBlockIndex ?? -1;
+    if (delta.text !== undefined) {
+        const current = blocks.get(index);
+        const existingText = current && 'text' in current ? (current.text ?? '') : '';
+        blocks.set(index, { text: existingText + delta.text });
+    } else if (delta.toolUse?.input !== undefined) {
+        const current = blocks.get(index);
+        if (current && 'toolUse' in current && current.toolUse) {
+            current.toolUse.input =
+                `${String(current.toolUse.input ?? '')}${delta.toolUse.input}` as unknown as JSONObject;
+        }
+    } else if (delta.reasoningContent) {
+        const reasoning = delta.reasoningContent;
+        const current = blocks.get(index);
+        const existing =
+            current && 'reasoningContent' in current
+                ? (current.reasoningContent as {
+                      reasoningText?: { text: string; signature?: string };
+                      redactedContent?: Uint8Array;
+                  })
+                : undefined;
+        if (reasoning.redactedContent) {
+            blocks.set(index, {
+                reasoningContent: {
+                    redactedContent: appendBytes(existing?.redactedContent, reasoning.redactedContent),
+                },
+            });
+        } else {
+            const reasoningText = existing?.reasoningText ?? { text: '' };
+            if (reasoning.text) reasoningText.text += reasoning.text;
+            if (reasoning.signature) reasoningText.signature = (reasoningText.signature ?? '') + reasoning.signature;
+            blocks.set(index, { reasoningContent: { reasoningText } });
+        }
+    }
+}
+
+function finalizeBedrockNativeBlocks(blocks: Map<number, ContentBlock>): ContentBlock[] {
+    return [...blocks.entries()]
+        .sort(([left], [right]) => left - right)
+        .map(([, block]) => {
+            if ('toolUse' in block && block.toolUse && typeof block.toolUse.input === 'string') {
+                try {
+                    return { toolUse: { ...block.toolUse, input: JSON.parse(block.toolUse.input) as JSONObject } };
+                } catch {
+                    return { toolUse: { ...block.toolUse, input: {} } };
+                }
+            }
+            return block;
+        });
 }
 
 function withBedrockRuntimeScope<T>(iterable: AsyncIterable<T>, scope: BedrockRuntimeExecutorScope): AsyncIterable<T> {
@@ -973,7 +1109,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
 
         // Deserialize any base64-encoded binary data back to Uint8Array before API call
         const incomingConversation = deserializeBinaryFromStorage(options.conversation) as ConverseRequest;
-        let conversation = updateConversation(incomingConversation, conversePrompt);
+        const conversation = updateConversation(incomingConversation, conversePrompt);
 
         const payload = this.preparePayload(conversation, options);
         const executorScope = this.getScopedNonStreamingExecutor(options);
@@ -987,20 +1123,8 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             executorScope.close();
         }
 
-        // Strip reasoningContent from assistant messages before storing in conversation
-        // (DeepSeek R1 returns reasoning blocks but rejects them in subsequent user turns)
         const assistantMsg = res.output?.message ?? { content: [{ text: '' }], role: 'assistant' };
-        if (assistantMsg.content) {
-            assistantMsg.content = assistantMsg.content.filter((c) => !('reasoningContent' in c));
-        }
-
-        conversation = updateConversation(conversation, {
-            messages: [assistantMsg],
-            modelId: conversePrompt.modelId,
-        });
-
-        // Increment turn counter for deferred stripping
-        conversation = incrementConversationTurn(conversation) as ConverseRequest;
+        const processedConversation = finalizeBedrockConversation(conversation, assistantMsg, options);
 
         let tool_use: ToolUse<unknown>[] | undefined;
         //Get tool requests, we check tool use regardless of finish reason, as you can hit length and still get a valid response.
@@ -1018,24 +1142,6 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         if (tool_use && tool_use.length === 0) {
             tool_use = undefined;
         }
-
-        // Strip/serialize binary data based on options.stripImagesAfterTurns
-        const currentTurn = getConversationMeta(conversation).turnNumber;
-        const stripOptions = {
-            keepForTurns: options.stripImagesAfterTurns ?? Infinity,
-            currentTurn,
-            textMaxTokens: options.stripTextMaxTokens,
-        };
-        let processedConversation = stripBinaryFromConversation(conversation, stripOptions);
-
-        // Truncate large text content if configured
-        processedConversation = truncateLargeTextInConversation(processedConversation, stripOptions);
-
-        // Strip old heartbeat status messages
-        processedConversation = stripHeartbeatsFromConversation(processedConversation, {
-            keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
-            currentTurn,
-        });
 
         const completion = {
             ...this.getExtractedExecution(res, conversePrompt, options),
@@ -1159,7 +1265,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
     async requestTextCompletionStream(
         prompt: BedrockPrompt,
         options: ExecutionOptions,
-    ): Promise<AsyncIterable<CompletionChunkObject>> {
+    ): Promise<DriverCompletionStream> {
         // Handle Twelvelabs Pegasus models
         if (options.model.includes('twelvelabs.pegasus')) {
             return this.requestTwelvelabsPegasusCompletionStream(prompt as TwelvelabsPegasusRequest, options);
@@ -1187,10 +1293,20 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                 }
 
                 const streamingToolBlocks = new Map<number, { id: string; name: string }>();
+                const nativeBlocks = new Map<number, ContentBlock>();
                 const transformedStream = transformAsyncIterator(stream, (streamSegment: ConverseStreamOutput) => {
+                    collectBedrockNativeStreamBlock(nativeBlocks, streamSegment);
                     return this.getExtractedStream(streamSegment, conversePrompt, options, streamingToolBlocks);
                 });
-                return withBedrockRuntimeScope(transformedStream, executorScope);
+                const scoped = withBedrockRuntimeScope(transformedStream, executorScope);
+                return Object.assign(scoped, {
+                    finalizeConversation: () =>
+                        finalizeBedrockConversation(
+                            conversation,
+                            { role: 'assistant', content: finalizeBedrockNativeBlocks(nativeBlocks) },
+                            options,
+                        ),
+                });
             })
             .catch((err) => {
                 executorScope.close();

--- a/drivers/src/bedrock/reasoning-replay.test.ts
+++ b/drivers/src/bedrock/reasoning-replay.test.ts
@@ -71,10 +71,17 @@ describe('Bedrock native reasoning replay', () => {
             {
                 contentBlockStart: {
                     contentBlockIndex: 3,
+                    start: { toolUse: { toolUseId: 'call-truncated', name: 'lookup' } },
+                },
+            },
+            { contentBlockDelta: { contentBlockIndex: 3, delta: { toolUse: { input: '{"city":' } } } },
+            {
+                contentBlockStart: {
+                    contentBlockIndex: 4,
                     start: { reasoningContent: { redactedContent: new Uint8Array([9, 8]) } },
                 },
             } as unknown as ConverseStreamOutput,
-            { messageStop: { stopReason: 'tool_use' } },
+            { messageStop: { stopReason: 'max_tokens' } },
             { metadata: { usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 }, metrics: { latencyMs: 1 } } },
         ];
         const driver = new BedrockDriver({ region: 'us-east-1' });
@@ -108,6 +115,12 @@ describe('Bedrock native reasoning replay', () => {
                 },
             ]),
         });
+        const persistedContent = (conversation as ConverseRequest).messages?.at(-1)?.content;
+        expect(persistedContent).not.toContainEqual(
+            expect.objectContaining({
+                toolUse: expect.objectContaining({ toolUseId: 'call-truncated' }),
+            }),
+        );
     });
 
     it('keeps the DeepSeek replay exclusion narrow', () => {

--- a/drivers/src/bedrock/reasoning-replay.test.ts
+++ b/drivers/src/bedrock/reasoning-replay.test.ts
@@ -1,0 +1,119 @@
+import type { ConverseRequest, ConverseResponse, ConverseStreamOutput } from '@aws-sdk/client-bedrock-runtime';
+import { describe, expect, it, vi } from 'vitest';
+import { BedrockDriver, excludesBedrockReasoningReplay } from './index.js';
+
+const MODEL = 'anthropic.claude-sonnet-4-6-v1:0';
+
+function prompt(): ConverseRequest {
+    return { modelId: MODEL, messages: [{ role: 'user', content: [{ text: 'question' }] }] };
+}
+
+describe('Bedrock native reasoning replay', () => {
+    it('preserves reasoning signatures and redacted bytes across a JSON roundtrip', async () => {
+        const redacted = new Uint8Array([1, 2, 255]);
+        const response: ConverseResponse = {
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [
+                        { reasoningContent: { reasoningText: { text: 'plan', signature: 'signed-chain' } } },
+                        { reasoningContent: { redactedContent: redacted } },
+                        { text: 'answer' },
+                    ],
+                },
+            },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            metrics: { latencyMs: 1 },
+        };
+        const converse = vi.fn(async (_request: ConverseRequest) => response);
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        Object.defineProperty(driver, 'getExecutor', {
+            value: () => ({ converse, destroy: vi.fn() }),
+        });
+
+        const first = await driver.requestTextCompletion(prompt(), {
+            model: MODEL,
+            stripTextMaxTokens: 1,
+            stripImagesAfterTurns: 0,
+        });
+        expect(first.result).toEqual([{ type: 'text', value: 'answer' }]);
+        const persisted = JSON.parse(JSON.stringify(first.conversation));
+
+        await driver.requestTextCompletion(
+            { modelId: MODEL, messages: [{ role: 'user', content: [{ text: 'continue' }] }] },
+            { model: MODEL, conversation: persisted },
+        );
+        const replay = converse.mock.calls[1][0] as ConverseRequest;
+        expect(replay.messages).toContainEqual(response.output?.message);
+        expect(replay.messages?.[1]?.content?.[1].reasoningContent?.redactedContent).toEqual(redacted);
+    });
+
+    it('reconstructs fragmented reasoning, text, redaction, and tool blocks by native index', async () => {
+        const events: ConverseStreamOutput[] = [
+            { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'plan ' } } } },
+            { contentBlockDelta: { contentBlockIndex: 0, delta: { reasoningContent: { text: 'more' } } } },
+            {
+                contentBlockDelta: {
+                    contentBlockIndex: 0,
+                    delta: { reasoningContent: { signature: 'stream-signature' } },
+                },
+            },
+            { contentBlockDelta: { contentBlockIndex: 1, delta: { text: 'answer' } } },
+            {
+                contentBlockStart: {
+                    contentBlockIndex: 2,
+                    start: { toolUse: { toolUseId: 'call-1', name: 'lookup' } },
+                },
+            },
+            { contentBlockDelta: { contentBlockIndex: 2, delta: { toolUse: { input: '{"city":' } } } },
+            { contentBlockDelta: { contentBlockIndex: 2, delta: { toolUse: { input: '"Paris"}' } } } },
+            {
+                contentBlockStart: {
+                    contentBlockIndex: 3,
+                    start: { reasoningContent: { redactedContent: new Uint8Array([9, 8]) } },
+                },
+            } as unknown as ConverseStreamOutput,
+            { messageStop: { stopReason: 'tool_use' } },
+            { metadata: { usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 }, metrics: { latencyMs: 1 } } },
+        ];
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        Object.defineProperty(driver, 'getExecutor', {
+            value: () => ({
+                converseStream: vi.fn(async () => ({
+                    stream: (async function* () {
+                        for (const event of events) yield event;
+                    })(),
+                })),
+                destroy: vi.fn(),
+            }),
+        });
+
+        const stream = await driver.requestTextCompletionStream(prompt(), { model: MODEL });
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.();
+
+        expect(results).toEqual([{ type: 'text', value: 'answer' }]);
+        expect(conversation).toMatchObject({
+            messages: expect.arrayContaining([
+                {
+                    role: 'assistant',
+                    content: [
+                        { reasoningContent: { reasoningText: { text: 'plan more', signature: 'stream-signature' } } },
+                        { text: 'answer' },
+                        { toolUse: { toolUseId: 'call-1', name: 'lookup', input: { city: 'Paris' } } },
+                        { reasoningContent: { redactedContent: { _base64: 'CQg=' } } },
+                    ],
+                },
+            ]),
+        });
+    });
+
+    it('keeps the DeepSeek replay exclusion narrow', () => {
+        expect(excludesBedrockReasoningReplay('deepseek.r1-v1:0')).toBe(true);
+        expect(excludesBedrockReasoningReplay('us.deepseek.r1-v1:0')).toBe(true);
+        expect(excludesBedrockReasoningReplay('deepseek.v3-v1:0')).toBe(false);
+        expect(excludesBedrockReasoningReplay('vendor.deepseek-r1-compatible')).toBe(false);
+    });
+});

--- a/drivers/src/bedrock/reasoning-replay.test.ts
+++ b/drivers/src/bedrock/reasoning-replay.test.ts
@@ -45,6 +45,7 @@ describe('Bedrock native reasoning replay', () => {
             { model: MODEL, conversation: persisted },
         );
         const replay = converse.mock.calls[1][0] as ConverseRequest;
+        expect(replay.messages?.[0]?.content?.[0]?.text).toBe('question');
         expect(replay.messages).toContainEqual(response.output?.message);
         expect(replay.messages?.[1]?.content?.[1].reasoningContent?.redactedContent).toEqual(redacted);
     });
@@ -121,6 +122,37 @@ describe('Bedrock native reasoning replay', () => {
                 toolUse: expect.objectContaining({ toolUseId: 'call-truncated' }),
             }),
         );
+    });
+
+    it('applies caller stripping to unsigned reasoning without modifying the reasoning block', async () => {
+        const reasoningContent = { reasoningText: { text: 'unsigned reasoning text' } };
+        const response: ConverseResponse = {
+            output: {
+                message: {
+                    role: 'assistant',
+                    content: [{ reasoningContent }, { text: 'answer' }],
+                },
+            },
+            stopReason: 'end_turn',
+            usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+            metrics: { latencyMs: 1 },
+        };
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        Object.defineProperty(driver, 'getExecutor', {
+            value: () => ({ converse: vi.fn(async () => response), destroy: vi.fn() }),
+        });
+
+        const result = await driver.requestTextCompletion(
+            {
+                modelId: MODEL,
+                messages: [{ role: 'user', content: [{ text: 'a deliberately long prior message' }] }],
+            },
+            { model: MODEL, stripTextMaxTokens: 1 },
+        );
+        const conversation = result.conversation as ConverseRequest;
+
+        expect(conversation.messages?.[0]?.content?.[0]?.text).toContain('[Content truncated');
+        expect(conversation.messages?.at(-1)?.content?.[0]).toEqual({ reasoningContent });
     });
 
     it('keeps the DeepSeek replay exclusion narrow', () => {

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -24,7 +24,6 @@ import {
     type OpenAiDalleOptions,
     type OpenAiGptImageOptions,
     type Providers,
-    type ReasoningEffort,
     stripBase64ImagesFromConversation,
     stripHeartbeatsFromConversation,
     supportsToolUse,
@@ -103,8 +102,8 @@ function isOpenAIReasoningModel(model: string): boolean {
     );
 }
 
-export function openAIReasoningEffort(model: string, effort: string | undefined): ReasoningEffort | undefined {
-    return effort && isOpenAIReasoningModel(model) ? (effort as ReasoningEffort) : undefined;
+export function openAIReasoningEffort(model: string, effort: string | undefined): string | undefined {
+    return effort && isOpenAIReasoningModel(model) ? effort : undefined;
 }
 
 //TODO: Do we need a list?, replace with if statements and modernize?

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -13,6 +13,7 @@ import {
     getConversationMeta,
     getModelCapabilities,
     incrementConversationTurn,
+    isOpenAIGptVersionGTE,
     type JSONSchema,
     LlumiverseError,
     type LlumiverseErrorContext,
@@ -23,6 +24,7 @@ import {
     type OpenAiDalleOptions,
     type OpenAiGptImageOptions,
     type Providers,
+    type ReasoningEffort,
     stripBase64ImagesFromConversation,
     stripHeartbeatsFromConversation,
     supportsToolUse,
@@ -60,6 +62,7 @@ import { formatOpenAILikeMultimodalPrompt } from './openai_format.js';
 // Response API types
 type ResponseInputItem = OpenAI.Responses.ResponseInputItem;
 type EasyInputMessage = OpenAI.Responses.EasyInputMessage;
+type OpenAIReasoning = NonNullable<OpenAI.Responses.ResponseCreateParams['reasoning']>;
 type OpenAIRequestOptions = Partial<TextFallbackOptions> & {
     image_detail?: 'low' | 'high' | 'auto';
     effort?: string;
@@ -96,23 +99,12 @@ function isOpenAIReasoningModel(model: string): boolean {
         normalized.includes('o1') ||
         normalized.includes('o3') ||
         normalized.includes('o4') ||
-        normalized.includes('gpt-5')
+        isOpenAIGptVersionGTE(model, 5, 0)
     );
 }
 
-function isGpt5ProModel(model: string): boolean {
-    const modelName = model.toLowerCase().split('/').pop() ?? model.toLowerCase();
-    return /^gpt-5(?:\.\d+)?-pro/.test(modelName);
-}
-
-function openAIReasoningEffort(model: string, effort: string | undefined): 'low' | 'medium' | 'high' | undefined {
-    if (!effort || !isOpenAIReasoningModel(model)) {
-        return undefined;
-    }
-    if (isGpt5ProModel(model)) {
-        return 'high';
-    }
-    return effort === 'low' || effort === 'medium' || effort === 'high' ? effort : undefined;
+export function openAIReasoningEffort(model: string, effort: string | undefined): ReasoningEffort | undefined {
+    return effort && isOpenAIReasoningModel(model) ? (effort as ReasoningEffort) : undefined;
 }
 
 //TODO: Do we need a list?, replace with if statements and modernize?
@@ -206,7 +198,9 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
 
         const isReasoningModel = isOpenAIReasoningModel(options.model);
         const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
-        const reasoning = effort ? { effort } : undefined;
+        // The SDK can lag newly documented effort values (for example `max`).
+        // Preserve caller input and let the provider validate model-specific support.
+        const reasoning = effort ? ({ effort } as unknown as OpenAIReasoning) : undefined;
 
         const stream = await this.service.responses.create({
             stream: true,
@@ -273,7 +267,7 @@ export abstract class BaseOpenAIDriver extends AbstractDriver<BaseOpenAIDriverOp
 
         const isReasoningModel = isOpenAIReasoningModel(options.model);
         const effort = openAIReasoningEffort(options.model, model_options?.effort ?? model_options?.reasoning_effort);
-        const reasoning = effort ? { effort } : undefined;
+        const reasoning = effort ? ({ effort } as unknown as OpenAIReasoning) : undefined;
 
         const res = await this.service.responses.create({
             stream: false,

--- a/drivers/src/openai/model-options.test.ts
+++ b/drivers/src/openai/model-options.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { openAIReasoningEffort } from './index.js';
+
+describe('OpenAI reasoning effort', () => {
+    it.each([
+        'none',
+        'minimal',
+        'low',
+        'medium',
+        'high',
+        'xhigh',
+        'max',
+    ])('preserves caller-supplied %s effort for reasoning models', (effort) => {
+        expect(openAIReasoningEffort('gpt-5.6-sol', effort)).toBe(effort);
+    });
+
+    it('does not send effort to a non-reasoning model', () => {
+        expect(openAIReasoningEffort('gpt-4o', 'medium')).toBeUndefined();
+    });
+});

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -41,6 +41,7 @@ import {
     type Completion,
     type CompletionChunkObject,
     type CompletionResult,
+    type DriverCompletionStream,
     type ExecutionOptions,
     type ExecutionTokenUsage,
     getConversationMeta,
@@ -193,6 +194,7 @@ export function claudeFinishReason(reason: string | undefined): string | undefin
         case 'end_turn':
             return 'stop';
         case 'max_tokens':
+        case 'model_context_window_exceeded':
             return 'length';
         default:
             return reason; // stop_sequence, tool_use
@@ -834,6 +836,91 @@ export function buildClaudeStreamingConversation(
     return processed as ClaudePrompt;
 }
 
+function finalizeClaudeConversation(
+    conversation: ClaudePrompt,
+    result: Message,
+    options: ExecutionOptions,
+): ClaudePrompt {
+    let completedConversation = updateClaudeConversation(conversation, createPromptFromResponse(result));
+    completedConversation = incrementConversationTurn(completedConversation) as ClaudePrompt;
+    completedConversation = pruneClaudeThinking(completedConversation);
+    const currentTurn = getConversationMeta(completedConversation).turnNumber;
+    const activeTurnStart = findClaudeActiveTurnStart(completedConversation);
+    const protectedMessages = new Set(
+        activeTurnStart >= 0 ? completedConversation.messages.slice(activeTurnStart) : [],
+    );
+    const preserveSubtree = (value: unknown): boolean => {
+        if (!value || typeof value !== 'object') return false;
+        if (protectedMessages.has(value as MessageParam)) return true;
+        const type = (value as { type?: unknown }).type;
+        return type === 'thinking' || type === 'redacted_thinking';
+    };
+    const stripOpts = {
+        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
+        currentTurn,
+        textMaxTokens: options.stripTextMaxTokens,
+        preserveSubtree,
+    };
+    let processedConversation = stripBase64ImagesFromConversation(completedConversation, stripOpts);
+    processedConversation = truncateLargeTextInConversation(processedConversation, stripOpts);
+    processedConversation = stripHeartbeatsFromConversation(processedConversation, {
+        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
+        currentTurn,
+        preserveSubtree,
+    });
+    return processedConversation as ClaudePrompt;
+}
+
+export function pruneClaudeThinking(conversation: ClaudePrompt): ClaudePrompt {
+    const activeTurnStart = findClaudeActiveTurnStart(conversation);
+    let latestAssistantIndex = -1;
+    for (let index = conversation.messages.length - 1; index >= 0; index--) {
+        const message = conversation.messages[index];
+        if (message.role === 'assistant') {
+            latestAssistantIndex = index;
+            break;
+        }
+    }
+    const preserveFrom = activeTurnStart >= 0 ? activeTurnStart : latestAssistantIndex;
+
+    const messages = conversation.messages.map((message, index): MessageParam => {
+        if (
+            (latestAssistantIndex >= 0 && index >= preserveFrom && index <= latestAssistantIndex) ||
+            message.role !== 'assistant' ||
+            !Array.isArray(message.content)
+        ) {
+            return message;
+        }
+        const content = message.content.filter(
+            (block) => block.type !== 'thinking' && block.type !== 'redacted_thinking',
+        );
+        return content.length === message.content.length ? message : { ...message, content };
+    });
+    return { ...conversation, messages };
+}
+
+function findClaudeActiveTurnStart(conversation: ClaudePrompt): number {
+    let activeAssistantIndex = -1;
+    for (let index = conversation.messages.length - 1; index >= 0; index--) {
+        const message = conversation.messages[index];
+        if (message.role !== 'assistant') continue;
+        if (Array.isArray(message.content) && message.content.some((block) => block.type === 'tool_use')) {
+            activeAssistantIndex = index;
+        }
+        break;
+    }
+    if (activeAssistantIndex < 0) return -1;
+
+    for (let index = activeAssistantIndex - 1; index >= 0; index--) {
+        const message = conversation.messages[index];
+        if (message.role !== 'user') continue;
+        const isToolResult =
+            Array.isArray(message.content) && message.content.some((block) => block.type === 'tool_result');
+        if (!isToolResult) return index + 1;
+    }
+    return 0;
+}
+
 // ============================================================================
 // Execution helpers (standalone, take a client parameter)
 // ============================================================================
@@ -849,7 +936,7 @@ export async function executeClaudeCompletion(
 ): Promise<Completion> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
 
-    let conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
+    const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
 
     const { payload, requestOptions } = getClaudePayload(options, conversation);
 
@@ -860,20 +947,7 @@ export async function executeClaudeCompletion(
     const text = collectAllTextContent(result.content, includeThoughts);
     const tool_use = collectClaudeTools(result.content);
 
-    conversation = updateClaudeConversation(conversation, createPromptFromResponse(result));
-    conversation = incrementConversationTurn(conversation) as ClaudePrompt;
-    const currentTurn = getConversationMeta(conversation).turnNumber;
-    const stripOpts = {
-        keepForTurns: options.stripImagesAfterTurns ?? Infinity,
-        currentTurn,
-        textMaxTokens: options.stripTextMaxTokens,
-    };
-    let processedConversation = stripBase64ImagesFromConversation(conversation, stripOpts);
-    processedConversation = truncateLargeTextInConversation(processedConversation, stripOpts);
-    processedConversation = stripHeartbeatsFromConversation(processedConversation, {
-        keepForTurns: options.stripHeartbeatsAfterTurns ?? 1,
-        currentTurn,
-    });
+    const processedConversation = finalizeClaudeConversation(conversation, result, options);
 
     return {
         result: text ? [{ type: 'text', value: text }] : [{ type: 'text', value: '' }],
@@ -892,7 +966,7 @@ export async function streamClaudeCompletion(
     client: Anthropic | AnthropicVertex,
     prompt: ClaudePrompt,
     options: ExecutionOptions,
-): Promise<AsyncIterable<CompletionChunkObject>> {
+): Promise<DriverCompletionStream> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
     const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
 
@@ -993,7 +1067,13 @@ export async function streamClaudeCompletion(
         return { result: [] } satisfies CompletionChunkObject;
     });
 
-    return stream;
+    return {
+        [Symbol.asyncIterator]: () => stream[Symbol.asyncIterator](),
+        finalizeConversation: async () => {
+            const finalMessage = await response_stream.finalMessage();
+            return finalizeClaudeConversation(conversation, finalMessage, options);
+        },
+    };
 }
 
 // ============================================================================

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -49,6 +49,7 @@ import {
     type JSONObject,
     LlumiverseError,
     type LlumiverseErrorContext,
+    type Logger,
     PromptRole,
     type PromptSegment,
     readStreamAsBase64,
@@ -198,6 +199,29 @@ export function claudeFinishReason(reason: string | undefined): string | undefin
             return 'length';
         default:
             return reason; // stop_sequence, tool_use
+    }
+}
+
+/**
+ * Keep Claude's provider-native truncation reason visible after both variants
+ * are normalized to `length` for cross-provider control flow.
+ */
+export function logClaudeTruncation(
+    logger: Logger | undefined,
+    reason: string | null | undefined,
+    context: { provider: string; model: string },
+): void {
+    if (!logger) return;
+
+    const details = {
+        ...context,
+        finish_reason: 'length',
+        provider_finish_reason: reason,
+    };
+    if (reason === 'max_tokens') {
+        logger.warn(details, '[Claude] Completion stopped at the output token limit');
+    } else if (reason === 'model_context_window_exceeded') {
+        logger.warn(details, '[Claude] Completion exceeded the model context window');
     }
 }
 
@@ -933,6 +957,8 @@ export async function executeClaudeCompletion(
     client: Anthropic | AnthropicVertex,
     prompt: ClaudePrompt,
     options: ExecutionOptions,
+    logger?: Logger,
+    provider = 'anthropic',
 ): Promise<Completion> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
 
@@ -942,6 +968,7 @@ export async function executeClaudeCompletion(
 
     const responseStream = await streamClaudeMessages(client, payload as MessageStreamParams, requestOptions);
     const result = await responseStream.finalMessage();
+    logClaudeTruncation(logger, result.stop_reason, { provider, model: options.model });
 
     const includeThoughts = model_options?.include_thoughts ?? false;
     const text = collectAllTextContent(result.content, includeThoughts);
@@ -966,6 +993,8 @@ export async function streamClaudeCompletion(
     client: Anthropic | AnthropicVertex,
     prompt: ClaudePrompt,
     options: ExecutionOptions,
+    logger?: Logger,
+    provider = 'anthropic',
 ): Promise<DriverCompletionStream> {
     const model_options = options.model_options as ClaudeBaseOptions | undefined;
     const conversation = updateClaudeConversation(options.conversation as ClaudePrompt | undefined, prompt);
@@ -986,6 +1015,7 @@ export async function streamClaudeCompletion(
                     token_usage: anthropicUsageToTokenUsage(streamEvent.message.usage as AnthropicUsageLike),
                 } satisfies CompletionChunkObject;
             case 'message_delta':
+                logClaudeTruncation(logger, streamEvent.delta.stop_reason, { provider, model: options.model });
                 return {
                     result: [{ type: 'text', value: '' }],
                     token_usage: { result: streamEvent.usage.output_tokens },

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -61,6 +61,7 @@ import {
     truncateLargeTextInConversation,
 } from '@llumiverse/core';
 import { asyncMap } from '@llumiverse/core/async';
+import { claudeFinishReason, logClaudeTruncation } from './claude-stop-reason.js';
 import { resolveClaudeThinking } from './claude-thinking.js';
 import { truncateBinaryForDebug } from './debug-prompt.js';
 
@@ -183,46 +184,6 @@ export function anthropicUsageToTokenUsage(usage: AnthropicUsageLike): Execution
         prompt_cached: usage.cache_read_input_tokens ?? undefined,
         prompt_cache_write: usage.cache_creation_input_tokens ?? undefined,
     };
-}
-
-// ============================================================================
-// Finish reason
-// ============================================================================
-
-export function claudeFinishReason(reason: string | undefined): string | undefined {
-    if (!reason) return undefined;
-    switch (reason) {
-        case 'end_turn':
-            return 'stop';
-        case 'max_tokens':
-        case 'model_context_window_exceeded':
-            return 'length';
-        default:
-            return reason; // stop_sequence, tool_use
-    }
-}
-
-/**
- * Keep Claude's provider-native truncation reason visible after both variants
- * are normalized to `length` for cross-provider control flow.
- */
-export function logClaudeTruncation(
-    logger: Logger | undefined,
-    reason: string | null | undefined,
-    context: { provider: string; model: string },
-): void {
-    if (!logger) return;
-
-    const details = {
-        ...context,
-        finish_reason: 'length',
-        provider_finish_reason: reason,
-    };
-    if (reason === 'max_tokens') {
-        logger.warn(details, '[Claude] Completion stopped at the output token limit');
-    } else if (reason === 'model_context_window_exceeded') {
-        logger.warn(details, '[Claude] Completion exceeded the model context window');
-    }
 }
 
 // ============================================================================

--- a/drivers/src/shared/claude-reasoning-replay.test.ts
+++ b/drivers/src/shared/claude-reasoning-replay.test.ts
@@ -4,6 +4,7 @@ import {
     type ClaudePrompt,
     claudeFinishReason,
     executeClaudeCompletion,
+    logClaudeTruncation,
     pruneClaudeThinking,
     streamClaudeCompletion,
 } from './claude-messages.js';
@@ -45,6 +46,38 @@ describe('Claude native reasoning replay', () => {
     it('normalizes both Claude truncation stop reasons to length', () => {
         expect(claudeFinishReason('max_tokens')).toBe('length');
         expect(claudeFinishReason('model_context_window_exceeded')).toBe('length');
+    });
+
+    it('logs distinct provider-native truncation causes after normalization', () => {
+        const logger = {
+            debug: vi.fn(),
+            info: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        };
+
+        logClaudeTruncation(logger, 'max_tokens', { provider: 'anthropic', model: 'claude-sonnet-4-6' });
+        logClaudeTruncation(logger, 'model_context_window_exceeded', {
+            provider: 'vertexai',
+            model: 'claude-sonnet-4-6',
+        });
+
+        expect(logger.warn).toHaveBeenNthCalledWith(
+            1,
+            expect.objectContaining({
+                finish_reason: 'length',
+                provider_finish_reason: 'max_tokens',
+            }),
+            '[Claude] Completion stopped at the output token limit',
+        );
+        expect(logger.warn).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({
+                finish_reason: 'length',
+                provider_finish_reason: 'model_context_window_exceeded',
+            }),
+            '[Claude] Completion exceeded the model context window',
+        );
     });
 
     it('persists ordered native blocks for blocking responses without exposing thoughts by default', async () => {

--- a/drivers/src/shared/claude-reasoning-replay.test.ts
+++ b/drivers/src/shared/claude-reasoning-replay.test.ts
@@ -1,0 +1,153 @@
+import type { Message, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources/messages.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+    type ClaudePrompt,
+    claudeFinishReason,
+    executeClaudeCompletion,
+    pruneClaudeThinking,
+    streamClaudeCompletion,
+} from './claude-messages.js';
+
+function sdkStream(events: RawMessageStreamEvent[], finalMessage: Message) {
+    return {
+        async *[Symbol.asyncIterator]() {
+            for (const event of events) yield event;
+        },
+        async finalMessage() {
+            return finalMessage;
+        },
+    };
+}
+
+const finalToolMessage = {
+    id: 'msg-1',
+    type: 'message',
+    role: 'assistant',
+    model: 'claude-sonnet-4-6',
+    content: [
+        { type: 'thinking', thinking: 'plan', signature: 'signed-thinking' },
+        { type: 'redacted_thinking', data: 'encrypted-redaction' },
+        { type: 'text', text: 'checking', citations: null },
+        { type: 'tool_use', id: 'call-1', name: 'lookup', input: { city: 'Paris' } },
+    ],
+    stop_reason: 'tool_use',
+    stop_sequence: null,
+    usage: { input_tokens: 2, output_tokens: 3 },
+} as unknown as Message;
+
+function clientFor(message: Message, events: RawMessageStreamEvent[] = []) {
+    return { messages: { stream: () => sdkStream(events, message) } } as never;
+}
+
+const prompt: ClaudePrompt = { messages: [{ role: 'user', content: 'question' }] };
+
+describe('Claude native reasoning replay', () => {
+    it('normalizes both Claude truncation stop reasons to length', () => {
+        expect(claudeFinishReason('max_tokens')).toBe('length');
+        expect(claudeFinishReason('model_context_window_exceeded')).toBe('length');
+    });
+
+    it('persists ordered native blocks for blocking responses without exposing thoughts by default', async () => {
+        const completion = await executeClaudeCompletion(clientFor(finalToolMessage), prompt, {
+            model: 'claude-sonnet-4-6',
+        });
+
+        expect(completion.result).toEqual([{ type: 'text', value: 'checking' }]);
+        expect(completion.conversation).toMatchObject({
+            messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+        });
+    });
+
+    it('persists reasoning on the latest completed blocking turn', async () => {
+        const finalMessage = {
+            ...finalToolMessage,
+            content: [
+                { type: 'thinking', thinking: 'final plan', signature: 'final-signature' },
+                { type: 'text', text: 'final answer', citations: null },
+            ],
+            stop_reason: 'end_turn',
+        } as unknown as Message;
+        const completion = await executeClaudeCompletion(clientFor(finalMessage), prompt, {
+            model: 'claude-sonnet-4-6',
+        });
+
+        expect(completion.result).toEqual([{ type: 'text', value: 'final answer' }]);
+        expect(completion.conversation).toMatchObject({
+            messages: expect.arrayContaining([{ role: 'assistant', content: finalMessage.content }]),
+        });
+    });
+
+    it('uses the SDK final message for streaming persistence and replays it on the next tool turn', async () => {
+        const events = [
+            { type: 'content_block_delta', index: 0, delta: { type: 'thinking_delta', thinking: 'plan' } },
+            { type: 'content_block_delta', index: 2, delta: { type: 'text_delta', text: 'checking', citations: null } },
+        ] as RawMessageStreamEvent[];
+        const stream = await streamClaudeCompletion(clientFor(finalToolMessage, events), prompt, {
+            model: 'claude-sonnet-4-6',
+        });
+        const results = [];
+        for await (const chunk of stream) results.push(...chunk.result);
+        const conversation = await stream.finalizeConversation?.();
+
+        expect(results).toEqual([{ type: 'text', value: 'checking' }]);
+        expect(conversation).toMatchObject({
+            messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+        });
+
+        const nextMessage = {
+            ...finalToolMessage,
+            id: 'msg-2',
+            content: [{ type: 'text', text: 'done', citations: null }],
+            stop_reason: 'end_turn',
+        } as unknown as Message;
+        const nextStream = vi.fn(() => sdkStream([], nextMessage));
+        await executeClaudeCompletion(
+            { messages: { stream: nextStream } } as never,
+            {
+                messages: [
+                    { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'sunny' }] },
+                ],
+            },
+            {
+                model: 'claude-sonnet-4-6',
+                conversation: JSON.parse(JSON.stringify(conversation)),
+                tools: [{ name: 'lookup', input_schema: { type: 'object' } }],
+            },
+        );
+
+        expect(nextStream).toHaveBeenCalledWith(
+            expect.objectContaining({
+                messages: expect.arrayContaining([{ role: 'assistant', content: finalToolMessage.content }]),
+            }),
+            undefined,
+        );
+    });
+
+    it('prunes only completed historical reasoning and keeps an active tool chain intact', () => {
+        const conversation: ClaudePrompt = {
+            messages: [
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'thinking', thinking: 'old', signature: 'old-signature' },
+                        { type: 'text', text: 'old answer' },
+                    ],
+                },
+                { role: 'user', content: 'next' },
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'thinking', thinking: 'active', signature: 'active-signature' },
+                        { type: 'tool_use', id: 'call-1', name: 'lookup', input: {} },
+                    ],
+                },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call-1', content: 'done' }] },
+            ],
+        };
+
+        const pruned = pruneClaudeThinking(conversation);
+        expect(pruned.messages[0]).toEqual({ role: 'assistant', content: [{ type: 'text', text: 'old answer' }] });
+        expect(pruned.messages[2]).toEqual(conversation.messages[2]);
+        expect(pruneClaudeThinking(pruned)).toEqual(pruned);
+    });
+});

--- a/drivers/src/shared/claude-reasoning-replay.test.ts
+++ b/drivers/src/shared/claude-reasoning-replay.test.ts
@@ -2,12 +2,11 @@ import type { Message, RawMessageStreamEvent } from '@anthropic-ai/sdk/resources
 import { describe, expect, it, vi } from 'vitest';
 import {
     type ClaudePrompt,
-    claudeFinishReason,
     executeClaudeCompletion,
-    logClaudeTruncation,
     pruneClaudeThinking,
     streamClaudeCompletion,
 } from './claude-messages.js';
+import { claudeFinishReason, logClaudeTruncation } from './claude-stop-reason.js';
 
 function sdkStream(events: RawMessageStreamEvent[], finalMessage: Message) {
     return {

--- a/drivers/src/shared/claude-stop-reason.ts
+++ b/drivers/src/shared/claude-stop-reason.ts
@@ -1,0 +1,34 @@
+import type { Logger } from '@llumiverse/core';
+
+export function claudeFinishReason(reason: string | undefined): string | undefined {
+    if (!reason) return undefined;
+    switch (reason) {
+        case 'end_turn':
+            return 'stop';
+        case 'max_tokens':
+        case 'model_context_window_exceeded':
+            return 'length';
+        default:
+            return reason;
+    }
+}
+
+/** Preserve Claude's provider-native truncation cause after normalizing control flow to `length`. */
+export function logClaudeTruncation(
+    logger: Logger | undefined,
+    reason: string | null | undefined,
+    context: { provider: string; model: string },
+): void {
+    if (!logger) return;
+
+    const details = {
+        ...context,
+        finish_reason: 'length',
+        provider_finish_reason: reason,
+    };
+    if (reason === 'max_tokens') {
+        logger.warn(details, '[Claude] Completion stopped at the output token limit');
+    } else if (reason === 'model_context_window_exceeded') {
+        logger.warn(details, '[Claude] Completion exceeded the model context window');
+    }
+}

--- a/drivers/src/shared/claude-thinking.test.ts
+++ b/drivers/src/shared/claude-thinking.test.ts
@@ -1,0 +1,55 @@
+import { getOptions } from '@llumiverse/core';
+import { describe, expect, it } from 'vitest';
+import { resolveClaudeThinking } from './claude-thinking.js';
+
+describe('resolveClaudeThinking', () => {
+    it('selects adaptive thinking with medium effort for Sonnet 4.6', () => {
+        expect(resolveClaudeThinking('claude-sonnet-4-6', { effort: 'medium' })).toMatchObject({
+            thinking: { type: 'adaptive', display: 'omitted' },
+            outputConfig: { effort: 'medium' },
+        });
+    });
+
+    it('prefers adaptive effort over a stale legacy budget', () => {
+        expect(
+            resolveClaudeThinking('claude-sonnet-4-6', {
+                effort: 'medium',
+                thinking_budget_tokens: 12_000,
+            }),
+        ).toMatchObject({
+            thinking: { type: 'adaptive', display: 'omitted' },
+            outputConfig: { effort: 'medium' },
+        });
+    });
+
+    it('preserves explicitly budgeted extended thinking on dual-mode models', () => {
+        expect(resolveClaudeThinking('claude-sonnet-4-6', { thinking_budget_tokens: 12_000 })).toMatchObject({
+            thinking: { type: 'enabled', budget_tokens: 12_000 },
+            outputConfig: undefined,
+        });
+        expect(getOptions('claude-sonnet-4-6', 'anthropic').options.map((option) => option.name)).toContain(
+            'thinking_budget_tokens',
+        );
+        expect(getOptions('claude-sonnet-5', 'anthropic').options.map((option) => option.name)).not.toContain(
+            'thinking_budget_tokens',
+        );
+    });
+
+    it('keeps extended-only models budget-driven', () => {
+        expect(resolveClaudeThinking('claude-3-7-sonnet', { thinking_budget_tokens: 8000 })).toMatchObject({
+            thinking: { type: 'enabled', budget_tokens: 8000 },
+            outputConfig: undefined,
+        });
+        expect(resolveClaudeThinking('claude-3-7-sonnet', { effort: 'medium' })).toMatchObject({
+            thinking: { type: 'disabled' },
+            outputConfig: { effort: 'medium' },
+        });
+    });
+
+    it('supports adaptive thinking on future Claude models', () => {
+        expect(resolveClaudeThinking('claude-sonnet-5', { effort: 'medium', include_thoughts: true })).toMatchObject({
+            thinking: { type: 'adaptive', display: 'summarized' },
+            outputConfig: { effort: 'medium' },
+        });
+    });
+});

--- a/drivers/src/shared/claude-thinking.ts
+++ b/drivers/src/shared/claude-thinking.ts
@@ -51,9 +51,13 @@ export function resolveClaudeThinking(model: string, options?: ClaudeThinkingInp
     if (!supportsThinking) {
         // Pre-3.7 models: no thinking support
         thinking = undefined;
+    } else if (adaptiveEnabled) {
+        // Prefer adaptive thinking when an effort level is supplied. This also
+        // ignores stale legacy budgets that may remain on a migrated model config.
+        thinking = { type: 'adaptive' as const, display: options?.include_thoughts ? 'summarized' : 'omitted' };
     } else if (extendedEnabled) {
-        // Explicit budget — use extended thinking regardless of adaptive support.
-        // On adaptive models this uses the deprecated path, but user input takes priority.
+        // Preserve explicitly budgeted configurations, including dual-mode models
+        // such as Sonnet 4.6 when no effort level was supplied.
         thinking = {
             type: 'enabled' as const,
             budget_tokens: budgetTokens,
@@ -61,9 +65,7 @@ export function resolveClaudeThinking(model: string, options?: ClaudeThinkingInp
     } else if (supportsAdaptive) {
         // Adaptive models: enable when effort is set, omit otherwise (thinking is OFF by default).
         // display controls whether thinking blocks are returned; defaults to omitted.
-        thinking = adaptiveEnabled
-            ? { type: 'adaptive' as const, display: options?.include_thoughts ? 'summarized' : 'omitted' }
-            : undefined;
+        thinking = undefined;
     } else {
         // Older thinking models (3.7, 4.5): no adaptive support, thinking is always disabled
         // unless an explicit budget is provided (handled above).

--- a/drivers/src/vertexai/models/claude.ts
+++ b/drivers/src/vertexai/models/claude.ts
@@ -83,7 +83,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         ) {
             driver.logger.debug({ options: resolvedOptions.model_options }, 'Unexpected option id');
         }
-        return executeClaudeCompletion(client, prompt, resolvedOptions);
+        return executeClaudeCompletion(client, prompt, resolvedOptions, driver.logger, driver.provider);
     }
 
     async requestTextCompletionStream(
@@ -101,7 +101,7 @@ export class ClaudeModelDefinition implements ModelDefinition<ClaudePrompt> {
         ) {
             driver.logger.debug({ options: resolvedOptions.model_options }, 'Unexpected option id');
         }
-        return streamClaudeCompletion(client, prompt, resolvedOptions);
+        return streamClaudeCompletion(client, prompt, resolvedOptions, driver.logger, driver.provider);
     }
 
     isClaudeErrorRetryable(

--- a/drivers/src/vertexai/models/gemini-thinking-options.test.ts
+++ b/drivers/src/vertexai/models/gemini-thinking-options.test.ts
@@ -24,6 +24,17 @@ describe('Gemini thinking configuration', () => {
         });
     });
 
+    it('passes through caller effort even when advisory metadata does not offer it', () => {
+        expect(geminiThinkingConfig(options('gemini-3.1-flash-image', { effort: 'low' }))).toEqual({
+            includeThoughts: false,
+            thinkingLevel: ThinkingLevel.LOW,
+        });
+        expect(geminiThinkingConfig(options('gemini-3-pro-image', { effort: 'minimal' }))).toEqual({
+            includeThoughts: false,
+            thinkingLevel: ThinkingLevel.MINIMAL,
+        });
+    });
+
     it('preserves explicitly requested thought inclusion without imposing a thinking level', () => {
         expect(geminiThinkingConfig(options('gemini-3.5-flash', { include_thoughts: true }))).toEqual({
             includeThoughts: true,

--- a/drivers/src/vertexai/models/gemini-thinking-options.test.ts
+++ b/drivers/src/vertexai/models/gemini-thinking-options.test.ts
@@ -1,0 +1,32 @@
+import { ThinkingLevel } from '@google/genai';
+import type { StatelessExecutionOptions } from '@llumiverse/core';
+import { describe, expect, it } from 'vitest';
+import { geminiThinkingConfig } from './gemini.js';
+
+function options(model: string, model_options?: Record<string, unknown>): StatelessExecutionOptions {
+    return { model, model_options } as StatelessExecutionOptions;
+}
+
+describe('Gemini thinking configuration', () => {
+    it('leaves thinking undefined when the caller did not configure it', () => {
+        expect(geminiThinkingConfig(options('gemini-3.5-flash'))).toBeUndefined();
+        expect(geminiThinkingConfig(options('gemini-2.5-pro'))).toBeUndefined();
+    });
+
+    it('maps current Gemini 3 effort levels', () => {
+        expect(geminiThinkingConfig(options('gemini-3.5-flash', { effort: 'minimal' }))).toEqual({
+            includeThoughts: false,
+            thinkingLevel: ThinkingLevel.MINIMAL,
+        });
+        expect(geminiThinkingConfig(options('gemini-3.1-pro', { effort: 'medium' }))).toEqual({
+            includeThoughts: false,
+            thinkingLevel: ThinkingLevel.MEDIUM,
+        });
+    });
+
+    it('preserves explicitly requested thought inclusion without imposing a thinking level', () => {
+        expect(geminiThinkingConfig(options('gemini-3.5-flash', { include_thoughts: true }))).toEqual({
+            includeThoughts: true,
+        });
+    });
+});

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -25,7 +25,6 @@ import {
     type ExecutionOptions,
     type ExecutionTokenUsage,
     getConversationMeta,
-    getGeminiModelVersion,
     incrementConversationTurn,
     isGeminiModelVersionGte,
     type JSONObject,
@@ -339,26 +338,6 @@ const recoverableToolCallReasons = [
     'UNEXPECTED_TOOL_CALL', // Model called an undeclared tool
 ];
 
-function geminiThinkingBudget(option: StatelessExecutionOptions) {
-    const model_options = option.model_options as VertexAIGeminiOptions | undefined;
-    // If thinking_budget_tokens is explicitly set in model options, use it directly
-    if (model_options?.thinking_budget_tokens !== undefined) {
-        return model_options.thinking_budget_tokens;
-    }
-    if (model_options?.effort) {
-        return geminiBudgetForEffort(option.model, model_options.effort);
-    }
-    // Set minimum thinking level by default.
-    // Docs: https://ai.google.dev/gemini-api/docs/thinking#set-budget
-    if (getGeminiModelVersion(option.model) === '2.5') {
-        if (option.model.includes('pro')) {
-            return 128;
-        }
-        return 0;
-    }
-    return undefined;
-}
-
 function geminiThinkingLevelForEffort(
     model: string,
     effort: VertexAIGeminiOptions['effort'],
@@ -367,9 +346,11 @@ function geminiThinkingLevelForEffort(
         return ThinkingLevel.HIGH;
     }
     if (model.includes('gemini-3.1-flash-image')) {
-        return effort === 'low' ? ThinkingLevel.MINIMAL : ThinkingLevel.HIGH;
+        return effort === 'minimal' ? ThinkingLevel.MINIMAL : ThinkingLevel.HIGH;
     }
     switch (effort) {
+        case 'minimal':
+            return ThinkingLevel.MINIMAL;
         case 'low':
             return ThinkingLevel.LOW;
         case 'medium':
@@ -386,6 +367,12 @@ function geminiBudgetForEffort(model: string, effort: NonNullable<VertexAIGemini
     const isFlash = model.includes('flash') && !isFlashLite;
     const isPro = model.includes('pro');
 
+    if (effort === 'minimal') {
+        if (isPro) return 128;
+        if (isFlashLite) return 512;
+        if (isFlash) return 1;
+        return 1024;
+    }
     if (effort === 'low') {
         if (isPro) return 128;
         if (isFlashLite) return 512;
@@ -400,7 +387,7 @@ function geminiBudgetForEffort(model: string, effort: NonNullable<VertexAIGemini
     return 8192;
 }
 
-function geminiThinkingConfig(option: StatelessExecutionOptions): ThinkingConfig | undefined {
+export function geminiThinkingConfig(option: StatelessExecutionOptions): ThinkingConfig | undefined {
     const model_options = option.model_options as VertexAIGeminiOptions | undefined;
 
     // If thinking options are explicitly set in model options, use them directly
@@ -425,21 +412,9 @@ function geminiThinkingConfig(option: StatelessExecutionOptions): ThinkingConfig
         };
     }
 
-    // Set a low thinking level by default.
-    // Docs: https://ai.google.dev/gemini-api/docs/thinking#set-budget
-    // https://docs.cloud.google.com/vertex-ai/generative-ai/docs/thinking
-    if (isGeminiModelVersionGte(option.model, '3.0')) {
-        return {
-            includeThoughts: include_thoughts,
-            thinkingLevel: option.model.includes('gemini-3-pro-image') ? ThinkingLevel.HIGH : ThinkingLevel.LOW,
-        };
-    }
-    if (isGeminiModelVersionGte(option.model, '2.5')) {
-        const thinking_budget_tokens = geminiThinkingBudget(option) ?? 0;
-        return {
-            includeThoughts: include_thoughts,
-            thinkingBudget: thinking_budget_tokens,
-        };
+    // When no thinking control is supplied, preserve the provider's model-specific default.
+    if (model_options?.include_thoughts !== undefined) {
+        return { includeThoughts: include_thoughts };
     }
 }
 

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -338,16 +338,7 @@ const recoverableToolCallReasons = [
     'UNEXPECTED_TOOL_CALL', // Model called an undeclared tool
 ];
 
-function geminiThinkingLevelForEffort(
-    model: string,
-    effort: VertexAIGeminiOptions['effort'],
-): ThinkingLevel | undefined {
-    if (model.includes('gemini-3-pro-image')) {
-        return ThinkingLevel.HIGH;
-    }
-    if (model.includes('gemini-3.1-flash-image')) {
-        return effort === 'minimal' ? ThinkingLevel.MINIMAL : ThinkingLevel.HIGH;
-    }
+function geminiThinkingLevelForEffort(effort: VertexAIGeminiOptions['effort']): ThinkingLevel | undefined {
     switch (effort) {
         case 'minimal':
             return ThinkingLevel.MINIMAL;
@@ -403,7 +394,7 @@ export function geminiThinkingConfig(option: StatelessExecutionOptions): Thinkin
         if (isGeminiModelVersionGte(option.model, '3.0')) {
             return {
                 includeThoughts: include_thoughts,
-                thinkingLevel: geminiThinkingLevelForEffort(option.model, model_options.effort),
+                thinkingLevel: geminiThinkingLevelForEffort(model_options.effort),
             };
         }
         return {

--- a/drivers/test/conversation.test.ts
+++ b/drivers/test/conversation.test.ts
@@ -192,7 +192,7 @@ function getTextOptions(model: string): ExecutionOptions {
               }
             : {
                   _option_id: 'text-fallback',
-                  max_tokens: 256,
+                  max_tokens: 1000,
                   temperature: 0.3,
               },
     };
@@ -506,8 +506,8 @@ describe.skipIf(!hasDrivers).concurrent.each(drivers)(
             const result1 = await driver.execute(prompt1, options);
             expect(result1.result.length).toBeGreaterThan(0);
             const text1 = result1.result.map(completionResultToString).join('').toLowerCase();
-            expect(text1).toMatch(/google/);
-            expect(text1).toMatch(/github/);
+            expect(text1).toContain('google');
+            expect(text1).toContain('github');
             expect(result1.conversation).toBeDefined();
 
             // Critical test: Verify conversation with multiple images is serializable


### PR DESCRIPTION
## Summary

- preserve authoritative native Claude reasoning blocks, signatures, redacted content, text, and tool calls across blocking and streaming Anthropic, Vertex Anthropic, and Bedrock conversations
- normalize Claude output and context truncation to the portable `length` finish reason while retaining distinct provider diagnostics in logs
- update advisory Claude, OpenAI, and Gemini model capabilities and future-compatible version parsing without overriding caller-supplied model options
- prefer adaptive Claude thinking when effort is supplied, while retaining explicit extended-thinking budgets and extended-only model behavior

## Verification

- common: lint, 68 focused tests, test typecheck, build
- core: lint, 142 tests, test typecheck, build
- drivers: lint, 26 focused Claude/model-option tests, test typecheck, build
- live `all-models.test` intentionally not run
