### PR TITLE
feat(common): define the API contracts as runtime Zod schemas

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -33,6 +33,10 @@
         ".": {
             "types": "./lib/index.d.ts",
             "default": "./lib/index.js"
+        },
+        "./schemas": {
+            "types": "./lib/schemas/index.d.ts",
+            "default": "./lib/schemas/index.js"
         }
     },
     "scripts": {
@@ -48,6 +52,9 @@
     "repository": {
         "type": "git",
         "url": "git+ssh://git@github.com/vertesia/llumiverse.git"
+    },
+    "dependencies": {
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@types/node": "catalog:",

--- a/common/src/options/bedrock.ts
+++ b/common/src/options/bedrock.ts
@@ -1,4 +1,17 @@
+import type { z } from 'zod';
 import { getBedrockModelKnowledge } from '../capability/bedrock-models.js';
+import type {
+    BedrockAI21OptionsSchema,
+    BedrockClaudeOptionsSchema,
+    BedrockCohereCommandOptionsSchema,
+    BedrockConverseOptionsSchema,
+    BedrockGptOssOptionsSchema,
+    BedrockMistralOptionsSchema,
+    BedrockNovaOptionsSchema,
+    BedrockPalmyraOptionsSchema,
+    NovaCanvasOptionsSchema,
+    TwelvelabsPegasusOptionsSchema,
+} from '../schemas/model-options.js';
 import { type ModelOptionInfoItem, type ModelOptions, type ModelOptionsInfo, OptionType } from '../types.js';
 import {
     buildClaudeCacheOptions,
@@ -9,6 +22,34 @@ import {
     getClaudeMaxTokensLimit,
 } from './shared-parsing.js';
 import { hasSamplingParameterRestriction } from './version-parsing.js';
+
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type NovaCanvasOptions = z.infer<typeof NovaCanvasOptionsSchema>;
+export type BedrockConverseOptions = z.infer<typeof BedrockConverseOptionsSchema>;
+export type BedrockNovaOptions = z.infer<typeof BedrockNovaOptionsSchema>;
+export type BedrockMistralOptions = z.infer<typeof BedrockMistralOptionsSchema>;
+export type BedrockAI21Options = z.infer<typeof BedrockAI21OptionsSchema>;
+export type BedrockCohereCommandOptions = z.infer<typeof BedrockCohereCommandOptionsSchema>;
+export type BedrockClaudeOptions = z.infer<typeof BedrockClaudeOptionsSchema>;
+export type BedrockPalmyraOptions = z.infer<typeof BedrockPalmyraOptionsSchema>;
+export type BedrockGptOssOptions = z.infer<typeof BedrockGptOssOptionsSchema>;
+export type TwelvelabsPegasusOptions = z.infer<typeof TwelvelabsPegasusOptionsSchema>;
+
+/**
+ * The shared Converse shape, re-expressed over the schema-derived type so it states nothing of its
+ * own. Kept because it is a published `@llumiverse/common` export, and because it still says the
+ * true thing: the five plain Converse option sets differ only in their discriminator.
+ */
+export type BaseConverseOptions<TOptionId extends string = string> = Omit<BedrockConverseOptions, '_option_id'> & {
+    _option_id: TOptionId;
+};
 
 /**
  * Union type of all Bedrock options
@@ -26,71 +67,6 @@ export type BedrockOptions =
     | BedrockPalmyraOptions
     | BedrockGptOssOptions
     | TwelvelabsPegasusOptions;
-
-export interface NovaCanvasOptions {
-    _option_id: 'bedrock-nova-canvas';
-    taskType:
-        | 'TEXT_IMAGE'
-        | 'TEXT_IMAGE_WITH_IMAGE_CONDITIONING'
-        | 'COLOR_GUIDED_GENERATION'
-        | 'IMAGE_VARIATION'
-        | 'INPAINTING'
-        | 'OUTPAINTING'
-        | 'BACKGROUND_REMOVAL';
-    width?: number;
-    height?: number;
-    quality?: 'standard' | 'premium';
-    cfgScale?: number;
-    seed?: number;
-    numberOfImages?: number;
-    controlMode?: 'CANNY_EDGE' | 'SEGMENTATION';
-    controlStrength?: number;
-    colors?: string[];
-    similarityStrength?: number;
-    outPaintingMode?: 'DEFAULT' | 'PRECISE';
-}
-
-export interface BaseConverseOptions<TOptionId extends string = string> {
-    _option_id: TOptionId;
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    stop_sequence?: string[];
-}
-
-export type BedrockConverseOptions = BaseConverseOptions<'bedrock-converse'>;
-export type BedrockNovaOptions = BaseConverseOptions<'bedrock-nova'>;
-export type BedrockMistralOptions = BaseConverseOptions<'bedrock-mistral'>;
-export type BedrockAI21Options = BaseConverseOptions<'bedrock-ai21'>;
-export type BedrockCohereCommandOptions = BaseConverseOptions<'bedrock-cohere-command'>;
-
-export interface BedrockClaudeOptions extends BaseConverseOptions<'bedrock-claude'> {
-    top_k?: number;
-    thinking_budget_tokens?: number;
-    include_thoughts?: boolean;
-    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-    cache_enabled?: boolean;
-    cache_ttl?: '5m' | '1h';
-}
-
-export interface BedrockPalmyraOptions extends BaseConverseOptions<'bedrock-palmyra'> {
-    min_tokens?: number;
-    seed?: number;
-    frequency_penalty?: number;
-    presence_penalty?: number;
-}
-
-export interface BedrockGptOssOptions extends BaseConverseOptions<'bedrock-gpt-oss'> {
-    reasoning_effort?: 'low' | 'medium' | 'high';
-    frequency_penalty?: number;
-    presence_penalty?: number;
-}
-
-export interface TwelvelabsPegasusOptions {
-    _option_id: 'bedrock-twelvelabs-pegasus';
-    temperature?: number;
-    max_tokens?: number;
-}
 
 export function getMaxTokensLimitBedrock(model: string): number | undefined {
     const documentedLimit = getBedrockModelKnowledge(model).max_output_tokens;

--- a/common/src/options/bedrock_mantle.ts
+++ b/common/src/options/bedrock_mantle.ts
@@ -1,43 +1,28 @@
+import type { z } from 'zod';
 import { getBedrockModelKnowledge } from '../capability/bedrock-models.js';
+import type {
+    BedrockMantleChatCompletionsOptionsSchema,
+    BedrockMantleClaudeOptionsSchema,
+    BedrockMantleResponsesOptionsSchema,
+} from '../schemas/model-options.js';
 import { type ModelOptionInfoItem, type ModelOptions, type ModelOptionsInfo, OptionType } from '../types.js';
 import { getAnthropicOptions } from './anthropic.js';
 import { textOptionsFallback } from './fallback.js';
 import { isModelFamilyVersionGTE } from './version-parsing.js';
 
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type BedrockMantleResponsesOptions = z.infer<typeof BedrockMantleResponsesOptionsSchema>;
+export type BedrockMantleChatCompletionsOptions = z.infer<typeof BedrockMantleChatCompletionsOptionsSchema>;
+export type BedrockMantleClaudeOptions = z.infer<typeof BedrockMantleClaudeOptionsSchema>;
+
 export type BedrockMantleProtocol = 'responses' | 'chat_completions' | 'messages';
-
-export interface BedrockMantleResponsesOptions {
-    _option_id: 'bedrock-mantle-responses';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
-    reasoning_effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
-    verbosity?: 'low' | 'medium' | 'high';
-    image_detail?: 'low' | 'high' | 'auto';
-}
-
-export interface BedrockMantleChatCompletionsOptions {
-    _option_id: 'bedrock-mantle-chat-completions';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    stop_sequence?: string[];
-}
-
-export interface BedrockMantleClaudeOptions {
-    _option_id: 'bedrock-mantle-claude';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    stop_sequence?: string[];
-    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-    thinking_budget_tokens?: number;
-    include_thoughts?: boolean;
-    cache_enabled?: boolean;
-    cache_ttl?: '5m' | '1h';
-}
 
 /**
  * @discriminator _option_id

--- a/common/src/options/fallback.ts
+++ b/common/src/options/fallback.ts
@@ -1,15 +1,16 @@
+import type { z } from 'zod';
+import type { TextFallbackOptionsSchema } from '../schemas/model-options.js';
 import { type ModelOptionsInfo, OptionType, SharedOptions } from '../types.js';
 
-export interface TextFallbackOptions {
-    _option_id: 'text-fallback'; //For specific models should be format as "provider-model"
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    presence_penalty?: number;
-    frequency_penalty?: number;
-    stop_sequence?: string[];
-}
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type TextFallbackOptions = z.infer<typeof TextFallbackOptionsSchema>;
 
 export const textOptionsFallback: ModelOptionsInfo = {
     _option_id: 'text-fallback',

--- a/common/src/options/groq.ts
+++ b/common/src/options/groq.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+import type { GroqOptionsSchema } from '../schemas/model-options.js';
 import {
     type ModelOptionInfoItem,
     type ModelOptions,
@@ -7,19 +9,18 @@ import {
 } from '../types.js';
 import { textOptionsFallback } from './fallback.js';
 
-// Union type of all Bedrock options
-export type GroqOptions = GroqDeepseekThinkingOptions;
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type GroqOptions = z.infer<typeof GroqOptionsSchema>;
 
-export interface GroqDeepseekThinkingOptions {
-    _option_id: 'groq-deepseek-thinking';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    presence_penalty?: number;
-    frequency_penalty?: number;
-    stop_sequence?: string[];
-    reasoning_format: 'parsed' | 'raw' | 'hidden';
-}
+/** The only member of the Groq union today; kept as its own name because the driver narrows to it. */
+export type GroqDeepseekThinkingOptions = GroqOptions;
 
 export function getGroqOptions(model: string, _option?: ModelOptions): ModelOptionsInfo {
     if (model.includes('deepseek') && model.includes('r1')) {

--- a/common/src/options/openai.ts
+++ b/common/src/options/openai.ts
@@ -1,55 +1,38 @@
+import type { z } from 'zod';
+import type {
+    OpenAiDalleOptionsSchema,
+    OpenAiGptImageOptionsSchema,
+    OpenAiTextOptionsSchema,
+    OpenAiThinkingOptionsSchema,
+} from '../schemas/model-options.js';
 import {
     type ModelOptionInfoItem,
     type ModelOptions,
     type ModelOptionsInfo,
     OptionType,
-    type ReasoningEffort,
     SharedOptions,
 } from '../types.js';
 import { getMaxOutputTokens } from './context-windows.js';
 import { getOpenAIReasoningEffortLevels, isOpenAIGptVersionGTE } from './version-parsing.js';
+
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type OpenAiThinkingOptions = z.infer<typeof OpenAiThinkingOptionsSchema>;
+export type OpenAiTextOptions = z.infer<typeof OpenAiTextOptionsSchema>;
+export type OpenAiDalleOptions = z.infer<typeof OpenAiDalleOptionsSchema>;
+export type OpenAiGptImageOptions = z.infer<typeof OpenAiGptImageOptionsSchema>;
 
 // Union type of all OpenAI options
 /**
  * @discriminator _option_id
  */
 export type OpenAiOptions = OpenAiThinkingOptions | OpenAiTextOptions | OpenAiDalleOptions | OpenAiGptImageOptions;
-
-export interface OpenAiThinkingOptions {
-    _option_id: 'openai-thinking';
-    max_tokens?: number;
-    stop_sequence?: string[];
-    effort?: ReasoningEffort;
-    reasoning_effort?: ReasoningEffort;
-    image_detail?: 'low' | 'high' | 'auto';
-}
-
-export interface OpenAiTextOptions {
-    _option_id: 'openai-text';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    presence_penalty?: number;
-    frequency_penalty?: number;
-    stop_sequence?: string[];
-    image_detail?: 'low' | 'high' | 'auto';
-}
-export interface OpenAiDalleOptions {
-    _option_id: 'openai-dalle';
-    size?: '256x256' | '512x512' | '1024x1024' | '1792x1024' | '1024x1792';
-    image_quality?: 'standard' | 'hd';
-    style?: 'vivid' | 'natural';
-    response_format?: 'url' | 'b64_json';
-    n?: number;
-}
-
-export interface OpenAiGptImageOptions {
-    _option_id: 'openai-gpt-image';
-    size?: '1024x1024' | '1024x1536' | '1536x1024' | 'auto';
-    image_quality?: 'low' | 'medium' | 'high' | 'auto';
-    background?: 'transparent' | 'opaque' | 'auto';
-    output_format?: 'png' | 'webp' | 'jpeg';
-}
 
 export function getOpenAiOptions(model: string, _option?: ModelOptions): ModelOptionsInfo {
     const visionOptions: ModelOptionInfoItem[] = isVisionModel(model)

--- a/common/src/options/vertexai.ts
+++ b/common/src/options/vertexai.ts
@@ -1,3 +1,10 @@
+import type { z } from 'zod';
+import type {
+    ImagenOptionsSchema,
+    VertexAIClaudeOptionsSchema,
+    VertexAIGeminiOptionsSchema,
+    VertexAIGrokOptionsSchema,
+} from '../schemas/model-options.js';
 import {
     type ModelOptionInfoItem,
     type ModelOptions,
@@ -16,6 +23,19 @@ import {
     getClaudeMaxTokensLimit,
 } from './shared-parsing.js';
 import { hasSamplingParameterRestriction, isGeminiModelVersionGte } from './version-parsing.js';
+
+// The option shapes are DERIVED, not declared. Each schema in `../schemas/model-options.js` is the
+// single definition of its option set: it is what the OpenAPI document publishes, what AJV enforces,
+// and — through `z.infer` below — what TypeScript sees. There is nothing here to keep in step with
+// anything, because there is only one statement of the shape.
+//
+// The OpenAPI scanner short-circuits these aliases to the component of the same name rather than
+// trying to expand `z.infer`, which it cannot do. That is why the alias name, the schema variable
+// and the published component id must all agree; generation fails loudly if they do not.
+export type ImagenOptions = z.infer<typeof ImagenOptionsSchema>;
+export type VertexAIClaudeOptions = z.infer<typeof VertexAIClaudeOptionsSchema>;
+export type VertexAIGeminiOptions = z.infer<typeof VertexAIGeminiOptionsSchema>;
+export type VertexAIGrokOptions = z.infer<typeof VertexAIGrokOptionsSchema>;
 
 // Union type of all VertexAI options
 /**
@@ -48,80 +68,6 @@ export enum ThinkingLevel {
     LOW = 'LOW',
     MINIMAL = 'MINIMAL',
     THINKING_LEVEL_UNSPECIFIED = 'THINKING_LEVEL_UNSPECIFIED',
-}
-
-export interface ImagenOptions {
-    _option_id: 'vertexai-imagen';
-
-    //General and generate options
-    number_of_images?: number;
-    seed?: number;
-    person_generation?: 'dont_allow' | 'allow_adults' | 'allow_all';
-    safety_setting?: 'block_none' | 'block_only_high' | 'block_medium_and_above' | 'block_low_and_above'; //The "off" option does not seem to work for Imagen 3, might be only for text models
-    image_file_type?: 'image/jpeg' | 'image/png';
-    jpeg_compression_quality?: number;
-    aspect_ratio?: '1:1' | '4:3' | '3:4' | '16:9' | '9:16';
-    add_watermark?: boolean;
-    enhance_prompt?: boolean;
-
-    //Capability options
-    edit_mode?: ImagenTaskType;
-    guidance_scale?: number;
-    edit_steps?: number;
-    mask_mode?: ImagenMaskMode;
-    mask_dilation?: number;
-    mask_class?: number[];
-
-    //Customization options
-    controlType?: 'CONTROL_TYPE_FACE_MESH' | 'CONTROL_TYPE_CANNY' | 'CONTROL_TYPE_SCRIBBLE';
-    controlImageComputation?: boolean;
-    subjectType?: 'SUBJECT_TYPE_PERSON' | 'SUBJECT_TYPE_ANIMAL' | 'SUBJECT_TYPE_PRODUCT' | 'SUBJECT_TYPE_DEFAULT';
-}
-
-export interface VertexAIClaudeOptions {
-    _option_id: 'vertexai-claude';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    stop_sequence?: string[];
-    effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
-    thinking_budget_tokens?: number;
-    include_thoughts?: boolean;
-    cache_enabled?: boolean;
-    cache_ttl?: '5m' | '1h';
-}
-
-export interface VertexAIGeminiOptions {
-    _option_id: 'vertexai-gemini';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    top_k?: number;
-    stop_sequence?: string[];
-    presence_penalty?: number;
-    frequency_penalty?: number;
-    seed?: number;
-    effort?: 'minimal' | 'low' | 'medium' | 'high';
-    include_thoughts?: boolean;
-    thinking_budget_tokens?: number;
-    thinking_level?: ThinkingLevel;
-    flex?: boolean;
-    // ImageConfig properties
-    image_aspect_ratio?: '1:1' | '2:3' | '3:2' | '3:4' | '4:3' | '9:16' | '16:9' | '21:9';
-    image_size?: '1K' | '2K' | '4K';
-    person_generation?: 'ALLOW_ALL' | 'ALLOW_ADULT' | 'ALLOW_NONE';
-    prominent_people?: 'PROMINENT_PEOPLE_UNSPECIFIED' | 'ALLOW_PROMINENT_PEOPLE' | 'BLOCK_PROMINENT_PEOPLE';
-    output_mime_type?: 'image/png' | 'image/jpeg';
-    output_compression_quality?: number;
-}
-
-export interface VertexAIGrokOptions {
-    _option_id: 'vertexai-grok';
-    max_tokens?: number;
-    temperature?: number;
-    top_p?: number;
-    stop_sequence?: string[];
 }
 
 /** Models that support Flex processing (shared, cost-efficient tier). */

--- a/common/src/schemas/completion.ts
+++ b/common/src/schemas/completion.ts
@@ -1,0 +1,184 @@
+import { z } from 'zod';
+import type { JSONObject, JSONValue } from '../types.js';
+// biome-ignore lint/suspicious/noDeprecatedImports: publishing a deprecated field's schema requires the deprecated enum
+import { Modalities, PromptRole } from '../types.js';
+import { HttpTimeoutOptionsSchema } from './http-timeout.js';
+import { JSONSchemaSchema } from './json-schema.js';
+import { ModelOptionsSchema } from './model-options.js';
+
+// Runtime schemas for the completion types that reach a public API contract: what a prompt is made
+// of, what a model returns, and the execution options a caller may send.
+//
+// `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration
+// is picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
+
+// `z.any()` annotated as `ZodType<JSONValue>`, the same arrangement `JSONSchemaSchema` uses and for
+// the same reason. `JSONValue` is recursive, so a faithful Zod schema would be a `z.lazy` union —
+// and would publish that union, where the component has always been the unconstrained `{}`. So the
+// RUNTIME schema stays unconstrained (a value that came out of `JSON.parse` is JSON by
+// construction), and the annotation gives every field built from these the type the API documents:
+// `test_data?: JSONObject` has to stay `JSONObject`, not decay to `{[k: string]: unknown}`.
+export const JSONValueSchema: z.ZodType<JSONValue> = z.any().meta({ id: 'JSONValue' });
+
+// A map, written as an object with a catchall rather than `z.record`: `z.record` also emits a
+// `propertyNames: {type: 'string'}` that the index signature never published.
+export const JSONObjectSchema: z.ZodType<JSONObject> = z
+    .object({})
+    .catchall(JSONValueSchema)
+    .meta({ id: 'JSONObject' });
+
+// `z.enum(PromptRole)` over the TS enum rather than a restated member list: the enum is a value that
+// callers write (`{ role: PromptRole.user }`), and a string-literal union here would infer a type
+// those calls no longer satisfy. Same for `Modalities`.
+export const PromptRoleSchema = z.enum(PromptRole).meta({ id: 'PromptRole' });
+
+export const ModalitiesSchema = z.enum(Modalities).meta({ id: 'Modalities' });
+
+// The wire form of a data source: what it is called and what it contains. The BYTES are not here —
+// a `DataSource` in memory can hand back a stream, and the published component has only ever
+// described these two fields.
+export const DataSourceSchema = z
+    .strictObject({
+        name: z.string(),
+        mime_type: z.string(),
+    })
+    .meta({ id: 'DataSource' });
+
+export const PromptSegmentSchema = z
+    .strictObject({
+        role: PromptRoleSchema,
+        content: z.string(),
+        tool_use_id: z.string().meta({ description: 'The tool use id if the segment is a tool response' }).optional(),
+        thought_signature: z
+            .string()
+            .meta({
+                description:
+                    'Gemini thinking models require thought_signature to be passed back with tool results. ' +
+                    'This should be copied from the ToolUse.thought_signature when sending tool responses.',
+            })
+            .optional(),
+        files: z.array(DataSourceSchema).optional(),
+    })
+    .meta({ id: 'PromptSegment' });
+
+export const ToolDefinitionSchema = z
+    .strictObject({
+        name: z.string(),
+        description: z.string().optional(),
+        // `looseObject`, matching the permissive `input_schema` the published component has always
+        // carried: it holds either an AJV `JSONSchemaType<T>` or a plain object schema. The
+        // `additionalProperties: true` is stated rather than left as Zod's equivalent `{}` because
+        // `true` is the spelling the published document carries, and a component the registry owns
+        // has to be published exactly as the registry defines it.
+        input_schema: z.looseObject({}).meta({ additionalProperties: true }),
+    })
+    .meta({
+        id: 'ToolDefinition',
+        description:
+            'Tool definition for LLM tool use. The input_schema uses a permissive type to support both:\n' +
+            "- AJV's JSONSchemaType<T> for type-safe schema generation\n" +
+            '- Plain object schemas for simpler cases',
+    });
+
+export const ToolUseSchema = z
+    .strictObject({
+        id: z.string(),
+        tool_name: z.string(),
+        tool_input: z.union([JSONObjectSchema, z.null()]),
+        thought_signature: z
+            .string()
+            .meta({
+                description:
+                    'Gemini thinking models require thought_signature to be passed back with tool results. This ' +
+                    "preserves the model's reasoning state during multi-turn tool use.",
+            })
+            .optional(),
+    })
+    .meta({
+        id: 'ToolUse',
+        description:
+            'A tool use instance represents a call to a tool. The id property is used to identify the tool call.',
+    });
+
+export const TextResultSchema = z
+    .strictObject({ type: z.literal('text'), value: z.string() })
+    .meta({ id: 'TextResult' });
+
+export const JsonResultSchema = z
+    .strictObject({ type: z.literal('json'), value: JSONValueSchema })
+    .meta({ id: 'JsonResult' });
+
+export const ImageResultSchema = z
+    .strictObject({ type: z.literal('image'), value: z.string() })
+    .meta({ id: 'ImageResult' });
+
+export const CompletionResultSchema = z
+    .discriminatedUnion('type', [TextResultSchema, JsonResultSchema, ImageResultSchema])
+    .meta({ id: 'CompletionResult' });
+
+export const ExecutionTokenUsageSchema = z
+    .strictObject({
+        prompt: z.number().optional(),
+        result: z.number().optional(),
+        total: z.number().optional(),
+        prompt_cached: z
+            .number()
+            .meta({ description: 'Number of input tokens read from prompt cache (discounted rate).' })
+            .optional(),
+        prompt_cache_write: z
+            .number()
+            .meta({ description: 'Number of input tokens written to prompt cache.' })
+            .optional(),
+        prompt_new: z.number().optional(),
+    })
+    .meta({ id: 'ExecutionTokenUsage' });
+
+// `format` is NOT here, and its absence is the point. `PromptOptions.format` is a `PromptFormatter`
+// — a FUNCTION — which the scanner published as an object with `namedArgs` and `returns` that no
+// caller could ever send. It stays on `ExecutionOptions`, which is the in-process type the drivers
+// take, so the wire component describes only what can cross a wire.
+export const StatelessExecutionOptionsSchema = z
+    .strictObject({
+        model: z.string(),
+        result_schema: JSONSchemaSchema.optional(),
+        prompt_cache_schema_suffix: z
+            .boolean()
+            .meta({
+                description:
+                    'Provider-specific opt-in to put the result schema after the cached prompt prefix instead of ' +
+                    'including it in native structured-output configuration. The returned JSON is still validated ' +
+                    'against result_schema by Llumiverse.',
+            })
+            .optional(),
+        include_original_response: z
+            .boolean()
+            .meta({
+                description:
+                    'If set to true the original response from the target LLM will be included in the response ' +
+                    'under the original_response field. This is useful for debugging and for some advanced use ' +
+                    'cases. It is ignored on streaming requests',
+            })
+            .optional(),
+        model_options: ModelOptionsSchema.optional(),
+        prompt_cache_key: z
+            .string()
+            .meta({
+                description:
+                    'Stable identity for prompt caching. Providers with cache routing keys receive the value ' +
+                    'directly; providers with cache breakpoints use its presence to cache the stable prefix before ' +
+                    'the final dynamic block. Providers with fully implicit caching still require an identical ' +
+                    'prompt prefix.',
+            })
+            .optional(),
+        httpTimeout: HttpTimeoutOptionsSchema.meta({
+            description:
+                "Per-call HTTP timeouts for upstream LLM-provider calls. These override the driver's default " +
+                '`DriverOptions.httpTimeout` for this execution only.',
+        }).optional(),
+        output_modality: ModalitiesSchema.meta({
+            description: 'Deprecated: This is deprecated. Use CompletionResult.type information instead.',
+            deprecated: true,
+            'x-deprecated-message': 'This is deprecated. Use CompletionResult.type information instead.',
+        }).optional(),
+    })
+    .meta({ id: 'StatelessExecutionOptions' });

--- a/common/src/schemas/embeddings.ts
+++ b/common/src/schemas/embeddings.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod';
+
+// Runtime schemas for the embedding result types that studio-server publishes from
+// `POST /environments/:envId/embeddings`.
+//
+// The request half of that endpoint is NOT here: the wire format a caller sends carries a
+// JSON-friendly source (a URL or base64 text) rather than the `DataSource` a driver consumes, so it
+// is a Vertesia type (`EmbeddingsApiRequest`) rather than a llumiverse one. The result half is
+// identical on both sides — vectors and counts are already JSON — so it is defined once, here.
+//
+// `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration
+// is picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
+
+export const EmbeddingTaskTypeSchema = z.enum(['query', 'document']).meta({
+    id: 'EmbeddingTaskType',
+    description:
+        'Semantic task type for embedding models. Drivers map these to provider- specific values ' +
+        '(e.g. "RETRIEVAL_QUERY" for Vertex, "search_query" for Cohere).\n' +
+        '- "query"    — a search query to find relevant documents\n' +
+        '- "document" — a document to be indexed and retrieved',
+});
+
+export const EmbeddingOutputSchema = z
+    .strictObject({
+        values: z.array(z.number()),
+        modality: z
+            .enum(['text', 'image', 'video', 'audio'])
+            .meta({ description: 'Which modality this vector represents (useful for joint-multimodal results).' })
+            .optional(),
+        start_sec: z.number().meta({ description: 'Segment start time for video/audio.' }).optional(),
+        end_sec: z.number().meta({ description: 'Segment end time for video/audio.' }).optional(),
+        embedding_option: z
+            .string()
+            .meta({ description: 'TwelveLabs Marengo: which view of the segment this vector represents.' })
+            .optional(),
+    })
+    .meta({ id: 'EmbeddingOutput' });
+
+export const EmbeddingResultItemSchema = z
+    .strictObject({
+        outputs: z.array(EmbeddingOutputSchema).meta({
+            description:
+                'One or more vectors produced for this input. Single vector for text/image; multiple for ' +
+                'segmented video/audio or joint-multimodal models that return per-modality vectors.',
+        }),
+        input_tokens: z
+            .number()
+            .meta({ description: 'Token count attributed to this input, when reported by the provider.' })
+            .optional(),
+    })
+    .meta({ id: 'EmbeddingResultItem' });
+
+export const EmbeddingsTokenUsageSchema = z
+    .strictObject({
+        input_tokens: z.number().optional(),
+        input_text_tokens: z.number().optional(),
+        input_image_tokens: z.number().optional(),
+    })
+    .meta({ id: 'EmbeddingsTokenUsage' });
+
+export const EmbeddingsResultSchema = z
+    .strictObject({
+        results: z.array(EmbeddingResultItemSchema).meta({
+            description: 'One result item per input, in the same order as EmbeddingsOptions.inputs.',
+        }),
+        model: z.string().meta({ description: 'The provider model id that produced the result.' }),
+        usage: EmbeddingsTokenUsageSchema.meta({
+            description: 'Aggregate token usage when reported by the provider.',
+        }).optional(),
+    })
+    .meta({ id: 'EmbeddingsResult' });

--- a/common/src/schemas/http-timeout.test.ts
+++ b/common/src/schemas/http-timeout.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { HttpTimeoutOptions } from '../types.js';
+import { HttpTimeoutOptionsSchema } from './http-timeout.js';
+
+/** Exact type identity — `extends` in both directions is too weak (`any`/`unknown` slip through). */
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+function assertType<T extends true>(_ok: T): void {}
+
+/**
+ * `HttpTimeoutOptions` is published by Vertesia as a component of `InteractionExecutionConfiguration`,
+ * and it converts here rather than there because this is where the type is declared. The emission is
+ * asserted rather than described: the component was derived from this interface's TSDoc for several
+ * releases, and the conversion is only sound if the schema reproduces it exactly — including the run
+ * of spaces where the scanner collapsed the defaults list onto one line.
+ */
+const emitted = z.toJSONSchema(HttpTimeoutOptionsSchema, { target: 'draft-2020-12', io: 'input' }) as Record<
+    string,
+    unknown
+>;
+
+describe('HttpTimeoutOptionsSchema', () => {
+    it('is the only definition — the public type is inferred from it', () => {
+        // Vacuous as an equality, and that is the point: it fails to COMPILE if the interface is ever
+        // restated beside the schema, which is the regression this guards.
+        assertType<Equals<HttpTimeoutOptions, z.infer<typeof HttpTimeoutOptionsSchema>>>(true);
+        assertType<Equals<HttpTimeoutOptions['bodyTimeout'], number | undefined>>(true);
+    });
+
+    it('emits the four optional millisecond fields and nothing else', () => {
+        const properties = emitted.properties as Record<string, { type: string; description: string }>;
+        expect(Object.keys(properties)).toEqual([
+            'headersTimeout',
+            'bodyTimeout',
+            'connectTimeout',
+            'keepAliveTimeout',
+        ]);
+        for (const property of Object.values(properties)) {
+            expect(property.type).toBe('number');
+            expect(property.description).toBeTruthy();
+        }
+        // No `required`: every field is optional, which is what the published component says.
+        expect(emitted.required).toBeUndefined();
+    });
+
+    it('rejects an unknown timeout instead of discarding it', () => {
+        // `strictObject`, not `object`. The published component has always said
+        // `additionalProperties: false`; plain `z.object` would have PARSED this successfully by
+        // dropping the key, so the document would promise a rejection the schema never performed.
+        expect(emitted.additionalProperties).toBe(false);
+        expect(HttpTimeoutOptionsSchema.safeParse({ bodyTimeout: 90_000 }).success).toBe(true);
+        expect(HttpTimeoutOptionsSchema.safeParse({ socketTimeout: 90_000 }).success).toBe(false);
+    });
+
+    it('reproduces the description the scanner derived from the TSDoc', () => {
+        // Byte-for-byte, because the OpenAPI document has to stay unchanged through the conversion —
+        // this component is `$ref`d from a slot that has not converted, so a canonical/derived
+        // disagreement here fails generation rather than merely reading differently.
+        const description = emitted.description as string;
+        expect(description.startsWith("HTTP timeouts applied to a driver's upstream LLM-provider calls.\n\n")).toBe(
+            true,
+        );
+        expect(description).toContain(
+            'the defaults applied in `@llumiverse/core/createDriverHttpAgent` are:   - headersTimeout:   60_000   ' +
+                '- bodyTimeout:      60_000   - connectTimeout:   10_000   - keepAliveTimeout: 30_000',
+        );
+        expect(description.endsWith('(e.g. tool-using agents).')).toBe(true);
+    });
+});

--- a/common/src/schemas/http-timeout.ts
+++ b/common/src/schemas/http-timeout.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+// Runtime schema for `HttpTimeoutOptions`, the per-run upstream timeouts an interaction execution
+// configuration can carry. It lives here rather than in `@vertesia/common` because the type is
+// declared here — restating it one package out would be the copy this migration removes.
+//
+// It is a LEAF of the `Project` closure: `InteractionExecutionConfiguration.http_timeout` references
+// it, and a canonical component may not `$ref` a TypeScript-derived one, so this has to convert
+// before that does. Like `ModelOptions` next door, publishing it from this package puts an ordering
+// constraint on the release — `@llumiverse/common` ships before the studio code that reads it.
+//
+// `//` rather than `/** */`: a JSDoc block immediately preceding an exported declaration is picked up
+// by Vertesia's OpenAPI scanner and published as that component's `description`.
+
+// `strictObject` for the reason `model-options.ts` gives: the derived component has always said
+// `additionalProperties: false`, and plain `z.object` would have PARSED an unknown key by dropping it.
+//
+// The `description` reproduces what the scanner already derived from the interface's TSDoc, including
+// the run of spaces where it collapsed the defaults list onto one line. Reproducing the contract, not
+// renegotiating it — the published document has to stay byte-identical through this conversion.
+export const HttpTimeoutOptionsSchema = z
+    .strictObject({
+        headersTimeout: z
+            .number()
+            .optional()
+            .meta({ description: 'Time (ms) to wait for the first response byte after the request is sent.' }),
+        bodyTimeout: z
+            .number()
+            .optional()
+            .meta({ description: 'Time (ms) between body chunks once streaming has started.' }),
+        connectTimeout: z.number().optional().meta({ description: 'TCP/TLS connect timeout (ms).' }),
+        keepAliveTimeout: z.number().optional().meta({ description: 'Idle socket reuse timeout (ms).' }),
+    })
+    .meta({
+        id: 'HttpTimeoutOptions',
+        description:
+            "HTTP timeouts applied to a driver's upstream LLM-provider calls.\n\nAll values are in " +
+            'milliseconds. Drivers should map these onto whatever HTTP client their SDK uses; the defaults ' +
+            'applied in `@llumiverse/core/createDriverHttpAgent` are:   - headersTimeout:   60_000   - ' +
+            'bodyTimeout:      60_000   - connectTimeout:   10_000   - keepAliveTimeout: 30_000\n\nThe ' +
+            "defaults are deliberately tighter than Node's undici default (5 minutes for headers/body) so a " +
+            'hung upstream surfaces quickly. Bump `bodyTimeout` for streaming flows that have legitimate ' +
+            'silent gaps (e.g. tool-using agents).',
+    });

--- a/common/src/schemas/index.ts
+++ b/common/src/schemas/index.ts
@@ -8,3 +8,4 @@
  * out — there, to keep ~34 ms of eager schema construction off packages that serve no HTTP.
  */
 export * from './json-schema.js';
+export * from './model-options.js';

--- a/common/src/schemas/index.ts
+++ b/common/src/schemas/index.ts
@@ -7,5 +7,6 @@
  * calls. `@vertesia/common` splits `./api-schemas` off its own barrel for the same reason one layer
  * out — there, to keep ~34 ms of eager schema construction off packages that serve no HTTP.
  */
+export * from './http-timeout.js';
 export * from './json-schema.js';
 export * from './model-options.js';

--- a/common/src/schemas/index.ts
+++ b/common/src/schemas/index.ts
@@ -7,6 +7,7 @@
  * calls. `@vertesia/common` splits `./api-schemas` off its own barrel for the same reason one layer
  * out — there, to keep ~34 ms of eager schema construction off packages that serve no HTTP.
  */
+export * from './completion.js';
 export * from './embeddings.js';
 export * from './http-timeout.js';
 export * from './json-schema.js';

--- a/common/src/schemas/index.ts
+++ b/common/src/schemas/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Runtime schemas for the llumiverse types that appear in a public API contract.
+ *
+ * A SUBPATH rather than part of the `@llumiverse/common` barrel, deliberately. The barrel is
+ * imported by the Studio SPA for its types, which erase; adding these to it would make every browser
+ * bundle load Zod at runtime and would need a CDN import-map entry for a module no browser code
+ * calls. `@vertesia/common` splits `./api-schemas` off its own barrel for the same reason one layer
+ * out — there, to keep ~34 ms of eager schema construction off packages that serve no HTTP.
+ */
+export * from './json-schema.js';

--- a/common/src/schemas/index.ts
+++ b/common/src/schemas/index.ts
@@ -7,6 +7,8 @@
  * calls. `@vertesia/common` splits `./api-schemas` off its own barrel for the same reason one layer
  * out — there, to keep ~34 ms of eager schema construction off packages that serve no HTTP.
  */
+export * from './embeddings.js';
 export * from './http-timeout.js';
 export * from './json-schema.js';
+export * from './model.js';
 export * from './model-options.js';

--- a/common/src/schemas/json-schema.test.ts
+++ b/common/src/schemas/json-schema.test.ts
@@ -13,7 +13,7 @@ import { JSONSchemaPropertiesSchema, JSONSchemaSchema } from './json-schema.js';
  * have to agree, or the build fails several packages downstream.
  *
  * That agreement check is shape-based rather than literal: key order carries no meaning in JSON
- * Schema, and `ts-json-schema-generator` is not self-consistent about it. The assertion below is
+ * Schema. The assertion below is
  * stricter than the constraint on purpose. It pins the exact emission, so any change to the schema
  * — including one that only moves a key — shows up here, in llumiverse's own test run, with the
  * before and after side by side.

--- a/common/src/schemas/json-schema.test.ts
+++ b/common/src/schemas/json-schema.test.ts
@@ -5,12 +5,18 @@ import { JSONSchemaPropertiesSchema, JSONSchemaSchema } from './json-schema.js';
 /**
  * The emission these two components must keep producing.
  *
- * Vertesia publishes `JSONSchema` and `JSONSchemaProperties` as OpenAPI components, and its
- * generator refuses to build when a schema-backed component and the one it derives from the
- * TypeScript type disagree by a single byte — including key order. Sixty-three published components
- * still reach these through a type the generator derives, so this is a hard constraint rather than a
- * preference, and it is checked here so a change to the schema fails in llumiverse's own test run
- * rather than several packages downstream.
+ * Vertesia publishes `JSONSchema` and `JSONSchemaProperties` as OpenAPI components. Unlike the
+ * option types in this package, they are NOT short-circuited by its OpenAPI scanner — they keep a
+ * named TypeScript type, because a recursive schema cannot hand TypeScript a usable inferred one —
+ * so the scanner still derives them wherever an unconverted type reaches them, and twenty-seven
+ * published components do. A schema-backed component and the one derived from the TypeScript type
+ * have to agree, or the build fails several packages downstream.
+ *
+ * That agreement check is shape-based rather than literal: key order carries no meaning in JSON
+ * Schema, and `ts-json-schema-generator` is not self-consistent about it. The assertion below is
+ * stricter than the constraint on purpose. It pins the exact emission, so any change to the schema
+ * — including one that only moves a key — shows up here, in llumiverse's own test run, with the
+ * before and after side by side.
  */
 const EXPECTED_JSON_SCHEMA = {
     type: 'object',
@@ -34,7 +40,9 @@ describe('JSONSchemaSchema', () => {
             unknown
         >;
         const { $schema: _schema, $defs: _defs, additionalProperties, ...rest } = emitted;
-        // Byte-for-byte, so a reordered property is a failure and not just a shape mismatch.
+        // Compared as text, so a reordered property fails here too. Deliberately stricter than the
+        // agreement the generator enforces: this is the place a change to the emission should be
+        // read and approved, not discovered downstream.
         expect(JSON.stringify(rest)).toBe(JSON.stringify(EXPECTED_JSON_SCHEMA));
         // `looseObject` emits this; Vertesia's adapter drops it because `{}` and an absent
         // `additionalProperties` mean the same thing, which is how the component stays byte-identical

--- a/common/src/schemas/json-schema.test.ts
+++ b/common/src/schemas/json-schema.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { JSONSchemaPropertiesSchema, JSONSchemaSchema } from './json-schema.js';
+
+/**
+ * The emission these two components must keep producing.
+ *
+ * Vertesia publishes `JSONSchema` and `JSONSchemaProperties` as OpenAPI components, and its
+ * generator refuses to build when a schema-backed component and the one it derives from the
+ * TypeScript type disagree by a single byte — including key order. Sixty-three published components
+ * still reach these through a type the generator derives, so this is a hard constraint rather than a
+ * preference, and it is checked here so a change to the schema fails in llumiverse's own test run
+ * rather than several packages downstream.
+ */
+const EXPECTED_JSON_SCHEMA = {
+    type: 'object',
+    properties: {
+        type: {},
+        description: { type: 'string' },
+        properties: { $ref: '#/$defs/JSONSchemaProperties' },
+        items: { $ref: '#' },
+        format: { type: 'string' },
+        editor: {},
+        default: {},
+        additionalProperties: { anyOf: [{ type: 'boolean' }, { $ref: '#' }] },
+        required: { type: 'array', items: { type: 'string' } },
+    },
+};
+
+describe('JSONSchemaSchema', () => {
+    it('emits the published component shape, property order included', () => {
+        const emitted = z.toJSONSchema(JSONSchemaSchema, { target: 'draft-2020-12', io: 'input' }) as Record<
+            string,
+            unknown
+        >;
+        const { $schema: _schema, $defs: _defs, additionalProperties, ...rest } = emitted;
+        // Byte-for-byte, so a reordered property is a failure and not just a shape mismatch.
+        expect(JSON.stringify(rest)).toBe(JSON.stringify(EXPECTED_JSON_SCHEMA));
+        // `looseObject` emits this; Vertesia's adapter drops it because `{}` and an absent
+        // `additionalProperties` mean the same thing, which is how the component stays byte-identical
+        // to the one derived from the interface. Anything OTHER than `{}` would not be dropped.
+        expect(additionalProperties).toEqual({});
+    });
+
+    it('emits a property map with no propertyNames', () => {
+        const emitted = z.toJSONSchema(JSONSchemaSchema, { target: 'draft-2020-12', io: 'input' }) as {
+            $defs: Record<string, unknown>;
+        };
+        // `z.record` would add `propertyNames: {type: 'string'}` here, which the derived component
+        // does not have — the reason `JSONSchemaPropertiesSchema` is a catchall object instead.
+        expect(emitted.$defs.JSONSchemaProperties).toEqual({
+            type: 'object',
+            properties: {},
+            additionalProperties: { $ref: '#' },
+        });
+    });
+
+    it('stays open, so keywords the interface never enumerated survive', () => {
+        // `enum`, `minimum`, `$ref` and friends are all valid JSON Schema and callers do send them.
+        const parsed = JSONSchemaSchema.parse({ type: 'string', enum: ['a', 'b'], minLength: 1 });
+        expect(parsed).toEqual({ type: 'string', enum: ['a', 'b'], minLength: 1 });
+    });
+
+    it('accepts the recursive shapes it exists to describe', () => {
+        const nested = {
+            type: 'object',
+            properties: {
+                tags: { type: 'array', items: { type: 'string' } },
+                nested: { type: 'object', additionalProperties: { type: 'number' } },
+            },
+            required: ['tags'],
+        };
+        expect(JSONSchemaSchema.parse(nested)).toEqual(nested);
+        expect(JSONSchemaPropertiesSchema.parse(nested.properties)).toEqual(nested.properties);
+    });
+
+    it('rejects a value that is not a schema at all', () => {
+        expect(JSONSchemaSchema.safeParse('string').success).toBe(false);
+        expect(JSONSchemaSchema.safeParse({ description: 42 }).success).toBe(false);
+        expect(JSONSchemaSchema.safeParse({ required: 'name' }).success).toBe(false);
+    });
+});

--- a/common/src/schemas/json-schema.test.ts
+++ b/common/src/schemas/json-schema.test.ts
@@ -74,6 +74,27 @@ describe('JSONSchemaSchema', () => {
         expect(JSONSchemaPropertiesSchema.parse(nested.properties)).toEqual(nested.properties);
     });
 
+    it('declares exactly the known fields, no more and no less', () => {
+        // The compile-time guard is `satisfies KnownFieldSchemas` in the source, which is what a
+        // `typecheck` run enforces. This is its runtime mirror, so the coverage property survives
+        // even if someone loosens the mapped type: the emitted `properties` map IS the known-field
+        // list, and a field added to the interface without a schema (or the reverse) moves it.
+        const emitted = z.toJSONSchema(JSONSchemaSchema, { target: 'draft-2020-12', io: 'input' }) as {
+            properties: Record<string, unknown>;
+        };
+        expect(Object.keys(emitted.properties)).toEqual([
+            'type',
+            'description',
+            'properties',
+            'items',
+            'format',
+            'editor',
+            'default',
+            'additionalProperties',
+            'required',
+        ]);
+    });
+
     it('rejects a value that is not a schema at all', () => {
         expect(JSONSchemaSchema.safeParse('string').success).toBe(false);
         expect(JSONSchemaSchema.safeParse({ description: 42 }).success).toBe(false);

--- a/common/src/schemas/json-schema.ts
+++ b/common/src/schemas/json-schema.ts
@@ -59,16 +59,13 @@ export const JSONSchemaPropertiesSchema: z.ZodType<JSONSchemaProperties> = z
 // the source instead of shipping to every client generator.
 //
 // Every other type in this closure is now `z.infer` of its schema. This one is not, and the reason
-// is RECURSION, not the scanner: the scanner short-circuits a `z.infer` alias to the published
-// component rather than deriving it, so that obstacle is gone. What remains is TypeScript's own
-// limit — Zod 4 infers a recursive type from the getters below, but the inference bottoms out at
+// is TypeScript recursion. Zod 4 infers a recursive type from the getters below, but the inference
+// bottoms out at
 // depth, so `items` degrades to `{}` a few levels down and driver code that walks a nested schema
 // stops compiling. A recursive schema has to be handed a named type.
 //
-// The exception is recorded, with this reason, in `packages/api-specs/canonical-aliases.json`, and
-// the gate there rejects it if it ever becomes inferable — so it cannot quietly outlive the
-// constraint. Because this type is NOT short-circuited, the scanner still derives it wherever an
-// unconverted type reaches it, and the derived result must still agree with the canonical component.
+// The named type is therefore an explicit recursion boundary; the runtime schema remains the JSON
+// contract published to OpenAPI and enforced by AJV.
 //
 // The known fields are split out from the index signature so the named type can actually be CHECKED
 // against the schema. `z.ZodType<JSONSchema>` alone does not check much: every named field is

--- a/common/src/schemas/json-schema.ts
+++ b/common/src/schemas/json-schema.ts
@@ -21,8 +21,8 @@ import { z } from 'zod';
 //    available failure, and it is invisible — the parse succeeds.
 //  - `type` is `z.any()`, not the `JSONSchemaTypeName | JSONSchemaTypeName[]` union it morally is —
 //    the one place in this file `any` is right. The published component has always emitted the
-//    unconstrained `{}` here, and a canonical component must stay byte-identical to the one the
-//    scanner derives for the slots that have not converted. The INTERFACE still states the union, so
+//    unconstrained `{}` here, and a canonical component must still agree with the one the scanner
+//    derives for the slots that have not converted. The NAMED TYPE still states the union, so
 //    TypeScript callers get the real type; only the emitted schema is loose. Tightening it is a
 //    contract change, possible once nothing derives these — at which point it is a one-line edit.
 export const JSONSchemaSchema: z.ZodType<JSONSchema> = z
@@ -47,7 +47,8 @@ export const JSONSchemaSchema: z.ZodType<JSONSchema> = z
 
 // A property map, written as an object with a catchall rather than `z.record`: `z.record` also emits
 // a `propertyNames: {type: 'string'}` — a no-op, since every JSON object key is a string, but not
-// what the index signature published, and these components are pinned byte-identical.
+// what the index signature published, and these components still have to agree with what the
+// scanner derives.
 export const JSONSchemaPropertiesSchema: z.ZodType<JSONSchemaProperties> = z
     .object({})
     .catchall(JSONSchemaSchema)
@@ -57,17 +58,24 @@ export const JSONSchemaPropertiesSchema: z.ZodType<JSONSchemaProperties> = z
 // leading `/** */` as the component's `description`. Rationale goes in `//` comments so it stays in
 // the source instead of shipping to every client generator.
 //
-// A BRIDGE, and a temporary one. It exists because the OpenAPI scanner still derives components from
-// TypeScript for every slot that has not converted, and `ts-json-schema-generator` resolves a
-// `z.infer<>` alias to nothing — aliasing this emptied 141 of the 1015 published components and
-// collapsed eight more to closed empty objects. It goes away as its dependants convert, not by
-// teaching the scanner to read Zod.
+// Every other type in this closure is now `z.infer` of its schema. This one is not, and the reason
+// is RECURSION, not the scanner: the scanner short-circuits a `z.infer` alias to the published
+// component rather than deriving it, so that obstacle is gone. What remains is TypeScript's own
+// limit — Zod 4 infers a recursive type from the getters below, but the inference bottoms out at
+// depth, so `items` degrades to `{}` a few levels down and driver code that walks a nested schema
+// stops compiling. A recursive schema has to be handed a named type.
 //
-// The known fields are split out from the index signature so the bridge can actually be CHECKED.
-// `z.ZodType<JSONSchema>` alone does not check much: every named field is optional and the type is
-// open, so `z.looseObject({})` — a schema declaring nothing at all — satisfies it. What catches a
-// field present on one side and missing from the other is {@link KnownFieldSchemas} below, which
-// requires the Zod shape to cover every key of `JSONSchemaKnownFields` exactly.
+// The exception is recorded, with this reason, in `packages/api-specs/canonical-aliases.json`, and
+// the gate there rejects it if it ever becomes inferable — so it cannot quietly outlive the
+// constraint. Because this type is NOT short-circuited, the scanner still derives it wherever an
+// unconverted type reaches it, and the derived result must still agree with the canonical component.
+//
+// The known fields are split out from the index signature so the named type can actually be CHECKED
+// against the schema. `z.ZodType<JSONSchema>` alone does not check much: every named field is
+// optional and the type is open, so `z.looseObject({})` — a schema declaring nothing at all —
+// satisfies it. What catches a field present on one side and missing from the other is
+// {@link KnownFieldSchemas} below, which requires the Zod shape to cover every key of
+// `JSONSchemaKnownFields` exactly.
 interface JSONSchemaKnownFields {
     type?: JSONSchemaTypeName | JSONSchemaTypeName[];
     description?: string;
@@ -92,7 +100,7 @@ type KnownFieldSchemas = {
     [K in keyof Required<JSONSchemaKnownFields>]-?: z.ZodType<JSONSchemaKnownFields[K]>;
 };
 
-// A property map. Same bridge reasoning as JSONSchema above.
+// A property map. Recursive through `JSONSchema`, so it keeps a named type for the same reason.
 export interface JSONSchemaProperties {
     [key: string]: JSONSchema;
 }

--- a/common/src/schemas/json-schema.ts
+++ b/common/src/schemas/json-schema.ts
@@ -42,7 +42,7 @@ export const JSONSchemaSchema: z.ZodType<JSONSchema> = z
             return z.union([z.boolean(), JSONSchemaSchema]).optional();
         },
         required: z.array(z.string()).optional(),
-    })
+    } satisfies KnownFieldSchemas)
     .meta({ id: 'JSONSchema' });
 
 // A property map, written as an object with a catchall rather than `z.record`: `z.record` also emits
@@ -57,21 +57,18 @@ export const JSONSchemaPropertiesSchema: z.ZodType<JSONSchemaProperties> = z
 // leading `/** */` as the component's `description`. Rationale goes in `//` comments so it stays in
 // the source instead of shipping to every client generator.
 //
-// Written as an interface rather than as `z.infer<typeof JSONSchemaSchema>`, for two reasons, of
-// which only the second is a workaround:
+// A BRIDGE, and a temporary one. It exists because the OpenAPI scanner still derives components from
+// TypeScript for every slot that has not converted, and `ts-json-schema-generator` resolves a
+// `z.infer<>` alias to nothing — aliasing this emptied 141 of the 1015 published components and
+// collapsed eight more to closed empty objects. It goes away as its dependants convert, not by
+// teaching the scanner to read Zod.
 //
-//  1. A RECURSIVE Zod schema cannot infer its own type — the getters make the inference circular —
-//     so `z.ZodType<...>` has to be handed a named result. The interface therefore exists either
-//     way; `z.infer` would only change which name is the public one, not remove a declaration. What
-//     prevents drift is the annotation: add a property to one side and not the other and
-//     `z.ZodType<JSONSchema>` stops accepting the schema, at compile time, in this file.
-//  2. Even where it WOULD remove a declaration, the OpenAPI scanner cannot follow it yet.
-//     `ts-json-schema-generator` derives components from the TypeScript AST, and a `z.infer<>` alias
-//     resolves to nothing. Aliasing these two emptied 141 of the 1015 published components — every
-//     closure reaching `JSONSchema` through a component not yet converted — and collapsed eight more
-//     to closed empty objects. Until every referrer publishes a canonical component, a public type
-//     reachable from a derived one has to stay a declaration the scanner can read.
-export interface JSONSchema {
+// The known fields are split out from the index signature so the bridge can actually be CHECKED.
+// `z.ZodType<JSONSchema>` alone does not check much: every named field is optional and the type is
+// open, so `z.looseObject({})` — a schema declaring nothing at all — satisfies it. What catches a
+// field present on one side and missing from the other is {@link KnownFieldSchemas} below, which
+// requires the Zod shape to cover every key of `JSONSchemaKnownFields` exactly.
+interface JSONSchemaKnownFields {
     type?: JSONSchemaTypeName | JSONSchemaTypeName[];
     description?: string;
     properties?: JSONSchemaProperties;
@@ -81,10 +78,21 @@ export interface JSONSchema {
     default?: unknown;
     additionalProperties?: boolean | JSONSchema;
     required?: string[];
-    [k: string]: unknown;
 }
 
-// A property map. Same reasoning as JSONSchema above for why it is an interface.
+// The extras a JSON Schema carries that this type never enumerated — `enum`, `oneOf`, `minimum`,
+// `$ref`. They are why the object is open, and why `looseObject` rather than `object` is load-bearing
+// rather than cosmetic: Zod's default STRIPS them on parse.
+export type JSONSchema = JSONSchemaKnownFields & Record<string, unknown>;
+
+// `-?` is what makes this exact rather than a subset check: an optional key in the mapped type would
+// let a missing schema property pass. With it, dropping `description` from the shape above fails to
+// compile here rather than silently narrowing the published component.
+type KnownFieldSchemas = {
+    [K in keyof Required<JSONSchemaKnownFields>]-?: z.ZodType<JSONSchemaKnownFields[K]>;
+};
+
+// A property map. Same bridge reasoning as JSONSchema above.
 export interface JSONSchemaProperties {
     [key: string]: JSONSchema;
 }

--- a/common/src/schemas/json-schema.ts
+++ b/common/src/schemas/json-schema.ts
@@ -1,0 +1,100 @@
+import { z } from 'zod';
+
+// Runtime schemas for the JSON Schema subset llumiverse passes to the drivers.
+//
+// Vertesia publishes both as OpenAPI components and validates request bodies against the SAME schema
+// object at runtime, which is what makes the published contract and the enforced one incapable of
+// disagreeing. The interfaces below carry the same shape because a recursive schema has to be handed
+// a named type — see the note above `JSONSchema` — and `z.ZodType<JSONSchema>` is what stops the two
+// from drifting: they are checked against each other by the compiler, in this file, on every build.
+//
+// `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration
+// is picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
+//
+// Two shape decisions, both deliberate:
+//
+//  - The object is OPEN — `looseObject`, not `object`. A JSON Schema carries keywords this type never
+//    enumerated (`enum`, `oneOf`, `minimum`, `$ref`, …) and callers do send them. `z.object` would
+//    not merely publish an open component, it would STRIP those keywords from anything it parses:
+//    `JSONSchemaSchema.parse({type: 'string', enum: [...]})` returns `{type: 'string'}`. For a type
+//    whose whole purpose is to carry a user's schema, silently deleting half of it is the worst
+//    available failure, and it is invisible — the parse succeeds.
+//  - `type` is `z.any()`, not the `JSONSchemaTypeName | JSONSchemaTypeName[]` union it morally is —
+//    the one place in this file `any` is right. The published component has always emitted the
+//    unconstrained `{}` here, and a canonical component must stay byte-identical to the one the
+//    scanner derives for the slots that have not converted. The INTERFACE still states the union, so
+//    TypeScript callers get the real type; only the emitted schema is loose. Tightening it is a
+//    contract change, possible once nothing derives these — at which point it is a one-line edit.
+export const JSONSchemaSchema: z.ZodType<JSONSchema> = z
+    .looseObject({
+        type: z.any().optional(),
+        description: z.string().optional(),
+        get properties() {
+            return JSONSchemaPropertiesSchema.optional();
+        },
+        get items() {
+            return JSONSchemaSchema.optional();
+        },
+        format: z.string().optional(),
+        editor: z.unknown().optional(),
+        default: z.unknown().optional(),
+        get additionalProperties() {
+            return z.union([z.boolean(), JSONSchemaSchema]).optional();
+        },
+        required: z.array(z.string()).optional(),
+    })
+    .meta({ id: 'JSONSchema' });
+
+// A property map, written as an object with a catchall rather than `z.record`: `z.record` also emits
+// a `propertyNames: {type: 'string'}` — a no-op, since every JSON object key is a string, but not
+// what the index signature published, and these components are pinned byte-identical.
+export const JSONSchemaPropertiesSchema: z.ZodType<JSONSchemaProperties> = z
+    .object({})
+    .catchall(JSONSchemaSchema)
+    .meta({ id: 'JSONSchemaProperties' });
+
+// NOT a JSDoc block: this file's types are published as OpenAPI components, and the scanner emits a
+// leading `/** */` as the component's `description`. Rationale goes in `//` comments so it stays in
+// the source instead of shipping to every client generator.
+//
+// Written as an interface rather than as `z.infer<typeof JSONSchemaSchema>`, for two reasons, of
+// which only the second is a workaround:
+//
+//  1. A RECURSIVE Zod schema cannot infer its own type — the getters make the inference circular —
+//     so `z.ZodType<...>` has to be handed a named result. The interface therefore exists either
+//     way; `z.infer` would only change which name is the public one, not remove a declaration. What
+//     prevents drift is the annotation: add a property to one side and not the other and
+//     `z.ZodType<JSONSchema>` stops accepting the schema, at compile time, in this file.
+//  2. Even where it WOULD remove a declaration, the OpenAPI scanner cannot follow it yet.
+//     `ts-json-schema-generator` derives components from the TypeScript AST, and a `z.infer<>` alias
+//     resolves to nothing. Aliasing these two emptied 141 of the 1015 published components — every
+//     closure reaching `JSONSchema` through a component not yet converted — and collapsed eight more
+//     to closed empty objects. Until every referrer publishes a canonical component, a public type
+//     reachable from a derived one has to stay a declaration the scanner can read.
+export interface JSONSchema {
+    type?: JSONSchemaTypeName | JSONSchemaTypeName[];
+    description?: string;
+    properties?: JSONSchemaProperties;
+    items?: JSONSchema;
+    format?: string;
+    editor?: unknown;
+    default?: unknown;
+    additionalProperties?: boolean | JSONSchema;
+    required?: string[];
+    [k: string]: unknown;
+}
+
+// A property map. Same reasoning as JSONSchema above for why it is an interface.
+export interface JSONSchemaProperties {
+    [key: string]: JSONSchema;
+}
+
+export type JSONSchemaTypeName =
+    | 'string' //
+    | 'number'
+    | 'integer'
+    | 'boolean'
+    | 'object'
+    | 'array'
+    | 'null'
+    | 'any';

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -22,16 +22,16 @@ const emitted = z.toJSONSchema(ModelOptionsSchema, { target: 'draft-2020-12', io
 const MEMBERS = (emitted.oneOf ?? emitted.anyOf ?? []).map((member) => member.$ref.replace('#/$defs/', ''));
 
 describe('ModelOptionsSchema', () => {
-    it('infers the public union exactly, so the bridge can be deleted rather than reconciled', () => {
-        // The per-member `satisfies FieldSchemas<T>` checks each option set field by field; this
-        // checks the UNION, which nothing else does — a member present in the TypeScript union and
-        // absent from `discriminatedUnion` type-checks everywhere else in the file.
-        //
-        // It is also the exit condition for the bridge. `ModelOptions` is not recursive, so once no
-        // derived component references these the interfaces go away and the public type becomes
-        // `z.infer<typeof ModelOptionsSchema>`. This asserts today that the swap is a rename.
+    it('is the only definition of the union — the public type is inferred from it', () => {
+        // Vacuous as an equality, and that is the point: `ModelOptions` in `../types.js` IS
+        // `z.infer` of this schema, so there is no second declaration for it to disagree with. The
+        // assertion is kept because it fails to COMPILE if the public type is ever redeclared as a
+        // hand-written union — which is the regression, not an inequality at runtime.
         assertType<Equals<ModelOptions, z.infer<typeof ModelOptionsSchema>>>(true);
-        expect(true).toBe(true);
+        // A real value, checked against the schema rather than only against the compiler.
+        expect(
+            ModelOptionsSchema.safeParse({ _option_id: 'vertexai-gemini', temperature: 0.2 } as ModelOptions).success,
+        ).toBe(true);
     });
 
     it('carries every driver option set, in the published order', () => {
@@ -81,7 +81,8 @@ describe('ModelOptionsSchema', () => {
     it('closes every member, so an unknown option is rejected rather than dropped', () => {
         // `z.object` would publish `additionalProperties: false` — the component has always said so —
         // while silently STRIPPING an unknown option at parse time. `strictObject` makes the enforced
-        // behaviour the published one.
+        // behaviour the published one, and since the public type is inferred from this schema, it is
+        // also what the compiler enforces.
         for (const name of MEMBERS) {
             expect((emitted.$defs[name] as { additionalProperties?: unknown }).additionalProperties, name).toBe(false);
         }

--- a/common/src/schemas/model-options.test.ts
+++ b/common/src/schemas/model-options.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import type { ModelOptions } from '../types.js';
+import { ModelOptionsSchema } from './model-options.js';
+
+/** Exact type identity — `extends` in both directions is too weak (`any`/`unknown` slip through). */
+type Equals<A, B> = (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+function assertType<T extends true>(_ok: T): void {}
+
+/**
+ * `ModelOptions` is published by Vertesia as a discriminated-union component with twenty-three
+ * members, each its own component. These pin the properties that a consumer of the published document
+ * depends on and that a careless edit here would break silently — the union is large enough that a
+ * dropped member reads as a normal diff.
+ */
+const emitted = z.toJSONSchema(ModelOptionsSchema, { target: 'draft-2020-12', io: 'input' }) as {
+    anyOf?: { $ref: string }[];
+    oneOf?: { $ref: string }[];
+    $defs: Record<string, { properties?: Record<string, unknown>; required?: string[] }>;
+};
+
+const MEMBERS = (emitted.oneOf ?? emitted.anyOf ?? []).map((member) => member.$ref.replace('#/$defs/', ''));
+
+describe('ModelOptionsSchema', () => {
+    it('infers the public union exactly, so the bridge can be deleted rather than reconciled', () => {
+        // The per-member `satisfies FieldSchemas<T>` checks each option set field by field; this
+        // checks the UNION, which nothing else does — a member present in the TypeScript union and
+        // absent from `discriminatedUnion` type-checks everywhere else in the file.
+        //
+        // It is also the exit condition for the bridge. `ModelOptions` is not recursive, so once no
+        // derived component references these the interfaces go away and the public type becomes
+        // `z.infer<typeof ModelOptionsSchema>`. This asserts today that the swap is a rename.
+        assertType<Equals<ModelOptions, z.infer<typeof ModelOptionsSchema>>>(true);
+        expect(true).toBe(true);
+    });
+
+    it('carries every driver option set, in the published order', () => {
+        // Order is significant: it becomes the `oneOf` order in the document, which decides the branch
+        // order a generated Java or Go client tries.
+        expect(MEMBERS).toEqual([
+            'TextFallbackOptions',
+            'ImagenOptions',
+            'VertexAIClaudeOptions',
+            'VertexAIGeminiOptions',
+            'VertexAIGrokOptions',
+            'NovaCanvasOptions',
+            'BedrockConverseOptions',
+            'BedrockNovaOptions',
+            'BedrockMistralOptions',
+            'BedrockAI21Options',
+            'BedrockCohereCommandOptions',
+            'BedrockClaudeOptions',
+            'BedrockPalmyraOptions',
+            'BedrockGptOssOptions',
+            'TwelvelabsPegasusOptions',
+            'BedrockMantleResponsesOptions',
+            'BedrockMantleChatCompletionsOptions',
+            'BedrockMantleClaudeOptions',
+            'OpenAiThinkingOptions',
+            'OpenAiTextOptions',
+            'OpenAiDalleOptions',
+            'OpenAiGptImageOptions',
+            'GroqOptions',
+        ]);
+    });
+
+    it('discriminates on a required, unique _option_id in every member', () => {
+        // What makes the union a `discriminator` + `mapping` in the document rather than a bare
+        // `oneOf`. Two members sharing a literal, or one leaving `_option_id` optional, silently
+        // demotes it and generated clients fall back to a loose map.
+        const ids = MEMBERS.map((name) => {
+            const member = emitted.$defs[name];
+            expect(member.required, `${name} must require _option_id`).toContain('_option_id');
+            const discriminant = member.properties?._option_id as { const?: string } | undefined;
+            expect(discriminant?.const, `${name} must pin a literal _option_id`).toBeTypeOf('string');
+            return discriminant?.const;
+        });
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('closes every member, so an unknown option is rejected rather than dropped', () => {
+        // `z.object` would publish `additionalProperties: false` — the component has always said so —
+        // while silently STRIPPING an unknown option at parse time. `strictObject` makes the enforced
+        // behaviour the published one.
+        for (const name of MEMBERS) {
+            expect((emitted.$defs[name] as { additionalProperties?: unknown }).additionalProperties, name).toBe(false);
+        }
+    });
+
+    it('parses a real option object and rejects a foreign key', () => {
+        const options = { _option_id: 'text-fallback', max_tokens: 100, temperature: 0.7 } as const;
+        expect(ModelOptionsSchema.parse(options)).toEqual(options);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'text-fallback', nope: 1 }).success).toBe(false);
+        expect(ModelOptionsSchema.safeParse({ _option_id: 'not-a-driver' }).success).toBe(false);
+    });
+});

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -6,9 +6,7 @@ import { ImagenMaskMode, ImagenTaskType, ThinkingLevel } from '../options/vertex
 //
 // These are the SINGLE definition of each option set. The OpenAPI document publishes them, AJV
 // enforces them, and the public TypeScript types in `../options/*` are `z.infer` of them, so there
-// is no second declaration to drift from. The scanner short-circuits those aliases to the component
-// of the same name rather than trying to expand `z.infer`, which is what makes one definition
-// enough — see `canonical-alias-parser.ts` in the api-scanner package.
+// is no second declaration to drift from. OpenAPI publishes these registered schemas directly.
 //
 // `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration is
 // picked up by Vertesia's OpenAPI scanner and published as that component's `description`.

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -1,54 +1,17 @@
 import { z } from 'zod';
-import type {
-    BedrockAI21Options,
-    BedrockClaudeOptions,
-    BedrockCohereCommandOptions,
-    BedrockConverseOptions,
-    BedrockGptOssOptions,
-    BedrockMistralOptions,
-    BedrockNovaOptions,
-    BedrockPalmyraOptions,
-    NovaCanvasOptions,
-    TwelvelabsPegasusOptions,
-} from '../options/bedrock.js';
-import type {
-    BedrockMantleChatCompletionsOptions,
-    BedrockMantleClaudeOptions,
-    BedrockMantleResponsesOptions,
-} from '../options/bedrock_mantle.js';
-import type { TextFallbackOptions } from '../options/fallback.js';
-import type { GroqOptions } from '../options/groq.js';
-import type {
-    OpenAiDalleOptions,
-    OpenAiGptImageOptions,
-    OpenAiTextOptions,
-    OpenAiThinkingOptions,
-} from '../options/openai.js';
-import type {
-    ImagenOptions,
-    VertexAIClaudeOptions,
-    VertexAIGeminiOptions,
-    VertexAIGrokOptions,
-} from '../options/vertexai.js';
 import { ImagenMaskMode, ImagenTaskType, ThinkingLevel } from '../options/vertexai.js';
 
 // Runtime schemas for `ModelOptions` — the union of every driver's per-model options — and its
 // twenty-seven members.
 //
+// These are the SINGLE definition of each option set. The OpenAPI document publishes them, AJV
+// enforces them, and the public TypeScript types in `../options/*` are `z.infer` of them, so there
+// is no second declaration to drift from. The scanner short-circuits those aliases to the component
+// of the same name rather than trying to expand `z.infer`, which is what makes one definition
+// enough — see `canonical-alias-parser.ts` in the api-scanner package.
+//
 // `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration is
 // picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
-//
-// These are BRIDGES in the same sense as `./json-schema.js`, and for the same reason: the scanner
-// still derives components from TypeScript for every slot that has not converted, and it resolves a
-// `z.infer<>` alias to nothing. The interfaces in `../options/*` therefore stay the public types.
-// Unlike `JSONSchema`, none of these is recursive, so when nothing derives them any more the
-// interfaces can be deleted outright and the public types become `z.infer` of the schemas below.
-//
-// Every schema is checked against its interface by {@link FieldSchemas}, which is what makes a
-// generated schema honest: it requires the Zod shape to cover every field of the interface exactly,
-// so a field on one side and not the other fails to compile here. The annotation alone would not —
-// these interfaces have one required property and the rest optional, so a schema declaring only
-// `_option_id` would satisfy `z.ZodType<T>`.
 
 // `strictObject`, not `object`. The published component has always said `additionalProperties: false`,
 // and Zod's default would have PARSED an unknown option key by silently dropping it — so the document
@@ -56,12 +19,6 @@ import { ImagenMaskMode, ImagenTaskType, ThinkingLevel } from '../options/vertex
 // `additionalProperties: false` the component already carried, so the published and enforced contracts
 // are the same statement. (`JSONSchema` next door is the opposite case for the opposite reason: a JSON
 // Schema legitimately carries keywords the type never enumerated.)
-
-// Exact per-field coverage. `-?` is the load-bearing part: an optional key in the mapped type would
-// make this a subset check and let a missing property through.
-type FieldSchemas<T> = {
-    [K in keyof Required<T>]-?: z.ZodType<T[K]>;
-};
 
 // The four option enums that are published as their own components.
 export const ImagenMaskModeSchema = z.enum(ImagenMaskMode).meta({ id: 'ImagenMaskMode' });
@@ -86,7 +43,7 @@ export const TextFallbackOptionsSchema = z
         presence_penalty: z.number().optional(),
         frequency_penalty: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<TextFallbackOptions>)
+    })
     .meta({ id: 'TextFallbackOptions' });
 
 // ===== groq =====
@@ -101,7 +58,7 @@ export const GroqOptionsSchema = z
         frequency_penalty: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
         reasoning_format: z.enum(['parsed', 'raw', 'hidden']),
-    } satisfies FieldSchemas<GroqOptions>)
+    })
     .meta({ id: 'GroqOptions' });
 
 // ===== bedrock =====
@@ -113,7 +70,7 @@ export const BedrockConverseOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockConverseOptions>)
+    })
     .meta({ id: 'BedrockConverseOptions' });
 
 export const BedrockNovaOptionsSchema = z
@@ -123,7 +80,7 @@ export const BedrockNovaOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockNovaOptions>)
+    })
     .meta({ id: 'BedrockNovaOptions' });
 
 export const BedrockMistralOptionsSchema = z
@@ -133,7 +90,7 @@ export const BedrockMistralOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockMistralOptions>)
+    })
     .meta({ id: 'BedrockMistralOptions' });
 
 export const BedrockAI21OptionsSchema = z
@@ -143,7 +100,7 @@ export const BedrockAI21OptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockAI21Options>)
+    })
     .meta({ id: 'BedrockAI21Options' });
 
 export const BedrockCohereCommandOptionsSchema = z
@@ -153,7 +110,7 @@ export const BedrockCohereCommandOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockCohereCommandOptions>)
+    })
     .meta({ id: 'BedrockCohereCommandOptions' });
 
 export const BedrockClaudeOptionsSchema = z
