### PR TITLE
chore(deps, security): raise brace-expansion and postcss floors

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,9 @@ overrides:
   google-auth-library: ^10.9.0
   '@types/node': ^24.13.3
   vite: ^8.0.16
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@>=3.0.0 <5.0.8: 5.0.8
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  postcss@<8.5.18: ^8.5.18
   protobufjs@<=7.6.4: 7.6.5
 
 importers:
@@ -1025,9 +1026,9 @@ packages:
   bowser@2.11.0:
     resolution: {integrity: sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -1400,8 +1401,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nanoid@3.3.13:
-    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1479,8 +1480,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   process@0.11.10:
@@ -2895,7 +2896,7 @@ snapshots:
 
   bowser@2.11.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3248,7 +3249,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -3258,7 +3259,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nanoid@3.3.13: {}
+  nanoid@3.3.16: {}
 
   node-domexception@1.0.0: {}
 
@@ -3315,9 +3316,9 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.13
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3497,7 +3498,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,8 @@ overrides:
   # ============================
   # Dependabot alerts #77/#78: Vite dev-server Windows path disclosure issues.
   vite: ^8.0.16
-  "brace-expansion@>=3.0.0 <5.0.7": 5.0.7
+  "brace-expansion@>=3.0.0 <5.0.8": 5.0.8
   "fast-uri@>=3.0.0 <3.1.4": 3.1.4
+  # GHSA path traversal in sourceMappingURL auto-loading. Reached via vitest > vite > postcss.
+  "postcss@<8.5.18": ^8.5.18
   protobufjs@<=7.6.4: 7.6.5


### PR DESCRIPTION
## Summary

Raises two transitive dependency floors flagged by `pnpm audit`:

- **`brace-expansion`** 5.x floor `5.0.7` -> `5.0.8` — GHSA-mh99-v99m-4gvg, denial of service via unbounded expansion length causing an out-of-memory process crash. Reached through `rimraf > glob > minimatch` in every workspace package.
- **`postcss`** — new floor `8.5.18`. Path traversal in previous-source-map auto-loading (`sourceMappingURL`) allowing arbitrary `.map` file disclosure. Reached through `vitest > vite > postcss`, which was resolving `8.5.15`; there was no postcss override here before.

Both patched versions are older than the 3-day `minimumReleaseAge` cooldown, so no `minimumReleaseAgeExclude` entry is needed.

## Test Plan

- [x] `pnpm audit` — **0 vulnerabilities** in this workspace (was 2 high).
- [x] `pnpm install --frozen-lockfile` — passes, lockfile consistent with the workspace config.
- [x] `pnpm build` — 4/4 tasks successful.