### PR TITLE
fix(vertexai): preserve provider retry delays

### DIFF
--- a/common/src/LlumiverseError.test.ts
+++ b/common/src/LlumiverseError.test.ts
@@ -18,6 +18,7 @@ describe('LlumiverseError', () => {
                 originalError,
                 429,
                 'RateLimitError',
+                1_500,
             );
 
             expect(error).toBeInstanceOf(Error);
@@ -26,6 +27,7 @@ describe('LlumiverseError', () => {
             expect(error.message).toBe('Test error message');
             expect(error.code).toBe(429);
             expect(error.retryable).toBe(true);
+            expect(error.retryAfterMs).toBe(1_500);
             expect(error.context).toEqual(mockContext);
             expect(error.originalError).toBe(originalError);
         });
@@ -64,7 +66,15 @@ describe('LlumiverseError', () => {
     describe('toJSON', () => {
         it('should serialize to JSON', () => {
             const originalError = new Error('Original error');
-            const error = new LlumiverseError('Test error', true, mockContext, originalError, 429, 'RateLimitError');
+            const error = new LlumiverseError(
+                'Test error',
+                true,
+                mockContext,
+                originalError,
+                429,
+                'RateLimitError',
+                1_500,
+            );
 
             const json = error.toJSON();
 
@@ -72,6 +82,7 @@ describe('LlumiverseError', () => {
             expect(json).toHaveProperty('message', 'Test error');
             expect(json).toHaveProperty('code', 429);
             expect(json).toHaveProperty('retryable', true);
+            expect(json).toHaveProperty('retryAfterMs', 1_500);
             expect(json).toHaveProperty('context', mockContext);
             expect(json).toHaveProperty('stack');
             expect(json).toHaveProperty('originalErrorMessage', 'Original error');

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -323,6 +323,12 @@ export class LlumiverseError extends Error {
     readonly retryable?: boolean;
 
     /**
+     * Provider-supplied delay before the request should be retried, in milliseconds.
+     * Undefined when the provider did not return a usable retry hint.
+     */
+    readonly retryAfterMs?: number;
+
+    /**
      * Context about where and how the error occurred.
      * Includes provider, model, operation type.
      */
@@ -341,11 +347,13 @@ export class LlumiverseError extends Error {
         originalError: unknown,
         code?: number,
         name?: string,
+        retryAfterMs?: number,
     ) {
         super(message);
         this.name = name || 'LlumiverseError';
         this.code = code;
         this.retryable = retryable;
+        this.retryAfterMs = retryAfterMs;
         this.context = context;
         this.originalError = originalError;
 
@@ -365,6 +373,7 @@ export class LlumiverseError extends Error {
             message: this.message,
             code: this.code,
             retryable: this.retryable,
+            retryAfterMs: this.retryAfterMs,
             context: this.context,
             stack: this.stack,
             // Include original error message if available

--- a/drivers/src/vertexai/models/gemini-error-handling.test.ts
+++ b/drivers/src/vertexai/models/gemini-error-handling.test.ts
@@ -138,6 +138,52 @@ describe('GeminiModelDefinition Error Handling', () => {
             expect(error.name).toBe('RESOURCE_EXHAUSTED');
         });
 
+        it('should preserve google.rpc.RetryInfo from the API error body', () => {
+            const googleError = {
+                status: 429,
+                message: JSON.stringify({
+                    error: {
+                        code: 429,
+                        status: 'RESOURCE_EXHAUSTED',
+                        message: 'Resource exhausted',
+                        details: [
+                            {
+                                '@type': 'type.googleapis.com/google.rpc.RetryInfo',
+                                retryDelay: '1.500s',
+                            },
+                        ],
+                    },
+                }),
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'gemini-2.0-flash',
+                operation: 'execute',
+            });
+
+            expect(error.retryAfterMs).toBe(1_500);
+            expect(error.toJSON().retryAfterMs).toBe(1_500);
+        });
+
+        it('should preserve Retry-After when the transport error exposes response headers', () => {
+            const googleError = {
+                status: 429,
+                message: 'RESOURCE_EXHAUSTED: Rate limit exceeded',
+                response: {
+                    headers: new Headers({ 'retry-after': '2' }),
+                },
+            };
+
+            const error = modelDef.formatLlumiverseError(driver, googleError, {
+                provider: 'vertexai',
+                model: 'gemini-2.0-flash',
+                operation: 'stream',
+            });
+
+            expect(error.retryAfterMs).toBe(2_000);
+        });
+
         it('should handle INTERNAL error (500) as retryable', () => {
             const googleError = {
                 status: 500,

--- a/drivers/src/vertexai/models/gemini.ts
+++ b/drivers/src/vertexai/models/gemini.ts
@@ -49,7 +49,95 @@ import { truncateBinaryForDebug } from '../../shared/debug-prompt.js';
 import type { GenerateContentPrompt, VertexAIDriver } from '../index.js';
 import type { ModelDefinition } from '../models.js';
 
-type GoogleApiErrorLike = Pick<ApiError, 'status' | 'message'>;
+type GoogleApiErrorLike = Pick<ApiError, 'status' | 'message'> & {
+    headers?: unknown;
+    response?: { headers?: unknown };
+    retryAfterMs?: unknown;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object';
+}
+
+function nonNegativeNumber(value: unknown): number | undefined {
+    const number =
+        typeof value === 'number'
+            ? value
+            : typeof value === 'string' && value.trim() !== ''
+              ? Number(value)
+              : Number.NaN;
+    return Number.isFinite(number) && number >= 0 ? number : undefined;
+}
+
+function headerValue(headers: unknown, name: string): string | undefined {
+    if (headers instanceof Headers) {
+        return headers.get(name) ?? undefined;
+    }
+    if (!isRecord(headers)) return undefined;
+
+    const entry = Object.entries(headers).find(([key]) => key.toLowerCase() === name);
+    return typeof entry?.[1] === 'string' ? entry[1] : undefined;
+}
+
+function retryAfterHeaderToMs(value: string | undefined): number | undefined {
+    if (value === undefined) return undefined;
+    const seconds = nonNegativeNumber(value);
+    if (seconds !== undefined) return seconds * 1_000;
+
+    const retryAt = Date.parse(value);
+    return Number.isNaN(retryAt) ? undefined : Math.max(0, retryAt - Date.now());
+}
+
+function protobufDurationToMs(value: unknown): number | undefined {
+    if (typeof value === 'string') {
+        const match = /^(\d+)(?:\.(\d{1,9}))?s$/.exec(value);
+        if (!match) return undefined;
+        const seconds = Number(match[1]);
+        const nanos = Number((match[2] ?? '').padEnd(9, '0'));
+        return seconds * 1_000 + Math.ceil(nanos / 1_000_000);
+    }
+    if (!isRecord(value)) return undefined;
+
+    const parsedSeconds = nonNegativeNumber(value.seconds);
+    const parsedNanos = nonNegativeNumber(value.nanos);
+    if ('seconds' in value && parsedSeconds === undefined) return undefined;
+    if ('nanos' in value && (parsedNanos === undefined || parsedNanos >= 1_000_000_000)) return undefined;
+    if (parsedSeconds === undefined && parsedNanos === undefined) return undefined;
+    const seconds = parsedSeconds ?? 0;
+    const nanos = parsedNanos ?? 0;
+    return seconds * 1_000 + Math.ceil(nanos / 1_000_000);
+}
+
+function retryInfoToMs(message: string): number | undefined {
+    try {
+        const body: unknown = JSON.parse(message);
+        if (!isRecord(body)) return undefined;
+        const error = isRecord(body.error) ? body.error : body;
+        if (!Array.isArray(error.details)) return undefined;
+
+        for (const detail of error.details) {
+            if (!isRecord(detail)) continue;
+            const type = detail['@type'];
+            if (typeof type !== 'string' || !type.endsWith('google.rpc.RetryInfo')) continue;
+            const delay = protobufDurationToMs(detail.retryDelay);
+            if (delay !== undefined) return delay;
+        }
+    } catch {
+        // ApiError messages are not guaranteed to contain a JSON response body.
+    }
+    return undefined;
+}
+
+function getGoogleRetryAfterMs(error: GoogleApiErrorLike): number | undefined {
+    const direct = nonNegativeNumber(error.retryAfterMs);
+    if (direct !== undefined) return direct;
+
+    const headers = error.headers ?? error.response?.headers;
+    const exact = nonNegativeNumber(headerValue(headers, 'x-retry-after-ms'));
+    if (exact !== undefined) return exact;
+
+    return retryAfterHeaderToMs(headerValue(headers, 'retry-after')) ?? retryInfoToMs(error.message);
+}
 
 function supportsStructuredOutput(options: PromptOptions): boolean {
     // Gemini 1.0 Ultra does not support JSON output, 1.0 Pro does.
@@ -876,6 +964,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
 
         // Extract error name/type from message if present
         const errorName = this.extractErrorName(message);
+        const retryAfterMs = getGoogleRetryAfterMs(apiError);
 
         return new LlumiverseError(
             `[${context.provider}] ${userMessage}`,
@@ -884,6 +973,7 @@ export class GeminiModelDefinition implements ModelDefinition<GenerateContentPro
             error,
             httpStatusCode,
             errorName,
+            retryAfterMs,
         );
     }
 


### PR DESCRIPTION
## Summary

- preserve a provider-supplied retry delay on `LlumiverseError` and its JSON representation
- extract Google `google.rpc.RetryInfo.retryDelay` metadata from Vertex error bodies
- normalize direct millisecond hints, `x-retry-after-ms`, and standard `Retry-After` when a transport exposes them
- add common error-contract and Vertex parsing tests

## Why

Vertex rate-limit responses can include an authoritative delay, but llumiverse currently drops it. Downstream retry policy then falls back to generic exponential backoff instead of respecting provider capacity guidance.

## Important limitation

Pinned `@google/genai` 2.13.0 constructs `ApiError` from only the status and response body; it discards failed-response headers. This PR captures `RetryInfo` available in the response body today and header-shaped hints if a future or custom transport exposes them. It does not monkey-patch the SDK transport and does not invent a delay when no usable hint is available. Guaranteed failed-response-header access requires an upstream SDK change.

Downstream adoption and package publishing are separate from this PR.

## Verification

- `pnpm --dir common lint`
- `pnpm --dir drivers lint`
- `pnpm --dir common typecheck:test`
- `pnpm --dir drivers typecheck:test`
- common tests — 134 passed
- drivers tests — 444 passed, 19 skipped
- all non-live functional tests — 718 passed, 17 skipped
- `pnpm format:check`
- `pnpm build` — 4/4 tasks
- `git diff --check`

No live Vertex call was made: a successful call cannot prove 429 metadata, and intentionally inducing quota pressure would be unsafe and non-deterministic.