@@ -169,7 +126,7 @@ export const BedrockClaudeOptionsSchema = z
         effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
         cache_enabled: z.boolean().optional(),
         cache_ttl: z.enum(['5m', '1h']).optional(),
-    } satisfies FieldSchemas<BedrockClaudeOptions>)
+    })
     .meta({ id: 'BedrockClaudeOptions' });
 
 export const BedrockPalmyraOptionsSchema = z
@@ -183,7 +140,7 @@ export const BedrockPalmyraOptionsSchema = z
         seed: z.number().optional(),
         frequency_penalty: z.number().optional(),
         presence_penalty: z.number().optional(),
-    } satisfies FieldSchemas<BedrockPalmyraOptions>)
+    })
     .meta({ id: 'BedrockPalmyraOptions' });
 
 export const BedrockGptOssOptionsSchema = z
@@ -196,7 +153,7 @@ export const BedrockGptOssOptionsSchema = z
         reasoning_effort: z.enum(['low', 'medium', 'high']).optional(),
         frequency_penalty: z.number().optional(),
         presence_penalty: z.number().optional(),
-    } satisfies FieldSchemas<BedrockGptOssOptions>)
+    })
     .meta({ id: 'BedrockGptOssOptions' });
 
 export const TwelvelabsPegasusOptionsSchema = z
