### PR TITLE
chore(deps): assign Renovate PR owners and align group names

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -46,13 +46,15 @@
       "addLabels": ["renovate-automerge"]
     },
     {
-      "groupName": "node deps",
+      "groupName": "node dependencies",
+      "assignees": ["michaelva"],
       "matchManagers": ["npm", "nvm", "nodenv"],
       "rangeStrategy": "bump",
       "schedule": "* * * * 3" // Wednesday
     },
     {
       "groupName": "biome",
+      "assignees": ["michaelva"],
       "matchManagers": [
         "npm"
       ],
@@ -84,11 +86,14 @@
         "@aws-sdk/**",
         "@anthropic-ai/**"
       ],
+      // Owner: LeonRuggiero maintains the model-provider client SDKs.
+      "assignees": ["LeonRuggiero"],
       "rangeStrategy": "bump",
       "schedule": "* * * * 4" // Thursday
     },
     {
       "groupName": "Vertesia libraries",
+      "assignees": ["LeonRuggiero"],
       "matchManagers": [
         "npm"
       ],
@@ -114,6 +119,8 @@
         "npm",
         "pnpm"
       ],
+      // Owner: LeonRuggiero.
+      "assignees": ["LeonRuggiero"],
       "rangeStrategy": "bump",
       "schedule": "* * * * 2" // Tuesday
     },
@@ -162,6 +169,14 @@
         "pnpm-workspace.overrides"
       ],
       "enabled": false
+    },
+    // Ownership: assign GitHub Actions dependency PRs to their maintainer.
+    {
+      "description": "Assign GitHub Actions dependency PRs to mincong-h",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "assignees": ["mincong-h"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Assign Renovate dependency-update PRs to their maintainers, and align one group name.

**Ownership** (per-group `assignees`):
- `node dependencies`, `biome` → michaelva
- `Model Provider Client libraries`, `Vertesia libraries`, `package manager dependencies` → LeonRuggiero
- GitHub Actions → mincong-h

**Group naming:**
- Rename the catch-all npm group `node deps` → `node dependencies` (consistent with the other groups; same schedule and match set).

## Notes

- Assignees have no `matchUpdateTypes` filter, so both minor and major update PRs (Renovate splits majors into their own PR) are assigned to the owner.

## Test Plan

- [x] `renovate-config-validator` passes. (`.renovaterc.json5` has no applicable build/lint/test.)
