### PR TITLE
fix(bedrock): drop Claude JSON prefill and honor the exclusive 128K output bound

### DIFF
--- a/common/src/capability/bedrock-models.ts
+++ b/common/src/capability/bedrock-models.ts
@@ -104,7 +104,10 @@ function getLimits(model: string): Pick<BedrockModelKnowledge, 'context_window' 
                 'claude-opus-4-8',
             ])
         ) {
-            return { context_window: 1_000_000, max_output_tokens: 131_072 };
+            // Bedrock enforces an EXCLUSIVE 128K bound for this family: it rejects
+            // max_tokens >= 128000 with "Try again with a maximum tokens value that
+            // is lower than 128000" (same exclusive-bound quirk as Haiku 4.5 below).
+            return { context_window: 1_000_000, max_output_tokens: 127_999 };
         }
         if (model.includes('claude-sonnet-4-6')) return { context_window: 1_000_000, max_output_tokens: 65_536 };
         // Bedrock documents 64K for Haiku 4.5 but rejects max_tokens=64000; its upper bound is exclusive.

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -43,7 +43,6 @@ import {
     getModelCapabilities,
     type HttpTimeoutOptions,
     incrementConversationTurn,
-    isClaudeVersionGTE,
     type JSONObject,
     LlumiverseError,
     type LlumiverseErrorContext,
@@ -320,7 +319,11 @@ export interface BedrockDriverOptions extends DriverOptions {
 function maxTokenFallbackClaude(option: StatelessExecutionOptions): number {
     const modelOptions = option.model_options as BedrockClaudeOptions | undefined;
     if (modelOptions && typeof modelOptions.max_tokens === 'number') {
-        return modelOptions.max_tokens;
+        // Clamp stored/user-provided values to the model's output limit: configs
+        // written for a larger-output model (or provider) otherwise pass through
+        // verbatim and Bedrock rejects the whole request with a ValidationException.
+        const limit = getMaxTokensLimitBedrock(option.model);
+        return limit ? Math.min(modelOptions.max_tokens, limit) : modelOptions.max_tokens;
     } else {
         let maxSupportedTokens = getMaxTokensLimitBedrock(option.model) ?? 8192; // Should always return a number for claude, 8192 is to satisfy the TypeScript type checker;
         // Fallback to the default max tokens limit for the model
@@ -1360,10 +1363,11 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
             }
         } else if (options.model.includes('claude')) {
             const claude_options = model_options as ModelOptions as BedrockClaudeOptions;
-            // Thinking is active when extended (budget set) or adaptive (effort set) thinking is enabled.
-            // JSON prefill is incompatible with active thinking.
-            const thinkingActive = claudeThinking.thinking != null && claudeThinking.thinking.type !== 'disabled';
-            supportsJSONPrefill = !thinkingActive;
+            // Claude never uses JSON prefill: newer models (4.6+) reject assistant
+            // message prefill outright, and every supported Claude follows the
+            // schema instruction injected into the prompt — so the model-version
+            // gate this used to need is gone. Titan/Nova (above) keep prefill as
+            // they have no native JSON adherence.
 
             // Claude 3.7+ supports thinking — use shared helper for reasoning_config
             if (claudeThinking.supportsThinking) {
@@ -1392,14 +1396,9 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
                     output_config: claudeThinking.outputConfig,
                 };
             }
-            // Claude 4.6 and later versions don't support JSON prefill
-            if (isClaudeVersionGTE(options.model, 4, 6)) {
-                supportsJSONPrefill = false;
-            }
-            // Needs max_tokens to be set
-            if (!model_options.max_tokens) {
-                model_options.max_tokens = maxTokenFallbackClaude(options);
-            }
+            // Needs max_tokens to be set — and caller-provided values clamped to
+            // the model's output limit (both handled by maxTokenFallbackClaude).
+            model_options.max_tokens = maxTokenFallbackClaude(options);
             // Only models without sampling restrictions support top_k
             if (!hasSamplingRestriction) {
                 additionalField = { ...additionalField, top_k: model_options.top_k };

--- a/drivers/src/bedrock/structured-output.test.ts
+++ b/drivers/src/bedrock/structured-output.test.ts
@@ -34,6 +34,55 @@ describe('Bedrock Converse structured output', () => {
         ]);
     });
 
+    it('never prefills an assistant JSON message for Claude models', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        for (const model of [
+            'anthropic.claude-3-5-sonnet-20241022-v2:0',
+            'anthropic.claude-sonnet-4-5',
+            'us.anthropic.claude-fable-5-20260115-v1:0',
+        ]) {
+            const payload = driver.preparePayload(
+                { modelId: undefined, messages: [{ role: 'user', content: [{ text: 'hello' }] }] },
+                { model, result_schema },
+            );
+            const last = payload.messages?.[payload.messages.length - 1];
+            expect(last?.role, model).toBe('user');
+        }
+    });
+
+    it('keeps the JSON prefill for Amazon models without native JSON adherence', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(
+            { modelId: undefined, messages: [{ role: 'user', content: [{ text: 'hello' }] }] },
+            { model: 'amazon.nova-pro-v1:0', result_schema },
+        );
+        const last = payload.messages?.[payload.messages.length - 1];
+        expect(last?.role).toBe('assistant');
+        expect(last?.content?.[0]?.text).toBe('```json');
+    });
+
+    it('clamps caller-provided max_tokens to the Claude model output limit', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(
+            { modelId: undefined, messages: [{ role: 'user', content: [{ text: 'hello' }] }] },
+            {
+                model: 'us.anthropic.claude-fable-5-20260115-v1:0',
+                model_options: { _option_id: 'bedrock-claude', max_tokens: 200_000 },
+            },
+        );
+        // Bedrock's bound for this family is exclusive at 128K (see bedrock-models.ts).
+        expect(payload.inferenceConfig?.maxTokens).toBe(127_999);
+    });
+
+    it('defaults max_tokens below Bedrock exclusive 128K bound when unset', () => {
+        const driver = new BedrockDriver({ region: 'us-east-1' });
+        const payload = driver.preparePayload(
+            { modelId: undefined, messages: [{ role: 'user', content: [{ text: 'hello' }] }] },
+            { model: 'us.anthropic.claude-fable-5-20260115-v1:0' },
+        );
+        expect(payload.inferenceConfig?.maxTokens).toBe(127_999);
+    });
+
     it('uses outputConfig for non-Claude models', () => {
         const driver = new BedrockDriver({ region: 'us-east-1' });
         const payload = driver.preparePayload(

--- a/drivers/src/shared/claude-messages.test.ts
+++ b/drivers/src/shared/claude-messages.test.ts
@@ -122,6 +122,54 @@ describe('formatClaudePrompt', () => {
         });
     });
 
+    it('appends a user turn when the conversation ends with an assistant message on no-prefill models', () => {
+        const options: ExecutionOptions = { model: 'claude-fable-5' };
+        const prompt = {
+            system: undefined,
+            messages: [
+                { role: 'user' as const, content: [{ type: 'text' as const, text: 'do the task' }] },
+                { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'partial answer' }] },
+            ],
+        };
+
+        const { payload } = getClaudePayload(options, prompt);
+
+        const last = payload.messages[payload.messages.length - 1];
+        expect(last).toEqual({ role: 'user', content: [{ type: 'text', text: 'Continue.' }] });
+    });
+
+    it('preserves intentional assistant prefill on pre-4.6 models', () => {
+        const options: ExecutionOptions = { model: 'claude-3-5-sonnet-20241022' };
+        const prompt = {
+            system: undefined,
+            messages: [
+                { role: 'user' as const, content: [{ type: 'text' as const, text: 'answer as JSON' }] },
+                { role: 'assistant' as const, content: [{ type: 'text' as const, text: '{' }] },
+            ],
+        };
+
+        const { payload } = getClaudePayload(options, prompt);
+
+        const last = payload.messages[payload.messages.length - 1];
+        expect(last?.role).toBe('assistant');
+    });
+
+    it('does not touch conversations already ending with a user turn', () => {
+        const options: ExecutionOptions = { model: 'claude-fable-5' };
+        const prompt = {
+            system: undefined,
+            messages: [
+                { role: 'assistant' as const, content: [{ type: 'text' as const, text: 'previous reply' }] },
+                { role: 'user' as const, content: [{ type: 'text' as const, text: 'next instruction' }] },
+            ],
+        };
+
+        const { payload } = getClaudePayload(options, prompt);
+
+        expect(payload.messages).toHaveLength(2);
+        expect(payload.messages[payload.messages.length - 1]?.role).toBe('user');
+    });
+
     it('preserves model-option cache controls when no routing identity is supplied', () => {
         const options: ExecutionOptions = {
             model: 'claude-sonnet-4-6',

--- a/drivers/src/shared/claude-messages.ts
+++ b/drivers/src/shared/claude-messages.ts
@@ -46,6 +46,7 @@ import {
     type ExecutionTokenUsage,
     getConversationMeta,
     incrementConversationTurn,
+    isClaudeVersionGTE,
     type JSONObject,
     LlumiverseError,
     type LlumiverseErrorContext,
@@ -713,6 +714,24 @@ export function getClaudePayload(
     const hasTools = options.tools && options.tools.length > 0;
     if (!hasTools && claudeMessagesContainToolBlocks(sanitizedMessages)) {
         sanitizedMessages = convertClaudeToolBlocksToText(sanitizedMessages);
+    }
+
+    // Claude 4.6+ rejects requests whose conversation ends with an assistant
+    // message ("does not support assistant message prefill"). A trailing
+    // assistant turn can emerge from upstream retry edges — e.g. a re-sent
+    // resume whose tool results were stripped as orphans above, leaving the
+    // previous attempt's reply last. Appending a minimal user turn converts a
+    // guaranteed 400 into a graceful continue — the same behavior pre-4.6
+    // models applied implicitly by treating the trailing turn as prefill.
+    // Older models are left untouched: prefill there can be intentional.
+    if (isClaudeVersionGTE(modelName, 4, 6)) {
+        const lastMessage = sanitizedMessages[sanitizedMessages.length - 1];
+        if (lastMessage?.role === 'assistant') {
+            sanitizedMessages = [
+                ...sanitizedMessages,
+                { role: 'user', content: [{ type: 'text', text: 'Continue.' }] },
+            ];
+        }
     }
 
     sanitizedMessages = stripClaudeCacheControlFromMessages(sanitizedMessages);


### PR DESCRIPTION
## Summary
Two Bedrock Claude request-shape fixes, both observed as live 400s:

- **Remove assistant JSON prefill for Claude entirely.** Newer Claude models (4.6+) reject assistant message prefill (`This model does not support assistant message prefill. The conversation must end with a user message.`), and every supported Claude version follows the JSON-schema instruction the formatter already injects into the prompt — so the prefill added no reliability while the per-version gate (`isClaudeVersionGTE(model, 4, 6)`) was a live footgun for every new model name the parser might miss. Titan/Nova keep the prefill: they have no native JSON adherence and don't reject it.
- **Honor Bedrock's exclusive 128K output bound for the 1M-window Claude family** (fable-5 / sonnet-5 / mythos / opus-4-6+). Bedrock rejects `max_tokens >= 128000` (`The maximum tokens you requested exceeds the model limit of 128000. Try again with a maximum tokens value that is lower than 128000.`) — the same exclusive-bound quirk already documented in the table for Haiku 4.5's 64K. The capability table claimed 131072, so even the driver's own default overshot. The table now returns 127999, and caller-provided `max_tokens` (from stored model configs, possibly written for a bigger-output provider) are clamped to the model limit instead of passing through verbatim.

- **Recover trailing-assistant conversations on no-prefill models (shared Claude path — Anthropic API, Vertex, Bedrock Mantle).** Upstream retry edges can re-send a resume whose tool results are stripped as orphans, leaving the previous attempt's assistant reply as the last message. Pre-4.6 models silently treated that as prefill and continued; 4.6+ hard-fails with the prefill 400. `getClaudePayload` now appends a minimal `Continue.` user turn in that case (4.6+ only — a trailing assistant message on older models can be intentional prefill).

## Test Plan
- [x] `common`: build + 134 tests
- [x] `drivers`: build + full bedrock suite (105 tests), incl. new cases: no prefill across Claude 3.5/4.5/5-family, prefill preserved for Nova, caller `max_tokens` clamped to 127999, unset `max_tokens` defaults below the exclusive bound
- [x] `pnpm lint` (biome) clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Bedrock Claude request assembly and token limits for production inference; behavior changes are intentional fixes for 400s but affect all Claude structured-output and high max_tokens paths.
> 
> **Overview**
> Fixes **live Bedrock ValidationExceptions** on Claude by aligning request shape with API rules that reject assistant prefill and `max_tokens` at or above documented caps.
> 
> **Structured output:** The Bedrock driver **no longer adds assistant ` ```json ` prefill for any Claude model** (Amazon Nova/Titan still use it). Claude relies on the existing JSON-schema system prompt instead. **`max_tokens` is always set via `maxTokenFallbackClaude`**, which **clamps** stored or user values to `getMaxTokensLimitBedrock` so oversized configs from other providers don’t pass through.
> 
> **Capability table:** For the 1M-context Claude family (fable-5, sonnet-5, mythos, opus 4.6+), **`max_output_tokens` is lowered from 131072 to 127999** because Bedrock treats 128K as an exclusive upper bound (same pattern as Haiku 4.5 at 64K).
> 
> **Shared Claude path:** In `getClaudePayload`, **Claude 4.6+ conversations that end with an assistant message get a minimal `Continue.` user turn**, avoiding prefill-related 400s on retries/resumes without changing pre-4.6 intentional prefill behavior.
> 
> Tests cover no Claude prefill, Nova prefill preserved, token clamping/defaults, and trailing-assistant handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ebb9e5df983b4f3efa1d7ceea7be0a96c240d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