@@ -204,7 +161,7 @@ export const TwelvelabsPegasusOptionsSchema = z
         _option_id: z.literal('bedrock-twelvelabs-pegasus'),
         temperature: z.number().optional(),
         max_tokens: z.number().optional(),
-    } satisfies FieldSchemas<TwelvelabsPegasusOptions>)
+    })
     .meta({ id: 'TwelvelabsPegasusOptions' });
 
 export const NovaCanvasOptionsSchema = z
@@ -230,7 +187,7 @@ export const NovaCanvasOptionsSchema = z
         colors: z.array(z.string()).optional(),
         similarityStrength: z.number().optional(),
         outPaintingMode: z.enum(['DEFAULT', 'PRECISE']).optional(),
-    } satisfies FieldSchemas<NovaCanvasOptions>)
+    })
     .meta({ id: 'NovaCanvasOptions' });
 
 // ===== bedrock_mantle =====
@@ -245,7 +202,7 @@ export const BedrockMantleResponsesOptionsSchema = z
         reasoning_effort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
         verbosity: z.enum(['low', 'medium', 'high']).optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
-    } satisfies FieldSchemas<BedrockMantleResponsesOptions>)
+    })
     .meta({ id: 'BedrockMantleResponsesOptions' });
 
 export const BedrockMantleChatCompletionsOptionsSchema = z
