### PR TITLE
feat: preserve prompt caches across result schemas

### DIFF
--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -615,6 +615,12 @@ export interface PromptOptions {
      */
     format?: PromptFormatter;
     result_schema?: JSONSchema;
+    /**
+     * Provider-specific opt-in to put the result schema after the cached prompt
+     * prefix instead of including it in native structured-output configuration.
+     * The returned JSON is still validated against result_schema by Llumiverse.
+     */
+    prompt_cache_schema_suffix?: boolean;
 }
 
 export interface StatelessExecutionOptions extends PromptOptions {

--- a/drivers/src/openai/error-handling.test.ts
+++ b/drivers/src/openai/error-handling.test.ts
@@ -203,6 +203,134 @@ describe('OpenAIResponsesDriverBase prompt caching', () => {
         expect(create).toHaveBeenCalledWith(expect.objectContaining({ prompt_cache_options: undefined }));
     });
 
+    it('puts a cacheable schema after the document boundary and uses JSON object mode', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: '{"value":"ok"}', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+        const resultSchema = { type: 'object' as const, properties: { value: { type: 'string' as const } } };
+        const prompt = [
+            { role: 'system' as const, content: 'process the document' },
+            {
+                role: 'user' as const,
+                content: [
+                    {
+                        type: 'input_image' as const,
+                        image_url: 'data:image/jpeg;base64,source',
+                        detail: 'auto' as const,
+                    },
+                    { type: 'input_text' as const, text: 'stable document blocks' },
+                ],
+            },
+            { role: 'user' as const, content: 'phase-specific task' },
+            {
+                role: 'user' as const,
+                content: [
+                    {
+                        type: 'input_text' as const,
+                        text: `IMPORTANT: only answer using JSON. <response_schema>${JSON.stringify(resultSchema)}</response_schema>`,
+                    },
+                ],
+            },
+        ];
+
+        await driver.requestTextCompletion(prompt, {
+            model: 'gpt-5.6',
+            prompt_cache_key: 'document-prefix',
+            prompt_cache_schema_suffix: true,
+            result_schema: resultSchema,
+        });
+
+        expect(create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prompt_cache_options: { mode: 'explicit' },
+                input: [
+                    prompt[0],
+                    {
+                        ...prompt[1],
+                        content: [
+                            {
+                                type: 'input_image',
+                                image_url: 'data:image/jpeg;base64,source',
+                                detail: 'auto',
+                            },
+                            {
+                                type: 'input_text',
+                                text: 'stable document blocks',
+                                prompt_cache_breakpoint: { mode: 'explicit' },
+                            },
+                        ],
+                    },
+                    prompt[2],
+                    prompt[3],
+                ],
+                text: { format: { type: 'json_object' } },
+            }),
+        );
+    });
+
+    it('renders a cacheable result schema as the final prompt message', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const prompt = await driver.createPrompt(
+            [
+                { role: PromptRole.system, content: 'system' },
+                { role: PromptRole.user, content: 'stable source' },
+                { role: PromptRole.user, content: 'dynamic task' },
+            ],
+            {
+                model: 'gpt-5.6',
+                prompt_cache_schema_suffix: true,
+                result_schema: { type: 'object', properties: { value: { type: 'string' } } },
+            },
+        );
+
+        expect(prompt).toHaveLength(4);
+        expect(prompt[3]).toMatchObject({ role: 'user' });
+        expect(JSON.stringify(prompt[3])).toContain('<response_schema>');
+    });
+
+    it('validates JSON object mode output against the result schema', async () => {
+        const driver = new TestOpenAIResponsesDriver();
+        const create = vi.fn().mockResolvedValue({
+            status: 'completed',
+            output: [
+                {
+                    type: 'message',
+                    role: 'assistant',
+                    content: [{ type: 'output_text', text: '{"unexpected":"value"}', annotations: [] }],
+                },
+            ],
+            usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        });
+        driver.service = { responses: { create } } as unknown as OpenAI;
+
+        const completion = await driver.execute([{ role: PromptRole.user, content: 'Return the requested data.' }], {
+            model: 'gpt-5.6',
+            prompt_cache_schema_suffix: true,
+            result_schema: {
+                type: 'object',
+                properties: { value: { type: 'string' } },
+                required: ['value'],
+                additionalProperties: false,
+            },
+        });
+
+        expect(create).toHaveBeenCalledWith(expect.objectContaining({ text: { format: { type: 'json_object' } } }));
+        expect(completion.error).toMatchObject({
+            code: 'validation_error',
+            message: expect.stringContaining("must have required property 'value'"),
+        });
+    });
+
     it('does not duplicate schemas in the prompt when native structured output is supported', async () => {
         const driver = new TestOpenAIResponsesDriver();
         const create = vi.fn().mockResolvedValue({

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -128,7 +128,15 @@ function configureOpenAIPromptCaching(
         return { input };
     }
 
-    const sourceIndex = userMessageIndexes.at(-2);
+    const sourceIndex =
+        userMessageIndexes.findLast((index) => {
+            const item = input[index];
+            return (
+                'content' in item &&
+                Array.isArray(item.content) &&
+                item.content.some((part) => part.type === 'input_image' || part.type === 'input_file')
+            );
+        }) ?? userMessageIndexes.at(-2);
     if (sourceIndex === undefined) {
         return { input };
     }
@@ -196,7 +204,11 @@ export class OpenAIResponsesProtocol {
 
         let parsedSchema: JSONSchema | undefined;
         let strictMode = false;
-        if (options.result_schema && supportsSchema(options.model, driver.provider)) {
+        if (
+            options.result_schema &&
+            supportsSchema(options.model, driver.provider) &&
+            options.prompt_cache_schema_suffix !== true
+        ) {
             const formattedSchema = formatOpenAISchema(options.result_schema);
             parsedSchema = formattedSchema.schema;
             strictMode = formattedSchema.strict;
@@ -221,7 +233,12 @@ export class OpenAIResponsesProtocol {
             top_p: isReasoningModel ? undefined : model_options?.top_p,
             max_output_tokens: model_options?.max_tokens,
             tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(parsedSchema, strictMode, model_options?.verbosity),
+            text: buildResponseTextConfig(
+                parsedSchema,
+                strictMode,
+                model_options?.verbosity,
+                options.prompt_cache_schema_suffix === true && !!options.result_schema,
+            ),
         });
 
         return mapResponseStream(stream);
@@ -261,7 +278,11 @@ export class OpenAIResponsesProtocol {
 
         let parsedSchema: JSONSchema | undefined;
         let strictMode = false;
-        if (options.result_schema && supportsSchema(options.model, driver.provider)) {
+        if (
+            options.result_schema &&
+            supportsSchema(options.model, driver.provider) &&
+            options.prompt_cache_schema_suffix !== true
+        ) {
             const formattedSchema = formatOpenAISchema(options.result_schema);
             parsedSchema = formattedSchema.schema;
             strictMode = formattedSchema.strict;
@@ -286,7 +307,12 @@ export class OpenAIResponsesProtocol {
             top_p: isReasoningModel ? undefined : model_options?.top_p,
             max_output_tokens: model_options?.max_tokens, //TODO: use max_tokens for older models, currently relying on OpenAI to handle it
             tools: useTools ? toolDefs : undefined,
-            text: buildResponseTextConfig(parsedSchema, strictMode, model_options?.verbosity),
+            text: buildResponseTextConfig(
+                parsedSchema,
+                strictMode,
+                model_options?.verbosity,
+                options.prompt_cache_schema_suffix === true && !!options.result_schema,
+            ),
         });
 
         const completion = driver.extractDataFromResponse(options, res);
@@ -344,8 +370,14 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
     }
 
     protected async formatPrompt(segments: PromptSegment[], options: PromptOptions): Promise<ResponseInputItem[]> {
-        const resultSchema = supportsSchema(options.model, this.provider) ? undefined : options.result_schema;
-        return formatOpenAILikeMultimodalPrompt(segments, { ...options, result_schema: resultSchema });
+        const schemaSuffix = options.prompt_cache_schema_suffix === true && !!options.result_schema;
+        const resultSchema =
+            supportsSchema(options.model, this.provider) && !schemaSuffix ? undefined : options.result_schema;
+        return formatOpenAILikeMultimodalPrompt(segments, {
+            ...options,
+            result_schema: resultSchema,
+            resultSchemaPosition: schemaSuffix ? 'suffix' : undefined,
+        });
     }
 
     /** @internal Resolve the model identifier sent to the Responses transport. */
@@ -799,8 +831,9 @@ function buildResponseTextConfig(
     schema: JSONSchema | undefined,
     strict: boolean,
     verbosity: OpenAIRequestOptions['verbosity'] | undefined,
+    jsonObject: boolean = false,
 ): OpenAI.Responses.ResponseTextConfig | undefined {
-    if (!schema && !verbosity) {
+    if (!schema && !verbosity && !jsonObject) {
         return undefined;
     }
     return {
@@ -813,7 +846,9 @@ function buildResponseTextConfig(
                       strict,
                   },
               }
-            : {}),
+            : jsonObject
+              ? { format: { type: 'json_object' as const } }
+              : {}),
         ...(verbosity ? { verbosity } : {}),
     };
 }

--- a/drivers/src/openai/openai_format.ts
+++ b/drivers/src/openai/openai_format.ts
@@ -181,9 +181,10 @@ export async function formatOpenAILikeMultimodalPrompt(
     }
 
     if (opts.result_schema && !opts.useToolForFormatting) {
+        const schemaPosition = opts.resultSchemaPosition ?? 'system';
         const schemaMsg: EasyInputMessage = {
             type: 'message',
-            role: 'system',
+            role: schemaPosition === 'suffix' ? 'user' : 'system',
             content: [
                 {
                     type: 'input_text',
@@ -191,7 +192,11 @@ export async function formatOpenAILikeMultimodalPrompt(
                 },
             ],
         };
-        system.push(schemaMsg);
+        if (schemaPosition === 'suffix') {
+            others.push(schemaMsg);
+        } else {
+            system.push(schemaMsg);
+        }
     }
 
     // put system messages first and safety last
@@ -202,6 +207,7 @@ export interface OpenAIPromptFormatterOptions {
     multimodal?: boolean;
     useToolForFormatting?: boolean;
     schema?: object;
+    resultSchemaPosition?: 'system' | 'suffix';
 }
 
 // Chat Completions API types


### PR DESCRIPTION
## Summary

- separate cacheable prompt prefixes from dynamic result-schema suffixes
- route OpenAI schema instructions after cached prompt content
- preserve provider error handling while improving structured-output fallback coverage

## Verification

- `pnpm run check`
- `pnpm run build`
- `pnpm run test` (637 passed, 19 credential-gated tests skipped)