### PR TITLE
fix: extend default Gemini request timeout

### DIFF
--- a/drivers/src/http-timeout-wiring.test.ts
+++ b/drivers/src/http-timeout-wiring.test.ts
@@ -317,7 +317,7 @@ describe('driver HTTP timeout wiring', () => {
         driver.destroy();
     });
 
-    it('allows five minutes for Gemini requests by default', () => {
+    it('allows ten minutes for Gemini requests by default', () => {
         const driver = new VertexAIDriver({
             project: 'project',
             region: 'us-central1',
@@ -335,8 +335,8 @@ describe('driver HTTP timeout wiring', () => {
             getGoogleGenAIHttpOptions: (flex: boolean) => { timeout: number };
         }>(connectOnlyDriver);
 
-        expect(internals.getGoogleGenAIHttpOptions(false).timeout).toBe(300_000);
-        expect(connectOnlyInternals.getGoogleGenAIHttpOptions(false).timeout).toBe(300_000);
+        expect(internals.getGoogleGenAIHttpOptions(false).timeout).toBe(600_000);
+        expect(connectOnlyInternals.getGoogleGenAIHttpOptions(false).timeout).toBe(600_000);
         expect(internals.getAnthropicVertexClientOptions('global', {}).timeout).toBe(60_000);
 
         connectOnlyDriver.destroy();

--- a/drivers/src/http-timeout-wiring.test.ts
+++ b/drivers/src/http-timeout-wiring.test.ts
@@ -316,4 +316,30 @@ describe('driver HTTP timeout wiring', () => {
 
         driver.destroy();
     });
+
+    it('allows five minutes for Gemini requests by default', () => {
+        const driver = new VertexAIDriver({
+            project: 'project',
+            region: 'us-central1',
+        });
+        const internals = exposePrivate<{
+            getGoogleGenAIHttpOptions: (flex: boolean) => { timeout: number };
+            getAnthropicVertexClientOptions: (region: string, authClient: unknown) => { timeout: number };
+        }>(driver);
+        const connectOnlyDriver = new VertexAIDriver({
+            project: 'project',
+            region: 'us-central1',
+            httpTimeout: { connectTimeout: 1_000 },
+        });
+        const connectOnlyInternals = exposePrivate<{
+            getGoogleGenAIHttpOptions: (flex: boolean) => { timeout: number };
+        }>(connectOnlyDriver);
+
+        expect(internals.getGoogleGenAIHttpOptions(false).timeout).toBe(300_000);
+        expect(connectOnlyInternals.getGoogleGenAIHttpOptions(false).timeout).toBe(300_000);
+        expect(internals.getAnthropicVertexClientOptions('global', {}).timeout).toBe(60_000);
+
+        connectOnlyDriver.destroy();
+        driver.destroy();
+    });
 });

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -36,7 +36,7 @@ import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } fro
 import type { LLamaPrompt } from './models/llama.js';
 import { getModelDefinition, trimModelName } from './models.js';
 
-const DEFAULT_GEMINI_REQUEST_TIMEOUT_MS = 5 * 60_000;
+const DEFAULT_GEMINI_REQUEST_TIMEOUT_MS = 10 * 60_000;
 
 export interface VertexAIDriverOptions extends DriverOptions {
     project: string;

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -36,6 +36,8 @@ import { formatImagenDebugPrompt, ImagenModelDefinition, type ImagenPrompt } fro
 import type { LLamaPrompt } from './models/llama.js';
 import { getModelDefinition, trimModelName } from './models.js';
 
+const DEFAULT_GEMINI_REQUEST_TIMEOUT_MS = 5 * 60_000;
+
 export interface VertexAIDriverOptions extends DriverOptions {
     project: string;
     region: string;
@@ -134,8 +136,11 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
     }
 
     private getGoogleGenAIHttpOptions(flex: boolean, httpTimeout?: HttpTimeoutOptions) {
+        const configuredTimeout = mergeDriverHttpTimeoutOptions(this.options.httpTimeout, httpTimeout);
+        const hasRequestTimeout =
+            configuredTimeout?.headersTimeout !== undefined || configuredTimeout?.bodyTimeout !== undefined;
         return {
-            timeout: this.getSdkRequestTimeoutMs(httpTimeout),
+            timeout: hasRequestTimeout ? this.getSdkRequestTimeoutMs(httpTimeout) : DEFAULT_GEMINI_REQUEST_TIMEOUT_MS,
             ...(flex
                 ? {
                       headers: {


### PR DESCRIPTION
## Summary
- increase the default Google GenAI SDK request timeout for Vertex Gemini models from 60 seconds to ten minutes
- preserve explicit driver-level and execution-level header/body timeout overrides
- keep the existing 60-second default for Vertex-hosted Anthropic and other providers
- cover default, connection-only, and explicit timeout behavior

## Test Plan
- [x] `pnpm --filter @llumiverse/drivers lint`
- [x] `pnpm --filter @llumiverse/drivers exec vitest run src/http-timeout-wiring.test.ts` (8/8)
- [x] `pnpm --filter @llumiverse/drivers typecheck:test`
- [x] `pnpm --filter @llumiverse/drivers build`