@@ -255,7 +212,7 @@ export const BedrockMantleChatCompletionsOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<BedrockMantleChatCompletionsOptions>)
+    })
     .meta({ id: 'BedrockMantleChatCompletionsOptions' });
 
 export const BedrockMantleClaudeOptionsSchema = z
@@ -271,7 +228,7 @@ export const BedrockMantleClaudeOptionsSchema = z
         include_thoughts: z.boolean().optional(),
         cache_enabled: z.boolean().optional(),
         cache_ttl: z.enum(['5m', '1h']).optional(),
-    } satisfies FieldSchemas<BedrockMantleClaudeOptions>)
+    })
     .meta({ id: 'BedrockMantleClaudeOptions' });
 
 // ===== openai =====
@@ -284,7 +241,7 @@ export const OpenAiThinkingOptionsSchema = z
         effort: ReasoningEffortSchema.optional(),
         reasoning_effort: ReasoningEffortSchema.optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
-    } satisfies FieldSchemas<OpenAiThinkingOptions>)
+    })
     .meta({ id: 'OpenAiThinkingOptions' });
 
 export const OpenAiTextOptionsSchema = z
@@ -297,7 +254,7 @@ export const OpenAiTextOptionsSchema = z
         frequency_penalty: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
         image_detail: z.enum(['low', 'high', 'auto']).optional(),
-    } satisfies FieldSchemas<OpenAiTextOptions>)
+    })
     .meta({ id: 'OpenAiTextOptions' });
 
 export const OpenAiDalleOptionsSchema = z
@@ -308,7 +265,7 @@ export const OpenAiDalleOptionsSchema = z
         style: z.enum(['vivid', 'natural']).optional(),
         response_format: z.enum(['url', 'b64_json']).optional(),
         n: z.number().optional(),
-    } satisfies FieldSchemas<OpenAiDalleOptions>)
+    })
     .meta({ id: 'OpenAiDalleOptions' });
 
 export const OpenAiGptImageOptionsSchema = z
@@ -318,7 +275,7 @@ export const OpenAiGptImageOptionsSchema = z
         image_quality: z.enum(['low', 'medium', 'high', 'auto']).optional(),
         background: z.enum(['transparent', 'opaque', 'auto']).optional(),
         output_format: z.enum(['png', 'webp', 'jpeg']).optional(),
-    } satisfies FieldSchemas<OpenAiGptImageOptions>)
+    })
     .meta({ id: 'OpenAiGptImageOptions' });
 
 // ===== vertexai =====
@@ -348,7 +305,7 @@ export const ImagenOptionsSchema = z
         subjectType: z
             .enum(['SUBJECT_TYPE_PERSON', 'SUBJECT_TYPE_ANIMAL', 'SUBJECT_TYPE_PRODUCT', 'SUBJECT_TYPE_DEFAULT'])
             .optional(),
-    } satisfies FieldSchemas<ImagenOptions>)
+    })
     .meta({ id: 'ImagenOptions' });
 
 export const VertexAIClaudeOptionsSchema = z
@@ -364,7 +321,7 @@ export const VertexAIClaudeOptionsSchema = z
         include_thoughts: z.boolean().optional(),
         cache_enabled: z.boolean().optional(),
         cache_ttl: z.enum(['5m', '1h']).optional(),
-    } satisfies FieldSchemas<VertexAIClaudeOptions>)
+    })
     .meta({ id: 'VertexAIClaudeOptions' });
 
 export const VertexAIGeminiOptionsSchema = z
@@ -391,7 +348,7 @@ export const VertexAIGeminiOptionsSchema = z
             .optional(),
         output_mime_type: z.enum(['image/png', 'image/jpeg']).optional(),
         output_compression_quality: z.number().optional(),
-    } satisfies FieldSchemas<VertexAIGeminiOptions>)
+    })
     .meta({ id: 'VertexAIGeminiOptions' });
 
 export const VertexAIGrokOptionsSchema = z
@@ -401,7 +358,7 @@ export const VertexAIGrokOptionsSchema = z
         temperature: z.number().optional(),
         top_p: z.number().optional(),
         stop_sequence: z.array(z.string()).optional(),
-    } satisfies FieldSchemas<VertexAIGrokOptions>)
+    })
     .meta({ id: 'VertexAIGrokOptions' });
 
 // The discriminated union. Member order is the order the derived component lists, which the adapter

--- a/common/src/schemas/model-options.ts
+++ b/common/src/schemas/model-options.ts
@@ -1,0 +1,436 @@
+import { z } from 'zod';
+import type {
+    BedrockAI21Options,
+    BedrockClaudeOptions,
+    BedrockCohereCommandOptions,
+    BedrockConverseOptions,
+    BedrockGptOssOptions,
+    BedrockMistralOptions,
+    BedrockNovaOptions,
+    BedrockPalmyraOptions,
+    NovaCanvasOptions,
+    TwelvelabsPegasusOptions,
+} from '../options/bedrock.js';
+import type {
+    BedrockMantleChatCompletionsOptions,
+    BedrockMantleClaudeOptions,
+    BedrockMantleResponsesOptions,
+} from '../options/bedrock_mantle.js';
+import type { TextFallbackOptions } from '../options/fallback.js';
+import type { GroqOptions } from '../options/groq.js';
+import type {
+    OpenAiDalleOptions,
+    OpenAiGptImageOptions,
+    OpenAiTextOptions,
+    OpenAiThinkingOptions,
+} from '../options/openai.js';
+import type {
+    ImagenOptions,
+    VertexAIClaudeOptions,
+    VertexAIGeminiOptions,
+    VertexAIGrokOptions,
+} from '../options/vertexai.js';
+import { ImagenMaskMode, ImagenTaskType, ThinkingLevel } from '../options/vertexai.js';
+
+// Runtime schemas for `ModelOptions` — the union of every driver's per-model options — and its
+// twenty-seven members.
+//
+// `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration is
+// picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
+//
+// These are BRIDGES in the same sense as `./json-schema.js`, and for the same reason: the scanner
+// still derives components from TypeScript for every slot that has not converted, and it resolves a
+// `z.infer<>` alias to nothing. The interfaces in `../options/*` therefore stay the public types.
+// Unlike `JSONSchema`, none of these is recursive, so when nothing derives them any more the
+// interfaces can be deleted outright and the public types become `z.infer` of the schemas below.
+//
+// Every schema is checked against its interface by {@link FieldSchemas}, which is what makes a
+// generated schema honest: it requires the Zod shape to cover every field of the interface exactly,
+// so a field on one side and not the other fails to compile here. The annotation alone would not —
+// these interfaces have one required property and the rest optional, so a schema declaring only
+// `_option_id` would satisfy `z.ZodType<T>`.
+
+// `strictObject`, not `object`. The published component has always said `additionalProperties: false`,
+// and Zod's default would have PARSED an unknown option key by silently dropping it — so the document
+// promised rejection while the schema quietly discarded. `strictObject` rejects, and emits the
+// `additionalProperties: false` the component already carried, so the published and enforced contracts
+// are the same statement. (`JSONSchema` next door is the opposite case for the opposite reason: a JSON
+// Schema legitimately carries keywords the type never enumerated.)
+
+// Exact per-field coverage. `-?` is the load-bearing part: an optional key in the mapped type would
+// make this a subset check and let a missing property through.
+type FieldSchemas<T> = {
+    [K in keyof Required<T>]-?: z.ZodType<T[K]>;
+};
+
+// The four option enums that are published as their own components.
+export const ImagenMaskModeSchema = z.enum(ImagenMaskMode).meta({ id: 'ImagenMaskMode' });
+
+export const ImagenTaskTypeSchema = z.enum(ImagenTaskType).meta({ id: 'ImagenTaskType' });
+
+export const ThinkingLevelSchema = z.enum(ThinkingLevel).meta({ id: 'ThinkingLevel' });
+
+export const ReasoningEffortSchema = z
+    .enum(['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
+    .meta({ id: 'ReasoningEffort' });
+
+// ===== fallback =====
+
+export const TextFallbackOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('text-fallback'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        top_k: z.number().optional(),
+        presence_penalty: z.number().optional(),
+        frequency_penalty: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<TextFallbackOptions>)
+    .meta({ id: 'TextFallbackOptions' });
+
+// ===== groq =====
+
+export const GroqOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('groq-deepseek-thinking'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        presence_penalty: z.number().optional(),
+        frequency_penalty: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        reasoning_format: z.enum(['parsed', 'raw', 'hidden']),
+    } satisfies FieldSchemas<GroqOptions>)
+    .meta({ id: 'GroqOptions' });
+
+// ===== bedrock =====
+
+export const BedrockConverseOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-converse'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockConverseOptions>)
+    .meta({ id: 'BedrockConverseOptions' });
+
+export const BedrockNovaOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-nova'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockNovaOptions>)
+    .meta({ id: 'BedrockNovaOptions' });
+
+export const BedrockMistralOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-mistral'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockMistralOptions>)
+    .meta({ id: 'BedrockMistralOptions' });
+
+export const BedrockAI21OptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-ai21'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockAI21Options>)
+    .meta({ id: 'BedrockAI21Options' });
+
+export const BedrockCohereCommandOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-cohere-command'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockCohereCommandOptions>)
+    .meta({ id: 'BedrockCohereCommandOptions' });
+
+export const BedrockClaudeOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-claude'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        top_k: z.number().optional(),
+        thinking_budget_tokens: z.number().optional(),
+        include_thoughts: z.boolean().optional(),
+        effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+        cache_enabled: z.boolean().optional(),
+        cache_ttl: z.enum(['5m', '1h']).optional(),
+    } satisfies FieldSchemas<BedrockClaudeOptions>)
+    .meta({ id: 'BedrockClaudeOptions' });
+
+export const BedrockPalmyraOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-palmyra'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        min_tokens: z.number().optional(),
+        seed: z.number().optional(),
+        frequency_penalty: z.number().optional(),
+        presence_penalty: z.number().optional(),
+    } satisfies FieldSchemas<BedrockPalmyraOptions>)
+    .meta({ id: 'BedrockPalmyraOptions' });
+
+export const BedrockGptOssOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-gpt-oss'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        reasoning_effort: z.enum(['low', 'medium', 'high']).optional(),
+        frequency_penalty: z.number().optional(),
+        presence_penalty: z.number().optional(),
+    } satisfies FieldSchemas<BedrockGptOssOptions>)
+    .meta({ id: 'BedrockGptOssOptions' });
+
+export const TwelvelabsPegasusOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-twelvelabs-pegasus'),
+        temperature: z.number().optional(),
+        max_tokens: z.number().optional(),
+    } satisfies FieldSchemas<TwelvelabsPegasusOptions>)
+    .meta({ id: 'TwelvelabsPegasusOptions' });
+
+export const NovaCanvasOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-nova-canvas'),
+        taskType: z.enum([
+            'TEXT_IMAGE',
+            'TEXT_IMAGE_WITH_IMAGE_CONDITIONING',
+            'COLOR_GUIDED_GENERATION',
+            'IMAGE_VARIATION',
+            'INPAINTING',
+            'OUTPAINTING',
+            'BACKGROUND_REMOVAL',
+        ]),
+        width: z.number().optional(),
+        height: z.number().optional(),
+        quality: z.enum(['standard', 'premium']).optional(),
+        cfgScale: z.number().optional(),
+        seed: z.number().optional(),
+        numberOfImages: z.number().optional(),
+        controlMode: z.enum(['CANNY_EDGE', 'SEGMENTATION']).optional(),
+        controlStrength: z.number().optional(),
+        colors: z.array(z.string()).optional(),
+        similarityStrength: z.number().optional(),
+        outPaintingMode: z.enum(['DEFAULT', 'PRECISE']).optional(),
+    } satisfies FieldSchemas<NovaCanvasOptions>)
+    .meta({ id: 'NovaCanvasOptions' });
+
+// ===== bedrock_mantle =====
+
+export const BedrockMantleResponsesOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-mantle-responses'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        effort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
+        reasoning_effort: z.enum(['none', 'low', 'medium', 'high', 'xhigh']).optional(),
+        verbosity: z.enum(['low', 'medium', 'high']).optional(),
+        image_detail: z.enum(['low', 'high', 'auto']).optional(),
+    } satisfies FieldSchemas<BedrockMantleResponsesOptions>)
+    .meta({ id: 'BedrockMantleResponsesOptions' });
+
+export const BedrockMantleChatCompletionsOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-mantle-chat-completions'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<BedrockMantleChatCompletionsOptions>)
+    .meta({ id: 'BedrockMantleChatCompletionsOptions' });
+
+export const BedrockMantleClaudeOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('bedrock-mantle-claude'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        top_k: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+        thinking_budget_tokens: z.number().optional(),
+        include_thoughts: z.boolean().optional(),
+        cache_enabled: z.boolean().optional(),
+        cache_ttl: z.enum(['5m', '1h']).optional(),
+    } satisfies FieldSchemas<BedrockMantleClaudeOptions>)
+    .meta({ id: 'BedrockMantleClaudeOptions' });
+
+// ===== openai =====
+
+export const OpenAiThinkingOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('openai-thinking'),
+        max_tokens: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        effort: ReasoningEffortSchema.optional(),
+        reasoning_effort: ReasoningEffortSchema.optional(),
+        image_detail: z.enum(['low', 'high', 'auto']).optional(),
+    } satisfies FieldSchemas<OpenAiThinkingOptions>)
+    .meta({ id: 'OpenAiThinkingOptions' });
+
+export const OpenAiTextOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('openai-text'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        presence_penalty: z.number().optional(),
+        frequency_penalty: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        image_detail: z.enum(['low', 'high', 'auto']).optional(),
+    } satisfies FieldSchemas<OpenAiTextOptions>)
+    .meta({ id: 'OpenAiTextOptions' });
+
+export const OpenAiDalleOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('openai-dalle'),
+        size: z.enum(['256x256', '512x512', '1024x1024', '1792x1024', '1024x1792']).optional(),
+        image_quality: z.enum(['standard', 'hd']).optional(),
+        style: z.enum(['vivid', 'natural']).optional(),
+        response_format: z.enum(['url', 'b64_json']).optional(),
+        n: z.number().optional(),
+    } satisfies FieldSchemas<OpenAiDalleOptions>)
+    .meta({ id: 'OpenAiDalleOptions' });
+
+export const OpenAiGptImageOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('openai-gpt-image'),
+        size: z.enum(['1024x1024', '1024x1536', '1536x1024', 'auto']).optional(),
+        image_quality: z.enum(['low', 'medium', 'high', 'auto']).optional(),
+        background: z.enum(['transparent', 'opaque', 'auto']).optional(),
+        output_format: z.enum(['png', 'webp', 'jpeg']).optional(),
+    } satisfies FieldSchemas<OpenAiGptImageOptions>)
+    .meta({ id: 'OpenAiGptImageOptions' });
+
+// ===== vertexai =====
+
+export const ImagenOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('vertexai-imagen'),
+        number_of_images: z.number().optional(),
+        seed: z.number().optional(),
+        person_generation: z.enum(['dont_allow', 'allow_adults', 'allow_all']).optional(),
+        safety_setting: z
+            .enum(['block_none', 'block_only_high', 'block_medium_and_above', 'block_low_and_above'])
+            .optional(),
+        image_file_type: z.enum(['image/jpeg', 'image/png']).optional(),
+        jpeg_compression_quality: z.number().optional(),
+        aspect_ratio: z.enum(['1:1', '4:3', '3:4', '16:9', '9:16']).optional(),
+        add_watermark: z.boolean().optional(),
+        enhance_prompt: z.boolean().optional(),
+        edit_mode: ImagenTaskTypeSchema.optional(),
+        guidance_scale: z.number().optional(),
+        edit_steps: z.number().optional(),
+        mask_mode: ImagenMaskModeSchema.optional(),
+        mask_dilation: z.number().optional(),
+        mask_class: z.array(z.number()).optional(),
+        controlType: z.enum(['CONTROL_TYPE_FACE_MESH', 'CONTROL_TYPE_CANNY', 'CONTROL_TYPE_SCRIBBLE']).optional(),
+        controlImageComputation: z.boolean().optional(),
+        subjectType: z
+            .enum(['SUBJECT_TYPE_PERSON', 'SUBJECT_TYPE_ANIMAL', 'SUBJECT_TYPE_PRODUCT', 'SUBJECT_TYPE_DEFAULT'])
+            .optional(),
+    } satisfies FieldSchemas<ImagenOptions>)
+    .meta({ id: 'ImagenOptions' });
+
+export const VertexAIClaudeOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('vertexai-claude'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        top_k: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        effort: z.enum(['low', 'medium', 'high', 'xhigh', 'max']).optional(),
+        thinking_budget_tokens: z.number().optional(),
+        include_thoughts: z.boolean().optional(),
+        cache_enabled: z.boolean().optional(),
+        cache_ttl: z.enum(['5m', '1h']).optional(),
+    } satisfies FieldSchemas<VertexAIClaudeOptions>)
+    .meta({ id: 'VertexAIClaudeOptions' });
+
+export const VertexAIGeminiOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('vertexai-gemini'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        top_k: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+        presence_penalty: z.number().optional(),
+        frequency_penalty: z.number().optional(),
+        seed: z.number().optional(),
+        effort: z.enum(['minimal', 'low', 'medium', 'high']).optional(),
+        include_thoughts: z.boolean().optional(),
+        thinking_budget_tokens: z.number().optional(),
+        thinking_level: ThinkingLevelSchema.optional(),
+        flex: z.boolean().optional(),
+        image_aspect_ratio: z.enum(['1:1', '2:3', '3:2', '3:4', '4:3', '9:16', '16:9', '21:9']).optional(),
+        image_size: z.enum(['1K', '2K', '4K']).optional(),
+        person_generation: z.enum(['ALLOW_ALL', 'ALLOW_ADULT', 'ALLOW_NONE']).optional(),
+        prominent_people: z
+            .enum(['PROMINENT_PEOPLE_UNSPECIFIED', 'ALLOW_PROMINENT_PEOPLE', 'BLOCK_PROMINENT_PEOPLE'])
+            .optional(),
+        output_mime_type: z.enum(['image/png', 'image/jpeg']).optional(),
+        output_compression_quality: z.number().optional(),
+    } satisfies FieldSchemas<VertexAIGeminiOptions>)
+    .meta({ id: 'VertexAIGeminiOptions' });
+
+export const VertexAIGrokOptionsSchema = z
+    .strictObject({
+        _option_id: z.literal('vertexai-grok'),
+        max_tokens: z.number().optional(),
+        temperature: z.number().optional(),
+        top_p: z.number().optional(),
+        stop_sequence: z.array(z.string()).optional(),
+    } satisfies FieldSchemas<VertexAIGrokOptions>)
+    .meta({ id: 'VertexAIGrokOptions' });
+
+// The discriminated union. Member order is the order the derived component lists, which the adapter
+// turns back into a `discriminator` + `mapping` keyed on `_option_id`; a generated Java or Go client
+// reads that mapping to pick the concrete subtype.
+export const ModelOptionsSchema = z
+    .discriminatedUnion('_option_id', [
+        TextFallbackOptionsSchema,
+        ImagenOptionsSchema,
+        VertexAIClaudeOptionsSchema,
+        VertexAIGeminiOptionsSchema,
+        VertexAIGrokOptionsSchema,
+        NovaCanvasOptionsSchema,
+        BedrockConverseOptionsSchema,
+        BedrockNovaOptionsSchema,
+        BedrockMistralOptionsSchema,
+        BedrockAI21OptionsSchema,
+        BedrockCohereCommandOptionsSchema,
+        BedrockClaudeOptionsSchema,
+        BedrockPalmyraOptionsSchema,
+        BedrockGptOssOptionsSchema,
+        TwelvelabsPegasusOptionsSchema,
+        BedrockMantleResponsesOptionsSchema,
+        BedrockMantleChatCompletionsOptionsSchema,
+        BedrockMantleClaudeOptionsSchema,
+        OpenAiThinkingOptionsSchema,
+        OpenAiTextOptionsSchema,
+        OpenAiDalleOptionsSchema,
+        OpenAiGptImageOptionsSchema,
+        GroqOptionsSchema,
+    ])
+    .meta({ id: 'ModelOptions' });

--- a/common/src/schemas/model.ts
+++ b/common/src/schemas/model.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+import { AIModelStatus, ModelType } from '../types.js';
+
+// Runtime schemas for the model-description types that studio-server publishes: what a model IS
+// (`AIModel`), the two closed vocabularies describing it, and the payload that searches for one.
+//
+// These are the SINGLE definition of each shape — the OpenAPI document publishes them, AJV enforces
+// them, and the public types in `../types.ts` are `z.infer` of them.
+//
+// `//` rather than `/** */` throughout: a JSDoc block immediately preceding an exported declaration
+// is picked up by Vertesia's OpenAPI scanner and published as that component's `description`.
+
+// `z.enum` over the TypeScript enum rather than a second list of strings. Both are published
+// identically, but the members stay one declaration: `ModelType.Text` is read in a dozen drivers and
+// in the Studio UI, so the enum has to survive, and a hand-copied string list beside it would be the
+// exact drift this migration removes.
+export const AIModelStatusSchema = z.enum(AIModelStatus).meta({ id: 'AIModelStatus' });
+
+export const ModelTypeSchema = z.enum(ModelType).meta({ id: 'ModelType' });
+
+// `strictObject`: `additionalProperties: false` is what the component has always published, and
+// `z.object` would have silently dropped an unknown key instead of rejecting it.
+export const AIModelSchema = z
+    .strictObject({
+        id: z.string(),
+        name: z.string(),
+        // A driver's own provider id, and every caller in and out of this repo instantiates it as a
+        // plain string. It used to be a type parameter (`AIModel<ProviderKeys = string>`) that was
+        // only ever passed `string`; a canonical alias cannot carry one, and nothing was using it.
+        provider: z.string(),
+        description: z.string().optional(),
+        version: z.string().optional(),
+        type: ModelTypeSchema.optional(),
+        tags: z.array(z.string()).optional(),
+        owner: z.string().optional(),
+        status: AIModelStatusSchema.optional(),
+        can_stream: z.boolean().optional(),
+        is_custom: z.boolean().optional(),
+        is_multimodal: z.boolean().optional(),
+        input_modalities: z.array(z.string()).optional(),
+        output_modalities: z.array(z.string()).optional(),
+        tool_support: z.boolean().optional(),
+        environment: z.string().optional(),
+    })
+    .meta({ id: 'AIModel' });
+
+export const AIModelArraySchema = z.array(AIModelSchema).meta({ id: 'AIModelArray' });
+
+// `text` is OPTIONAL, where the derived parameter said `required: true`. The interface declared it
+// non-optional, but `EnvironmentsApi.listModels(id, payload?)` takes the whole payload optionally and
+// three Studio call sites pass nothing — so the document promised a parameter that its own client
+// omits and the server never wanted. Enforcing it would have 400'd the UI; publishing it optional
+// says what has always been true.
+export const ModelSearchPayloadSchema = z
+    .strictObject({
+        text: z.string().optional(),
+        type: ModelTypeSchema.optional(),
+        tags: z.array(z.string()).optional(),
+        owner: z.string().optional(),
+    })
+    .meta({ id: 'ModelSearchPayload' });

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,6 +1,6 @@
 import type { z } from 'zod';
 import type { JSONSchema } from './schemas/json-schema.js';
-import type { ModelOptionsSchema } from './schemas/model-options.js';
+import type { ModelOptionsSchema, ReasoningEffortSchema } from './schemas/model-options.js';
 
 // ============== Provider details ===============
 
@@ -707,7 +707,11 @@ export enum OptionType {
     string_list = 'string_list',
 }
 
-export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+// Derived from the schema, like the option types that use it. Restating the seven values here made
+// this the one member of the `ModelOptions` closure still written twice: the schema is what the
+// OpenAPI component and the AJV validator come from, so a value added to one and not the other
+// would type-check on both sides and disagree at runtime.
+export type ReasoningEffort = z.infer<typeof ReasoningEffortSchema>;
 
 // ============== Model Options ===============
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import type { HttpTimeoutOptionsSchema } from './schemas/http-timeout.js';
 import type { JSONSchema } from './schemas/json-schema.js';
 import type { ModelOptionsSchema, ReasoningEffortSchema } from './schemas/model-options.js';
 
@@ -531,32 +532,7 @@ export interface Logger {
     error<T>(obj: T, msg?: T extends string ? never : string, ...args: (string | number | boolean)[]): void;
 }
 
-/**
- * HTTP timeouts applied to a driver's upstream LLM-provider calls.
- *
- * All values are in milliseconds. Drivers should map these onto whatever
- * HTTP client their SDK uses; the defaults applied in
- * `@llumiverse/core/createDriverHttpAgent` are:
- *   - headersTimeout:   60_000
- *   - bodyTimeout:      60_000
- *   - connectTimeout:   10_000
- *   - keepAliveTimeout: 30_000
- *
- * The defaults are deliberately tighter than Node's undici default
- * (5 minutes for headers/body) so a hung upstream surfaces quickly. Bump
- * `bodyTimeout` for streaming flows that have legitimate silent gaps
- * (e.g. tool-using agents).
- */
-export interface HttpTimeoutOptions {
-    /** Time (ms) to wait for the first response byte after the request is sent. */
-    headersTimeout?: number;
-    /** Time (ms) between body chunks once streaming has started. */
-    bodyTimeout?: number;
-    /** TCP/TLS connect timeout (ms). */
-    connectTimeout?: number;
-    /** Idle socket reuse timeout (ms). */
-    keepAliveTimeout?: number;
-}
+export type HttpTimeoutOptions = z.infer<typeof HttpTimeoutOptionsSchema>;
 
 export interface DriverOptions {
     logger?: Logger | 'console';

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import type { ExecutionTokenUsageSchema, StatelessExecutionOptionsSchema } from './schemas/completion.js';
 import type {
     EmbeddingOutputSchema,
     EmbeddingResultItemSchema,
@@ -561,7 +562,14 @@ export interface PromptOptions {
     prompt_cache_schema_suffix?: boolean;
 }
 
-export interface StatelessExecutionOptions extends PromptOptions {
+// `format` is NOT on this type, and its absence is deliberate. It lives on `PromptOptions`, which is
+// the in-process shape a driver takes; this one is PUBLISHED as an API component, and a
+// `PromptFormatter` is a function — the scanner used to emit it as an object with `namedArgs` and
+// `returns` that no caller could construct or send. `ExecutionOptions` below re-adds it, so the
+// drivers are unaffected.
+export type StatelessExecutionOptions = z.infer<typeof StatelessExecutionOptionsSchema>;
+
+export interface ExecutionOptionsBase extends PromptOptions {
     /**
      * If set to true the original response from the target LLM will be included in the response under the original_response field.
      * This is useful for debugging and for some advanced use cases.
@@ -589,7 +597,7 @@ export interface StatelessExecutionOptions extends PromptOptions {
     output_modality?: Modalities;
 }
 
-export interface ExecutionOptions extends StatelessExecutionOptions {
+export interface ExecutionOptions extends ExecutionOptionsBase {
     /**
      * Available tools for the request
      */
@@ -752,22 +760,7 @@ export interface PromptSegment {
     files?: DataSource[];
 }
 
-export interface ExecutionTokenUsage {
-    prompt?: number;
-    result?: number;
-    total?: number;
-    /**
-     * Number of input tokens read from prompt cache (discounted rate).
-     */
-    prompt_cached?: number;
-    /**
-     * Number of input tokens written to prompt cache.
-     */
-    prompt_cache_write?: number;
-
-    /* Number of new input tokens not from cache. This is useful for providers with prompt caching to understand how many tokens were actually newly processed in the prompt, separate from any cached tokens. Calculated as prompt - prompt_cached. */
-    prompt_new?: number; // Number of new input tokens not from cache (calculated as prompt - prompt_cached)
-}
+export type ExecutionTokenUsage = z.infer<typeof ExecutionTokenUsageSchema>;
 
 /**
  * @deprecated This is deprecated. Use CompletionResult.type information instead.

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -4,6 +4,7 @@ import type { TextFallbackOptions } from './options/fallback.js';
 import type { GroqOptions } from './options/groq.js';
 import type { OpenAiOptions } from './options/openai.js';
 import type { VertexAIOptions } from './options/vertexai.js';
+import type { JSONSchema } from './schemas/json-schema.js';
 
 // ============== Provider details ===============
 
@@ -571,16 +572,6 @@ export interface DriverOptions {
     httpTimeout?: HttpTimeoutOptions;
 }
 
-export type JSONSchemaTypeName =
-    | 'string' //
-    | 'number'
-    | 'integer'
-    | 'boolean'
-    | 'object'
-    | 'array'
-    | 'null'
-    | 'any';
-
 export type JSONSchemaType =
     | string //
     | number
@@ -595,22 +586,12 @@ export interface JSONSchemaObject {
 
 export interface JSONSchemaArray extends Array<JSONSchemaType> {}
 
-export interface JSONSchemaProperties {
-    [key: string]: JSONSchema;
-}
-
-export interface JSONSchema {
-    type?: JSONSchemaTypeName | JSONSchemaTypeName[];
-    description?: string;
-    properties?: JSONSchemaProperties;
-    items?: JSONSchema;
-    format?: string;
-    editor?: unknown;
-    default?: unknown;
-    additionalProperties?: boolean | JSONSchema;
-    required?: string[];
-    [k: string]: unknown;
-}
+/**
+ * Declared beside their Zod schemas in `./schemas/json-schema.js` and re-exported here so every
+ * historical import path keeps working. The schemas are annotated with these interfaces, so the two
+ * cannot disagree without a compile error in that file.
+ */
+export type { JSONSchema, JSONSchemaProperties, JSONSchemaTypeName } from './schemas/json-schema.js';
 
 export type PromptFormatter<T = unknown> = (messages: PromptSegment[], schema?: JSONSchema) => T;
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,10 +1,6 @@
-import type { BedrockOptions } from './options/bedrock.js';
-import type { BedrockMantleOptions } from './options/bedrock_mantle.js';
-import type { TextFallbackOptions } from './options/fallback.js';
-import type { GroqOptions } from './options/groq.js';
-import type { OpenAiOptions } from './options/openai.js';
-import type { VertexAIOptions } from './options/vertexai.js';
+import type { z } from 'zod';
 import type { JSONSchema } from './schemas/json-schema.js';
+import type { ModelOptionsSchema } from './schemas/model-options.js';
 
 // ============== Provider details ===============
 
@@ -715,16 +711,15 @@ export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | '
 
 // ============== Model Options ===============
 
-/**
- * @discriminator _option_id
- */
-export type ModelOptions =
-    | TextFallbackOptions
-    | VertexAIOptions
-    | BedrockOptions
-    | BedrockMantleOptions
-    | OpenAiOptions
-    | GroqOptions;
+// Derived from the schema, which is the single definition of the union — the OpenAPI component, the
+// AJV validator and this type are all it. The per-driver unions above (`VertexAIOptions`,
+// `BedrockOptions`, …) are groupings over the same schema-derived members and add no shape of their
+// own.
+//
+// No `@discriminator` tag: the scanner short-circuits this alias to the published `ModelOptions`
+// component rather than deriving it, and that component already carries the discriminator the
+// schema's `discriminatedUnion` produced.
+export type ModelOptions = z.infer<typeof ModelOptionsSchema>;
 
 // ============== Option Info ===============
 

--- a/common/src/types.ts
+++ b/common/src/types.ts
@@ -1,6 +1,14 @@
 import type { z } from 'zod';
+import type {
+    EmbeddingOutputSchema,
+    EmbeddingResultItemSchema,
+    EmbeddingsResultSchema,
+    EmbeddingsTokenUsageSchema,
+    EmbeddingTaskTypeSchema,
+} from './schemas/embeddings.js';
 import type { HttpTimeoutOptionsSchema } from './schemas/http-timeout.js';
 import type { JSONSchema } from './schemas/json-schema.js';
+import type { AIModelSchema, ModelSearchPayloadSchema } from './schemas/model.js';
 import type { ModelOptionsSchema, ReasoningEffortSchema } from './schemas/model-options.js';
 
 // ============== Provider details ===============
@@ -144,13 +152,8 @@ export const ProviderList: Record<Providers, ProviderParams> = {
 
 // ============== Embeddings ===============
 
-/**
- * Semantic task type for embedding models. Drivers map these to provider-
- * specific values (e.g. "RETRIEVAL_QUERY" for Vertex, "search_query" for Cohere).
- * - "query"    — a search query to find relevant documents
- * - "document" — a document to be indexed and retrieved
- */
-export type EmbeddingTaskType = 'query' | 'document';
+// Inferred from `./schemas/embeddings.js`, which carries the description the document publishes.
+export type EmbeddingTaskType = z.infer<typeof EmbeddingTaskTypeSchema>;
 
 /**
  * One input to an embedding model. Discriminated by `type`.
@@ -209,43 +212,15 @@ export interface EmbeddingsOptions {
     dimensions?: number;
 }
 
-export interface EmbeddingsResult {
-    /** One result item per input, in the same order as EmbeddingsOptions.inputs. */
-    results: EmbeddingResultItem[];
-    /** The provider model id that produced the result. */
-    model: string;
-    /** Aggregate token usage when reported by the provider. */
-    usage?: EmbeddingsTokenUsage;
-}
+// The four result shapes are inferred from `./schemas/embeddings.js` — one definition each, which
+// the OpenAPI document publishes and AJV enforces. The per-property documentation moved with them.
+export type EmbeddingsResult = z.infer<typeof EmbeddingsResultSchema>;
 
-export interface EmbeddingResultItem {
-    /**
-     * One or more vectors produced for this input.
-     * Single vector for text/image; multiple for segmented video/audio or
-     * joint-multimodal models that return per-modality vectors.
-     */
-    outputs: EmbeddingOutput[];
-    /** Token count attributed to this input, when reported by the provider. */
-    input_tokens?: number;
-}
+export type EmbeddingResultItem = z.infer<typeof EmbeddingResultItemSchema>;
 
-export interface EmbeddingOutput {
-    values: number[];
-    /** Which modality this vector represents (useful for joint-multimodal results). */
-    modality?: 'text' | 'image' | 'video' | 'audio';
-    /** Segment start time for video/audio. */
-    start_sec?: number;
-    /** Segment end time for video/audio. */
-    end_sec?: number;
-    /** TwelveLabs Marengo: which view of the segment this vector represents. */
-    embedding_option?: string;
-}
+export type EmbeddingOutput = z.infer<typeof EmbeddingOutputSchema>;
 
-export interface EmbeddingsTokenUsage {
-    input_tokens?: number;
-    input_text_tokens?: number;
-    input_image_tokens?: number;
-}
+export type EmbeddingsTokenUsage = z.infer<typeof EmbeddingsTokenUsageSchema>;
 
 export interface ResultValidationError {
     code: 'validation_error' | 'json_error' | 'content_policy_violation';
@@ -822,24 +797,11 @@ export interface ModelCapabilities {
 
 // ============== AI MODEL ==============
 
-export interface AIModel<ProviderKeys = string> {
-    id: string; //id of the model known by the provider
-    name: string; //human readable name
-    provider: ProviderKeys; //provider name
-    description?: string;
-    version?: string; //if any version is specified
-    type?: ModelType; //type of the model
-    tags?: string[]; //tags for searching
-    owner?: string; //owner of the model
-    status?: AIModelStatus; //status of the model
-    can_stream?: boolean; //if the model's response can be streamed
-    is_custom?: boolean; //if the model is a custom model (a trained model)
-    is_multimodal?: boolean; //if the model support files and images
-    input_modalities?: string[]; //Input modalities supported by the model (e.g. text, image, video, audio)
-    output_modalities?: string[]; //Output modalities supported by the model (e.g. text, image, video, audio)
-    tool_support?: boolean; //if the model supports tool use
-    environment?: string; //the environment name
-}
+// Inferred from `./schemas/model.js`. The type parameter it used to carry (`AIModel<ProviderKeys =
+// string>`, narrowing `provider`) is gone: every instantiation in and out of this repo passed
+// `string`, which is what the published component has always said, and a canonical alias cannot
+// carry one. `AIModel` becomes `AIModel`.
+export type AIModel = z.infer<typeof AIModelSchema>;
 
 export enum AIModelStatus {
     Available = 'available',
@@ -850,19 +812,10 @@ export enum AIModelStatus {
     Legacy = 'legacy',
 }
 
-/**
- * payload to list available models for an environment
- * @param environmentId id of the environment
- * @param query text to search for in model name/description
- * @param type type of the model
- * @param tags tags for searching
- */
-export interface ModelSearchPayload {
-    text: string;
-    type?: ModelType;
-    tags?: string[];
-    owner?: string;
-}
+// The query `GET /environments/:envId/models` takes, inferred from `./schemas/model.js`. It reaches
+// the document as four expanded query parameters rather than as a component body, which is why no
+// `ModelSearchPayload` schema appears there.
+export type ModelSearchPayload = z.infer<typeof ModelSearchPayloadSchema>;
 
 export enum ModelType {
     Classifier = 'classifier',

--- a/core/test/conversation-strip.test.ts
+++ b/core/test/conversation-strip.test.ts
@@ -616,6 +616,14 @@ describe('turn-based stripping', () => {
 
 const TEXT_TRUNCATED_MARKER = '\n\n[Content truncated - exceeded token limit]';
 
+function expectString(value: unknown): string {
+    expect(typeof value).toBe('string');
+    if (typeof value !== 'string') {
+        throw new TypeError('Expected a string value');
+    }
+    return value;
+}
+
 describe('truncateLargeTextInConversation', () => {
     test('should not truncate when textMaxTokens is not set', () => {
         const input = {
@@ -649,7 +657,7 @@ describe('truncateLargeTextInConversation', () => {
         // Should be truncated to ~40000 chars + marker
         expect(result.content[0].text.length).toBeLessThan(50000);
         expect(result.content[0].text).toContain(TEXT_TRUNCATED_MARKER);
-        expect((result.content[0].text as unknown as string).substring(0, 40000)).toBe('a'.repeat(40000));
+        expect(expectString(result.content[0].text).substring(0, 40000)).toBe('a'.repeat(40000));
     });
 
     test('should not truncate text within token limit', () => {

--- a/drivers/src/azure/azure_foundry.ts
+++ b/drivers/src/azure/azure_foundry.ts
@@ -466,7 +466,7 @@ export class AzureFoundryDriver extends AbstractDriver<AzureFoundryDriverOptions
                     input_modalities: modelModalitiesToArray(modelCapability.input),
                     output_modalities: modelModalitiesToArray(modelCapability.output),
                     tool_support: modelCapability.tool_support,
-                } satisfies AIModel<string>;
+                } satisfies AIModel;
             })
             .sort((modelA, modelB) => modelA.id.localeCompare(modelB.id));
 

--- a/drivers/src/bedrock-mantle/index.ts
+++ b/drivers/src/bedrock-mantle/index.ts
@@ -285,7 +285,7 @@ export class BedrockMantleDriver extends AbstractDriver<BedrockMantleDriverOptio
                         input_modalities: modelModalitiesToArray(modelCapability.input),
                         output_modalities: modelModalitiesToArray(modelCapability.output),
                         tool_support: modelCapability.tool_support,
-                    } satisfies AIModel<string>,
+                    } satisfies AIModel,
                 ];
             })
             .sort((a, b) => a.id.localeCompare(b.id));

--- a/drivers/src/bedrock/index.ts
+++ b/drivers/src/bedrock/index.ts
@@ -1754,7 +1754,7 @@ export class BedrockDriver extends AbstractDriver<BedrockDriverOptions, BedrockP
         return true;
     }
 
-    async listTrainableModels(): Promise<AIModel<string>[]> {
+    async listTrainableModels(): Promise<AIModel[]> {
         this.logger.debug('[Bedrock] listing trainable models');
         return this._listModels((m) =>
             m.customizationsSupported ? m.customizationsSupported.includes('FINE_TUNING') : false,

--- a/drivers/src/groq/index.ts
+++ b/drivers/src/groq/index.ts
@@ -86,7 +86,7 @@ export class GroqDriver extends OpenAIChatCompletionsDriverBase<GroqDriverOption
         return openAIChatCompletionsStreamToSSE(normalizeGroqStream(stream));
     }
 
-    async listModels(): Promise<AIModel<string>[]> {
+    async listModels(): Promise<AIModel[]> {
         const models = await this.client.models.list();
         return models.data.map((model) => ({
             id: model.id,

--- a/drivers/src/mistral/index.ts
+++ b/drivers/src/mistral/index.ts
@@ -70,7 +70,7 @@ export class MistralAIDriver extends OpenAIChatCompletionsDriverBase<MistralAIDr
         return openAIChatCompletionsStreamToSSE(normalizeMistralStream(stream));
     }
 
-    async listModels(): Promise<AIModel<string>[]> {
+    async listModels(): Promise<AIModel[]> {
         const models = await this.client.models.list();
         return (models.data ?? []).flatMap((model) =>
             'id' in model
@@ -81,7 +81,7 @@ export class MistralAIDriver extends OpenAIChatCompletionsDriverBase<MistralAIDr
                           description: ('description' in model && model.description) || undefined,
                           provider: this.provider,
                           owner: 'ownedBy' in model ? model.ownedBy : '',
-                      } satisfies AIModel<string>,
+                      } satisfies AIModel,
                   ]
                 : [],
         );

--- a/drivers/src/openai/azure_openai.ts
+++ b/drivers/src/openai/azure_openai.ts
@@ -95,7 +95,7 @@ export class AzureOpenAIDriver extends OpenAIResponsesDriverBase {
                 input_modalities: modelModalitiesToArray(modelCapability.input),
                 output_modalities: modelModalitiesToArray(modelCapability.output),
                 tool_support: modelCapability.tool_support,
-            } satisfies AIModel<string>,
+            } satisfies AIModel,
         ];
     }
 }

--- a/drivers/src/openai/index.ts
+++ b/drivers/src/openai/index.ts
@@ -543,7 +543,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
         }
     }
 
-    listTrainableModels(): Promise<AIModel<string>[]> {
+    listTrainableModels(): Promise<AIModel[]> {
         return this._listModels((m) => supportFineTunning.has(m.id));
     }
 
@@ -601,7 +601,7 @@ export abstract class OpenAIResponsesDriverBase extends OpenAICompatibleDriverBa
                     input_modalities: modelModalitiesToArray(modelCapability.input),
                     output_modalities: modelModalitiesToArray(modelCapability.output),
                     tool_support: modelCapability.tool_support,
-                } satisfies AIModel<string>;
+                } satisfies AIModel;
             })
             .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/drivers/src/openai/openai_responses.ts
+++ b/drivers/src/openai/openai_responses.ts
@@ -79,7 +79,7 @@ export class OpenAIResponsesDriver extends OpenAIResponsesDriverBase {
                         input_modalities: modelModalitiesToArray(modelCapability.input),
                         output_modalities: modelModalitiesToArray(modelCapability.output),
                         tool_support: modelCapability.tool_support,
-                    } satisfies AIModel<string>;
+                    } satisfies AIModel;
                 })
                 .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/drivers/src/test-driver/index.ts
+++ b/drivers/src/test-driver/index.ts
@@ -66,11 +66,11 @@ export class TestDriver implements Driver<PromptSegment[]> {
         }
     }
 
-    async listTrainableModels(): Promise<AIModel<string>[]> {
+    async listTrainableModels(): Promise<AIModel[]> {
         return [];
     }
 
-    async listModels(): Promise<AIModel<string>[]> {
+    async listModels(): Promise<AIModel[]> {
         return [
             {
                 id: TestDriverModels.executionError,

--- a/drivers/src/togetherai/index.ts
+++ b/drivers/src/togetherai/index.ts
@@ -139,7 +139,7 @@ export class TogetherAIDriver extends OpenAIChatCompletionsDriverBase<TogetherAI
                         input_modalities: modelModalitiesToArray(modelCapability.input),
                         output_modalities: modelModalitiesToArray(modelCapability.output),
                         tool_support: modelCapability.tool_support,
-                    } satisfies AIModel<string>,
+                    } satisfies AIModel,
                 ];
             })
             .sort((a, b) => a.id.localeCompare(b.id));

--- a/drivers/src/vertexai/index.ts
+++ b/drivers/src/vertexai/index.ts
@@ -601,13 +601,13 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
         return models;
     }
 
-    async listModels(_params?: ModelSearchPayload): Promise<AIModel<string>[]> {
+    async listModels(_params?: ModelSearchPayload): Promise<AIModel[]> {
         // Get clients
         const modelGarden = await this.getModelGardenClient();
         const aiplatform = await this.getAIPlatformClient();
         const globalGenAiClient = this.getGoogleGenAIClient('global');
 
-        let models: AIModel<string>[] = [];
+        let models: AIModel[] = [];
 
         // Model Garden publisher listings for families that are reliably returned by the API.
         // Open MaaS-only families are appended from VERTEX_OPEN_MAAS_MODELS below to avoid
@@ -732,7 +732,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                             input_modalities: modelModalitiesToArray(modelCapability.input),
                             output_modalities: modelModalitiesToArray(modelCapability.output),
                             tool_support: modelCapability.tool_support,
-                        } satisfies AIModel<string>;
+                        } satisfies AIModel;
                     }),
             );
 
@@ -772,7 +772,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                             input_modalities: modelModalitiesToArray(modelCapability.input),
                             output_modalities: modelModalitiesToArray(modelCapability.output),
                             tool_support: modelCapability.tool_support,
-                        } satisfies AIModel<string>;
+                        } satisfies AIModel;
                     });
 
                 models = models.concat(globalGeminiModels);
@@ -806,7 +806,7 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                             input_modalities: modelModalitiesToArray(modelCapability.input),
                             output_modalities: modelModalitiesToArray(modelCapability.output),
                             tool_support: modelCapability.tool_support,
-                        } satisfies AIModel<string>;
+                        } satisfies AIModel;
                     });
 
                 models = models.concat(globalAnthropicModels);
@@ -824,14 +824,14 @@ export class VertexAIDriver extends AbstractDriver<VertexAIDriverOptions, Vertex
                     input_modalities: modelModalitiesToArray(modelCapability.input),
                     output_modalities: modelModalitiesToArray(modelCapability.output),
                     tool_support: modelCapability.tool_support,
-                } satisfies AIModel<string>);
+                } satisfies AIModel);
             }
         }
 
         //Remove duplicates
         const uniqueModels = Array.from(new Set(models.map((a) => a.id)))
             .map((id) => {
-                return models.find((a) => a.id === id) ?? ({} as AIModel<string>);
+                return models.find((a) => a.id === id) ?? ({} as AIModel);
             })
             .sort((a, b) => a.id.localeCompare(b.id));
 

--- a/drivers/src/vertexai/open-maas-models.ts
+++ b/drivers/src/vertexai/open-maas-models.ts
@@ -188,7 +188,7 @@ export function getVertexOpenMaaSRequestModel(
     return undefined;
 }
 
-export function vertexOpenMaaSModelToAIModel(entry: VertexOpenMaaSModel, region: string): AIModel<string> {
+export function vertexOpenMaaSModelToAIModel(entry: VertexOpenMaaSModel, region: string): AIModel {
     const id = `locations/${region}/publishers/${entry.publisher}/models/${entry.model}`;
     const modelCapability = getModelCapabilities(entry.model, 'vertexai');
     return {
@@ -199,10 +199,10 @@ export function vertexOpenMaaSModelToAIModel(entry: VertexOpenMaaSModel, region:
         input_modalities: modelModalitiesToArray(modelCapability.input),
         output_modalities: modelModalitiesToArray(modelCapability.output),
         tool_support: modelCapability.tool_support,
-    } satisfies AIModel<string>;
+    } satisfies AIModel;
 }
 
-export function getListedVertexOpenMaaSModels(_region: string): AIModel<string>[] {
+export function getListedVertexOpenMaaSModels(_region: string): AIModel[] {
     return (VERTEX_OPEN_MAAS_MODELS as readonly VertexOpenMaaSModel[]).flatMap((entry) => {
         return entry.regions.map((listingRegion) => vertexOpenMaaSModelToAIModel(entry, listingRegion));
     });

--- a/drivers/src/watsonx/index.ts
+++ b/drivers/src/watsonx/index.ts
@@ -131,7 +131,7 @@ export class WatsonxDriver extends AbstractDriver<WatsonxDriverOptions, string> 
         });
     }
 
-    async listModels(): Promise<AIModel<string>[]> {
+    async listModels(): Promise<AIModel[]> {
         const res = (await this.fetchClient
             .get(`/ml/v1/foundation_model_specs?version=${API_VERSION}`)
             .catch((err) => this.logger.warn(`Can't list models on Watsonx: ${err}`))) as WatsonxListModelResponse;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,6 +31,10 @@ importers:
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@8.0.16(@types/node@24.13.3))
 
   common:
+    dependencies:
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^24.13.3


### PR DESCRIPTION
## Summary

Declare the public wire contracts in `@llumiverse/common` as runtime Zod schemas, and derive the
exported TypeScript types from those schemas instead of maintaining the two side by side.

- **New `common/src/schemas/`** — runtime schemas for the `ModelOptions` closure and every
  provider's option set, `AIModel`, the embedding results, the completion contracts,
  `HttpTimeoutOptions`, and the JSON Schema types.
- **Types become `z.infer` aliases** of those schemas, so a type and its schema cannot drift: the
  provider option types in `common/src/options/*` and the shared types in `common/src/types.ts` are
  now derived rather than hand-written. `ReasoningEffort` is derived the same way.
- **Exact JSON Schema bridge check**, so a schema that no longer matches its declared type fails
  rather than being silently accepted.
- Drivers updated for the derived types; removed an unsafe string cast in the core tests; dropped
  documentation wording that described the older generator-based flow.

The JSON Schema types keep their existing names — `common/src/schemas/json-schema.ts` states the
reason inline.

## Test Plan

Run standalone (fresh `pnpm install --frozen-lockfile`), which is how CI builds this repository:

- [x] `pnpm run check` — 182 files, no fixes applied
- [x] `pnpm run build` — 4/4 tasks
- [x] `pnpm run typecheck:test` — 7/7 tasks
- [x] `pnpm run test` — 8/8 tasks: `@llumiverse/common` 10 files / 149 tests,
      `@llumiverse/core` 8 files / 142 tests, `@llumiverse/drivers` 47 files / 449 tests
      (2 files / 19 tests skipped)
